### PR TITLE
restore broadcaster UI and add stream setup endpoint

### DIFF
--- a/canopy/ui/routes.py
+++ b/canopy/ui/routes.py
@@ -8124,6 +8124,331 @@ def create_ui_blueprint() -> Blueprint:
             logger.error(f"Channel search error: {e}")
             return jsonify({'error': 'Internal server error'}), 500
 
+    @ui.route('/ajax/streams', methods=['GET'])
+    @require_login
+    def ajax_list_streams():
+        """List streams visible to the current user."""
+        try:
+            stream_manager = current_app.config.get('STREAM_MANAGER')
+            if not stream_manager:
+                return jsonify({'success': False, 'error': 'Streaming unavailable'}), 503
+            user_id = get_current_user()
+            channel_id = str(request.args.get('channel_id') or '').strip() or None
+            status = str(request.args.get('status') or '').strip().lower() or None
+            try:
+                limit = int(request.args.get('limit', 100))
+            except Exception:
+                limit = 100
+            streams = stream_manager.list_streams_for_user(
+                user_id=user_id,
+                channel_id=channel_id,
+                status=status,
+                limit=limit,
+            )
+            return jsonify({'success': True, 'streams': streams, 'count': len(streams)})
+        except Exception as e:
+            logger.error(f"List streams UI failed: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
+    @ui.route('/ajax/streams', methods=['POST'])
+    @require_login
+    def ajax_create_stream():
+        """Create a stream, optionally post a stream card into the channel."""
+        try:
+            db_manager, _, _, _, channel_manager, _, _, _, profile_manager, _, p2p_manager = _get_app_components_any(current_app)
+            stream_manager = current_app.config.get('STREAM_MANAGER')
+            if not stream_manager:
+                return jsonify({'success': False, 'error': 'Streaming unavailable'}), 503
+
+            user_id = get_current_user()
+            data = request.get_json(silent=True) or {}
+            channel_id = str(data.get('channel_id') or '').strip()
+            title = str(data.get('title') or '').strip()
+            description = str(data.get('description') or '').strip()
+            stream_kind = str(data.get('stream_kind') or '').strip().lower() or None
+            media_kind = str(data.get('media_kind') or 'audio').strip().lower()
+            protocol_default = 'events-json' if stream_kind == 'telemetry' else 'hls'
+            protocol = str(data.get('protocol') or protocol_default).strip().lower()
+            relay_allowed = str(data.get('relay_allowed') or '').strip().lower() in {'1', 'true', 'yes', 'on'}
+            auto_post = True if data.get('auto_post') is None else str(data.get('auto_post')).strip().lower() in {'1', 'true', 'yes', 'on'}
+            start_now = str(data.get('start_now') or '').strip().lower() in {'1', 'true', 'yes', 'on'}
+
+            stream_row, error = stream_manager.create_stream(
+                channel_id=channel_id,
+                created_by=user_id,
+                title=title,
+                description=description,
+                stream_kind=stream_kind,
+                media_kind=media_kind,
+                protocol=protocol,
+                relay_allowed=relay_allowed,
+                origin_peer=(p2p_manager.get_peer_id() if p2p_manager else None),
+                metadata={'created_via': 'ui'},
+            )
+            if error:
+                if error in {'channel_not_found', 'not_channel_member'}:
+                    return jsonify({'success': False, 'error': 'Channel not found'}), 404
+                return jsonify({'success': False, 'error': error}), 400
+
+            posted_message_id = None
+            if auto_post and stream_row:
+                from ..core.channels import MessageType as ChannelMessageType
+
+                attachment = {
+                    'name': str(stream_row.get('title') or title or 'Live stream'),
+                    'type': 'application/vnd.canopy.stream+json',
+                    'kind': 'stream',
+                    'stream_id': str(stream_row.get('id') or ''),
+                    'title': str(stream_row.get('title') or title or ''),
+                    'description': str(stream_row.get('description') or description or ''),
+                    'media_kind': str(stream_row.get('media_kind') or media_kind or 'audio'),
+                    'stream_kind': str(stream_row.get('stream_kind') or stream_kind or 'media'),
+                    'protocol': str(stream_row.get('protocol') or protocol or 'hls'),
+                    'status': str(stream_row.get('status') or 'created'),
+                    'channel_id': str(stream_row.get('channel_id') or channel_id),
+                    'created_by': str(stream_row.get('created_by') or user_id),
+                    'relay_allowed': bool(stream_row.get('relay_allowed')),
+                }
+                post_content = str(data.get('post_content') or '').strip()
+                if not post_content:
+                    stream_kind_value = str(stream_row.get('stream_kind') or stream_kind or 'media').lower()
+                    if stream_kind_value == 'telemetry':
+                        label = "Telemetry stream"
+                    else:
+                        label = "Live video stream" if media_kind == "video" else "Live audio stream"
+                    post_content = f"{label}: {stream_row.get('title') or title}"
+                message = channel_manager.send_message(
+                    channel_id=channel_id,
+                    user_id=user_id,
+                    content=post_content,
+                    message_type=ChannelMessageType.FILE,
+                    attachments=[attachment],
+                    origin_peer=(p2p_manager.get_peer_id() if p2p_manager else None),
+                )
+                if message:
+                    posted_message_id = message.id
+                    try:
+                        if p2p_manager:
+                            display_name = None
+                            if profile_manager:
+                                profile = profile_manager.get_profile(user_id)
+                                if profile:
+                                    display_name = profile.display_name or profile.username
+                            mode_row = None
+                            with db_manager.get_connection() as conn:
+                                mode_row = conn.execute(
+                                    "SELECT privacy_mode FROM channels WHERE id = ?",
+                                    (channel_id,),
+                                ).fetchone()
+                            channel_mode = str(mode_row['privacy_mode'] if mode_row else 'open').lower()
+                            target_peers = None
+                            if channel_mode in {'private', 'confidential'}:
+                                target_peers = channel_manager.get_target_peer_ids_for_channel(channel_id)
+                            p2p_manager.broadcast_channel_message(
+                                channel_id=channel_id,
+                                user_id=user_id,
+                                content=post_content,
+                                message_id=message.id,
+                                timestamp=message.created_at.isoformat() if getattr(message, 'created_at', None) else datetime.now(timezone.utc).isoformat(),
+                                attachments=[attachment],
+                                display_name=display_name,
+                                security={'privacy_mode': channel_mode},
+                                target_peer_ids=target_peers,
+                            )
+                    except Exception as bcast_err:
+                        logger.warning(f"Failed to broadcast stream post card: {bcast_err}")
+
+            if start_now and stream_row:
+                started, start_err = stream_manager.start_stream(stream_row['id'], user_id)
+                if not start_err and started:
+                    stream_row = started
+
+            payload = {'success': True, 'stream': stream_row}
+            if posted_message_id:
+                payload['posted_message_id'] = posted_message_id
+            return jsonify(payload), 201
+        except Exception as e:
+            logger.error(f"Create stream UI failed: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
+    @ui.route('/ajax/streams/<stream_id>', methods=['GET'])
+    @require_login
+    def ajax_get_stream(stream_id):
+        try:
+            stream_manager = current_app.config.get('STREAM_MANAGER')
+            if not stream_manager:
+                return jsonify({'success': False, 'error': 'Streaming unavailable'}), 503
+            user_id = get_current_user()
+            stream_row = stream_manager.get_stream_for_user(stream_id, user_id)
+            if not stream_row:
+                return jsonify({'success': False, 'error': 'Not found'}), 404
+            return jsonify({'success': True, 'stream': stream_row})
+        except Exception as e:
+            logger.error(f"Get stream UI failed: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
+    @ui.route('/ajax/streams/<stream_id>/start', methods=['POST'])
+    @require_login
+    def ajax_start_stream(stream_id):
+        try:
+            stream_manager = current_app.config.get('STREAM_MANAGER')
+            if not stream_manager:
+                return jsonify({'success': False, 'error': 'Streaming unavailable'}), 503
+            user_id = get_current_user()
+            stream_row, error = stream_manager.start_stream(stream_id, user_id)
+            if error in {'not_found', 'not_authorized'}:
+                return jsonify({'success': False, 'error': 'Not found'}), 404
+            if error:
+                return jsonify({'success': False, 'error': error}), 400
+            return jsonify({'success': True, 'stream': stream_row})
+        except Exception as e:
+            logger.error(f"Start stream UI failed: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
+    @ui.route('/ajax/streams/<stream_id>/stop', methods=['POST'])
+    @require_login
+    def ajax_stop_stream(stream_id):
+        try:
+            stream_manager = current_app.config.get('STREAM_MANAGER')
+            if not stream_manager:
+                return jsonify({'success': False, 'error': 'Streaming unavailable'}), 503
+            user_id = get_current_user()
+            stream_row, error = stream_manager.stop_stream(stream_id, user_id)
+            if error in {'not_found', 'not_authorized'}:
+                return jsonify({'success': False, 'error': 'Not found'}), 404
+            if error:
+                return jsonify({'success': False, 'error': error}), 400
+            return jsonify({'success': True, 'stream': stream_row})
+        except Exception as e:
+            logger.error(f"Stop stream UI failed: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
+    @ui.route('/ajax/streams/<stream_id>/session', methods=['POST'])
+    @require_login
+    def ajax_stream_session(stream_id):
+        """Issue a short-lived stream playback token for the current user."""
+        try:
+            stream_manager = current_app.config.get('STREAM_MANAGER')
+            if not stream_manager:
+                return jsonify({'success': False, 'error': 'Streaming unavailable'}), 503
+            user_id = get_current_user()
+            logger.info(f"Stream session request: stream_id={stream_id} user_id={user_id} ip={request.remote_addr}")
+            data = request.get_json(silent=True) or {}
+            ttl_seconds = data.get('ttl_seconds')
+            token_payload, error = stream_manager.issue_token(
+                stream_id=stream_id,
+                user_id=user_id,
+                scope='view',
+                ttl_seconds=ttl_seconds,
+                metadata={'issued_via': 'ui_session'},
+            )
+            logger.info(f"Stream session result: stream_id={stream_id} user_id={user_id} error={error} token_ok={bool(token_payload)}")
+            if error in {'not_found', 'not_authorized'}:
+                return jsonify({'success': False, 'error': 'Not found'}), 404
+            if error or not token_payload:
+                return jsonify({'success': False, 'error': error or 'token_issue_failed'}), 400
+
+            stream_row = stream_manager.get_stream_for_user(stream_id, user_id)
+            token_q = quote_plus(str(token_payload.get('token') or ''))
+            stream_kind = str((stream_row or {}).get('stream_kind') or 'media').lower()
+            protocol = str((stream_row or {}).get('protocol') or 'hls').lower()
+            if stream_kind == 'telemetry' or protocol == 'events-json':
+                playback_url = f"/api/v1/streams/{stream_id}/events?token={token_q}"
+            else:
+                playback_url = f"/api/v1/streams/{stream_id}/manifest.m3u8?token={token_q}"
+            return jsonify({
+                'success': True,
+                'stream': stream_row,
+                'stream_kind': stream_kind,
+                'token': token_payload.get('token'),
+                'expires_at': token_payload.get('expires_at'),
+                'playback_url': playback_url,
+                'transport_url': playback_url,
+            })
+        except Exception as e:
+            logger.error(f"Create stream session failed: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
+    @ui.route('/ajax/streams/<stream_id>/setup', methods=['POST'])
+    @require_login
+    def ajax_stream_setup(stream_id):
+        """Return a setup bundle for stream operators: ingest/view tokens, URLs, and ffmpeg command templates."""
+        try:
+            stream_manager = current_app.config.get('STREAM_MANAGER')
+            if not stream_manager:
+                return jsonify({'success': False, 'error': 'Streaming unavailable'}), 503
+
+            user_id = get_current_user()
+            data = request.get_json(silent=True) or {}
+            ingest_ttl = data.get('ingest_ttl_seconds', 4 * 3600)
+            view_ttl = data.get('view_ttl_seconds', 3600)
+
+            ingest_payload, ingest_err = stream_manager.issue_token(
+                stream_id=stream_id,
+                user_id=user_id,
+                scope='ingest',
+                ttl_seconds=ingest_ttl,
+                metadata={'issued_via': 'ui_setup'},
+            )
+            if ingest_err in {'not_found', 'not_authorized'}:
+                return jsonify({'success': False, 'error': 'Not found'}), 404
+            if ingest_err or not ingest_payload:
+                return jsonify({'success': False, 'error': ingest_err or 'token_issue_failed'}), 400
+
+            view_payload, view_err = stream_manager.issue_token(
+                stream_id=stream_id,
+                user_id=user_id,
+                scope='view',
+                ttl_seconds=view_ttl,
+                metadata={'issued_via': 'ui_setup'},
+            )
+            if view_err or not view_payload:
+                return jsonify({'success': False, 'error': view_err or 'view_token_failed'}), 400
+
+            stream_row = stream_manager.get_stream_for_user(stream_id, user_id) or {}
+            stream_kind = str(stream_row.get('stream_kind') or 'media').lower()
+            protocol = str(stream_row.get('protocol') or 'hls').lower()
+
+            ingest_tok = quote_plus(str(ingest_payload.get('token') or ''))
+            view_tok = quote_plus(str(view_payload.get('token') or ''))
+            base = f"/api/v1/streams/{stream_id}"
+
+            if stream_kind == 'telemetry' or protocol == 'events-json':
+                ingest_bundle = {'events_url': f"{base}/ingest/events?token={ingest_tok}"}
+                playback = {'url': f"{base}/events?token={view_tok}"}
+                posix_cmd = f"# curl -X POST '{base}/ingest/events?token={ingest_tok}' -H 'Content-Type: application/json' -d '{{\"value\": 1}}'"
+                ps_cmd = posix_cmd
+            else:
+                ingest_bundle = {
+                    'manifest_url': f"{base}/ingest/manifest?token={ingest_tok}",
+                    'segment_url_template': f"{base}/ingest/segments/seg%06d.ts?token={ingest_tok}",
+                }
+                playback = {'url': f"{base}/manifest.m3u8?token={view_tok}"}
+                posix_cmd = (
+                    f"ffmpeg -re -i INPUT -c:v libx264 -preset veryfast -tune zerolatency"
+                    f" -c:a aac -b:a 128k -f hls -hls_time 2 -hls_list_size 5"
+                    f" -hls_flags delete_segments"
+                    f" -hls_segment_filename '{base}/ingest/segments/seg%06d.ts?token={ingest_tok}'"
+                    f" '{base}/ingest/manifest?token={ingest_tok}'"
+                )
+                ps_cmd = posix_cmd.replace("'", '"')
+
+            return jsonify({
+                'success': True,
+                'setup': {
+                    'stream_id': stream_id,
+                    'stream_kind': stream_kind,
+                    'ingest': ingest_bundle,
+                    'playback': playback,
+                    'commands': {'posix': posix_cmd, 'powershell': ps_cmd},
+                    'ingest_expires_at': ingest_payload.get('expires_at'),
+                    'view_expires_at': view_payload.get('expires_at'),
+                },
+            })
+        except Exception as e:
+            logger.error(f"Stream setup failed: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': 'Internal server error'}), 500
+
     @ui.route('/ajax/send_channel_message', methods=['POST'])
     @require_login
     def ajax_send_channel_message():

--- a/canopy/ui/templates/channels.html
+++ b/canopy/ui/templates/channels.html
@@ -1536,6 +1536,28 @@
                                 <i class="bi bi-people"></i>
                             </button>
                             <div id="channel-mention-macro-buttons" class="mention-macro-buttons" style="display: none;"></div>
+                            <div class="btn-group">
+                                <button type="button"
+                                        class="btn btn-outline-danger dropdown-toggle"
+                                        id="channel-stream-quick-toggle"
+                                        data-bs-toggle="dropdown"
+                                        aria-expanded="false"
+                                        title="Create a live stream post">
+                                    <i class="bi bi-broadcast-pin"></i>
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="channel-stream-quick-toggle">
+                                    <li>
+                                        <button type="button" class="dropdown-item" onclick="quickCreateLiveStream('audio')">
+                                            <i class="bi bi-mic-fill me-2"></i>Start audio stream card
+                                        </button>
+                                    </li>
+                                    <li>
+                                        <button type="button" class="dropdown-item" onclick="quickCreateLiveStream('video')">
+                                            <i class="bi bi-camera-video-fill me-2"></i>Start video stream card
+                                        </button>
+                                    </li>
+                                </ul>
+                            </div>
                             <button type="submit" class="btn btn-primary">
                                 <i class="bi bi-send"></i>
                             </button>
@@ -6066,7 +6088,8 @@ function displayAttachments(attachments) {
         return (parts.pop() || '').toLowerCase();
     };
 
-    // Separate images, audio, video, and other files
+    // Separate stream cards, images, audio, video, and other files
+    const streamCards = [];
     const images = [];
     const audioFiles = [];
     const videoFiles = [];
@@ -6074,11 +6097,16 @@ function displayAttachments(attachments) {
     attachments.forEach(att => {
         const mime = String((att && att.type) || '').toLowerCase();
         const ext = extOf((att && att.name) || (att && att.url) || '');
+        const streamKind = String((att && att.kind) || '').toLowerCase();
+        const hasStreamId = !!(att && att.stream_id);
+        const isStream = streamKind === 'stream' || hasStreamId || mime.indexOf('application/vnd.canopy.stream') === 0;
         const isImage = mime.startsWith('image/') || ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg', 'avif'].includes(ext);
         const isAudio = mime.startsWith('audio/') || ['mp3', 'wav', 'aac', 'm4a', 'flac', 'oga', 'opus', 'weba'].includes(ext);
         const isVideo = mime.startsWith('video/') || ['mp4', 'webm', 'ogv', 'm4v', 'mov'].includes(ext);
 
-        if (isImage) {
+        if (isStream) {
+            streamCards.push(att);
+        } else if (isImage) {
             images.push(att);
         } else if (isAudio) {
             audioFiles.push(att);
@@ -6090,6 +6118,58 @@ function displayAttachments(attachments) {
     });
 
     let html = '<div class="attachments mt-2">';
+
+    // Render stream cards with one-click watch/listen session join.
+    streamCards.forEach((att, idx) => {
+        const streamId = String(att.stream_id || '').trim();
+        const streamKind = String(att.stream_kind || (String(att.protocol || '').toLowerCase() === 'events-json' ? 'telemetry' : 'media')).toLowerCase();
+        const mediaKindRaw = String(att.media_kind || 'audio').toLowerCase();
+        const mediaKind = mediaKindRaw === 'video' ? 'video' : (mediaKindRaw === 'data' ? 'data' : 'audio');
+        const status = String(att.status || 'created').toLowerCase();
+        const safeTitle = (att.title || att.name || 'Live stream').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+        const safeDesc = String(att.description || '').replace(/</g, '&lt;');
+        const slotId = `stream-slot-${Math.random().toString(36).slice(2, 10)}-${idx}`;
+        const statusLabel = status === 'live' ? 'LIVE' : (status === 'stopped' ? 'Stopped' : 'Preparing');
+        const statusClass = status === 'live' ? 'bg-danger' : 'bg-secondary';
+        const icon = streamKind === 'telemetry' ? 'cpu' : (mediaKind === 'video' ? 'camera-video' : 'broadcast');
+        const actionLabel = streamKind === 'telemetry' ? 'Open feed' : (mediaKind === 'video' ? 'Watch' : 'Listen');
+        const isOwner = att.created_by && att.created_by === currentUserId;
+        const goLiveBtn = isOwner && streamId && streamKind !== 'telemetry'
+            ? `<button class="btn btn-sm btn-outline-warning" onclick="openBroadcasterPanel('${streamId.replace(/'/g, "\\'")}', '${mediaKind}', '${slotId}')">
+                    <i class="bi bi-broadcast"></i> Go Live
+               </button>`
+            : '';
+        const streamBtn = streamId
+            ? `<button class="btn btn-sm btn-outline-success" onclick="openStreamAttachmentPlayer('${streamId.replace(/'/g, "\\'")}', '${mediaKind}', '${slotId}', '${streamKind}')">
+                    <i class="bi bi-play-fill"></i> ${actionLabel}
+               </button>`
+            : `<span class="small text-muted">Stream metadata incomplete</span>`;
+        html += `
+            <div class="attachment-item mb-2 p-2 border rounded" style="background: linear-gradient(145deg, rgba(19,36,58,0.95), rgba(16,22,34,0.94)); border-color: rgba(61, 84, 116, 0.65) !important;">
+                <div class="d-flex align-items-start justify-content-between gap-2">
+                    <div class="d-flex align-items-start gap-2">
+                        <div class="rounded-circle d-flex align-items-center justify-content-center" style="width:32px;height:32px;background:rgba(32,189,126,0.18);">
+                            <i class="bi bi-${icon}"></i>
+                        </div>
+                        <div>
+                            <div class="fw-semibold">${safeTitle}</div>
+                            <div class="small text-muted">${safeDesc || (streamKind === 'telemetry' ? 'Telemetry feed card' : (mediaKind === 'video' ? 'Video stream card' : 'Audio stream card'))}</div>
+                        </div>
+                    </div>
+                    <span class="badge ${statusClass}">${statusLabel}</span>
+                </div>
+                <div class="d-flex align-items-center justify-content-between mt-2">
+                    <span class="small text-muted">ID: ${streamId || 'n/a'}</span>
+                    <div class="d-flex align-items-center gap-2">
+                        ${streamBtn}
+                        ${goLiveBtn}
+                        ${streamId ? `<button class="btn btn-sm btn-outline-secondary" onclick="navigator.clipboard.writeText('${streamId.replace(/'/g, "\\'")}')"><i class="bi bi-clipboard"></i></button>` : ''}
+                    </div>
+                </div>
+                <div id="${slotId}" class="mt-2" style="display:none;"></div>
+            </div>
+        `;
+    });
 
     // Render image grid
     if (images.length > 0) {
@@ -6210,6 +6290,458 @@ function displayAttachments(attachments) {
 
     html += '</div>';
     return html;
+}
+
+function _escapeHtml(value) {
+    return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+async function _renderTelemetryStreamPanel(streamId, slot, sessionPayload) {
+    const eventsUrl = String((sessionPayload && sessionPayload.playback_url) || '');
+    if (!eventsUrl) {
+        throw new Error('Telemetry stream session did not return an events URL');
+    }
+    const response = await fetch(eventsUrl, {
+        method: 'GET',
+        credentials: 'same-origin',
+        cache: 'no-store',
+    });
+    let body = null;
+    try {
+        body = await response.json();
+    } catch (e) {
+        body = null;
+    }
+    if (!response.ok || !body || body.success === false) {
+        const reason = (body && (body.error || body.message)) || `HTTP ${response.status}`;
+        throw new Error(`Telemetry feed unavailable: ${reason}`);
+    }
+
+    const events = Array.isArray(body.events) ? body.events : [];
+    const rows = events.slice(-30).map((ev) => {
+        const seq = Number(ev && ev.seq ? ev.seq : 0);
+        const ts = _escapeHtml((ev && ev.event_ts) || '');
+        const ctype = _escapeHtml((ev && ev.content_type) || 'application/json');
+        const payload = (ev && Object.prototype.hasOwnProperty.call(ev, 'payload')) ? ev.payload : null;
+        const payloadPreview = typeof payload === 'string'
+            ? payload
+            : JSON.stringify(payload || {}, null, 2);
+        return `<tr>
+            <td class="text-muted small">#${Number.isFinite(seq) ? seq : 0}</td>
+            <td class="small text-muted">${ts}</td>
+            <td class="small">${ctype}</td>
+            <td><pre class="small mb-0" style="max-height: 160px; overflow:auto; white-space: pre-wrap;">${_escapeHtml(payloadPreview)}</pre></td>
+        </tr>`;
+    }).join('');
+
+    slot.style.display = 'block';
+    slot.innerHTML = `
+        <div class="border rounded p-2" style="background: rgba(13, 19, 30, 0.66); border-color: rgba(66, 92, 126, 0.6) !important;">
+            <div class="d-flex align-items-center justify-content-between mb-2">
+                <div class="small fw-semibold"><i class="bi bi-cpu me-1"></i>Telemetry feed (latest ${events.length})</div>
+                <button class="btn btn-sm btn-outline-secondary" onclick="openStreamAttachmentPlayer('${streamId.replace(/'/g, "\\'")}', 'data', '${slot.id}', 'telemetry')">
+                    <i class="bi bi-arrow-clockwise"></i> Refresh
+                </button>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th scope="col">Seq</th>
+                            <th scope="col">Timestamp</th>
+                            <th scope="col">Type</th>
+                            <th scope="col">Payload</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${rows || '<tr><td colspan="4" class="small text-muted">No events yet.</td></tr>'}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    `;
+}
+
+// Lazily loads hls.js from CDN on first call; subsequent calls reuse the promise.
+let _hlsJsLoadPromise = null;
+function _loadHlsJs() {
+    if (!_hlsJsLoadPromise) {
+        _hlsJsLoadPromise = new Promise((resolve, reject) => {
+            if (window.Hls) { resolve(window.Hls); return; }
+            const s = document.createElement('script');
+            s.src = 'https://cdn.jsdelivr.net/npm/hls.js@1/dist/hls.min.js';
+            s.crossOrigin = 'anonymous';
+            s.onload = () => resolve(window.Hls);
+            s.onerror = () => reject(new Error('Failed to load hls.js'));
+            document.head.appendChild(s);
+        });
+    }
+    return _hlsJsLoadPromise;
+}
+
+async function openStreamAttachmentPlayer(streamId, mediaKind, slotId, streamKind = 'media') {
+    if (!streamId) {
+        showAlert('Stream ID missing for this attachment', 'warning');
+        return;
+    }
+    const slot = document.getElementById(slotId);
+    if (!slot) return;
+    try {
+        const res = await apiCall(`/ajax/streams/${encodeURIComponent(streamId)}/session`, {
+            method: 'POST',
+            body: JSON.stringify({}),
+        });
+        if (!res || !res.success || !res.playback_url) {
+            throw new Error((res && (res.error || res.message)) || 'Unable to join stream');
+        }
+
+        const normalizedKind = String(streamKind || '').toLowerCase();
+        if (normalizedKind === 'telemetry' || String(mediaKind || '').toLowerCase() === 'data') {
+            await _renderTelemetryStreamPanel(streamId, slot, res);
+            return;
+        }
+
+        const playbackUrl = String(res.playback_url);
+        const safeUrl = playbackUrl.replace(/"/g, '&quot;');
+        const isVideo = String(mediaKind || '').toLowerCase() === 'video';
+        const tag = isVideo ? 'video' : 'audio';
+        const extraAttrs = isVideo
+            ? 'playsinline class="w-100" style="max-width:100%;border-radius:10px;background:#000;"'
+            : 'class="w-100" style="max-width:100%;"';
+        const mediaElId = `stream-player-${streamId.replace(/[^a-z0-9]/gi, '')}-${Date.now()}`;
+
+        slot.style.display = 'block';
+        slot.innerHTML = `
+            <${tag} id="${mediaElId}" controls autoplay preload="metadata" ${extraAttrs}></${tag}>
+            <div class="small text-muted mt-1">If playback does not start, <a href="${safeUrl}" target="_blank" rel="noopener">open stream URL</a> in VLC or Safari.</div>
+        `;
+
+        const mediaEl = document.getElementById(mediaElId);
+        if (!mediaEl) return;
+
+        // Live WebM streams use MSE instead of hls.js
+        const isWebm = String(res.live_format || '').toLowerCase() === 'webm' ||
+            playbackUrl.indexOf('/segments/') < 0 && playbackUrl.indexOf('webm') >= 0;
+        if (isWebm) {
+            await _startMSELiveViewer(streamId, playbackUrl, slot, mediaKind);
+            return;
+        }
+
+        if (mediaEl.canPlayType('application/vnd.apple.mpegurl')) {
+            // Safari / native HLS
+            mediaEl.src = playbackUrl;
+            mediaEl.play().catch(() => {});
+        } else {
+            // Chrome, Firefox, Edge — use hls.js; switch to MSE on media error (WebM segments)
+            try {
+                const HlsLib = await _loadHlsJs();
+                if (HlsLib && HlsLib.isSupported()) {
+                    const hls = new HlsLib({ enableWorker: true });
+                    hls.loadSource(playbackUrl);
+                    hls.attachMedia(mediaEl);
+                    hls.on(HlsLib.Events.MANIFEST_PARSED, () => mediaEl.play().catch(() => {}));
+                    hls.on(HlsLib.Events.ERROR, (_e, data) => {
+                        if (data.fatal) {
+                            console.warn('HLS fatal error', data.type, data.details);
+                            if (data.type === HlsLib.ErrorTypes.MEDIA_ERROR) {
+                                hls.destroy();
+                                _startMSELiveViewer(streamId, playbackUrl, slot, mediaKind).catch(() => {});
+                            }
+                        }
+                    });
+                } else {
+                    mediaEl.src = playbackUrl;
+                    mediaEl.play().catch(() => {});
+                }
+            } catch (hlsErr) {
+                console.warn('hls.js load failed, falling back to native src', hlsErr);
+                mediaEl.src = playbackUrl;
+                mediaEl.play().catch(() => {});
+            }
+        }
+    } catch (err) {
+        const serverMsg = err && (err.error || err.message || err.details);
+        const status = err && err.status ? ` [HTTP ${err.status}]` : '';
+        console.error('Stream error:', err);
+        if (err && err.status === 404) {
+            showAlert('Stream not found' + status + ' — this stream may live on another peer that is currently offline.', 'warning');
+        } else {
+            showAlert('Stream error' + status + ': ' + (serverMsg || 'Unable to start stream playback'), 'danger');
+        }
+    }
+}
+
+async function quickCreateLiveStream(mediaKind) {
+    const mode = String(mediaKind || 'audio').toLowerCase() === 'video' ? 'video' : 'audio';
+    if (!currentChannelId) {
+        showAlert('Select a channel before creating a stream post', 'warning');
+        return;
+    }
+    const titleHint = mode === 'video' ? 'Live camera feed' : 'Live audio feed';
+    const channelLabelEl = document.getElementById('current-channel-name');
+    const channelLabel = channelLabelEl ? channelLabelEl.textContent.trim() : String(currentChannelId);
+    const defaultTitle = `${titleHint} ${channelLabel}`.trim();
+    const title = window.prompt(`Stream title (${mode})`, defaultTitle);
+    if (title === null) return;
+    const cleanTitle = String(title || '').trim();
+    if (!cleanTitle) {
+        showAlert('Stream title is required', 'warning');
+        return;
+    }
+    const description = window.prompt('Optional stream description', '') || '';
+
+    try {
+        const payload = {
+            channel_id: currentChannelId,
+            title: cleanTitle,
+            description: String(description).trim(),
+            stream_kind: 'media',
+            media_kind: mode,
+            protocol: 'hls',
+            relay_allowed: currentChannelPrivacy === 'open',
+            auto_post: true,
+            start_now: true,
+            post_content: mode === 'video'
+                ? `Live video stream started: ${cleanTitle}`
+                : `Live audio stream started: ${cleanTitle}`,
+        };
+        const res = await apiCall('/ajax/streams', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        if (!res || !res.success || !res.stream) {
+            throw new Error((res && (res.error || res.message)) || 'Failed to create stream');
+        }
+        showAlert(`Stream "${cleanTitle}" created — click Go Live on the card to start broadcasting`, 'success');
+        await loadChannelMessages(currentChannelId, { forceScroll: true });
+        // Auto-open broadcaster panel for the new stream
+        const newId = String(res.stream?.id || res.stream?.stream_id || '');
+        if (newId) {
+            setTimeout(() => {
+                document.querySelectorAll(`[onclick*="openBroadcasterPanel"]`).forEach(btn => {
+                    const m = btn.getAttribute('onclick')?.match(/openBroadcasterPanel\('([^']+)','([^']+)','([^']+)'\)/);
+                    if (m && m[1] === newId) { openBroadcasterPanel(m[1], m[2], m[3]); }
+                });
+            }, 700);
+        }
+    } catch (err) {
+        const msg = err && err.message ? err.message : 'Failed to create stream';
+        showAlert(msg, 'danger');
+    }
+}
+
+const _activeBroadcasters = {};
+
+async function openBroadcasterPanel(streamId, mediaKind, slotId) {
+    const slot = document.getElementById(slotId);
+    if (!slot) return;
+
+    // If already open, toggle it closed
+    if (slot.dataset.bcOpen === '1') {
+        slot.dataset.bcOpen = '0';
+        slot.style.display = 'none';
+        slot.innerHTML = '';
+        _stopLiveBroadcast(streamId);
+        return;
+    }
+
+    // Enumerate devices
+    let videoDevices = [], audioDevices = [];
+    try {
+        await navigator.mediaDevices.getUserMedia({ video: mediaKind === 'video', audio: true });
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        videoDevices = devices.filter(d => d.kind === 'videoinput');
+        audioDevices = devices.filter(d => d.kind === 'audioinput');
+    } catch (e) {
+        slot.style.display = 'block';
+        slot.innerHTML = `<p class="small text-danger mt-1">Camera/mic access denied: ${e.message}</p>`;
+        return;
+    }
+
+    const videoOpts = videoDevices.map((d, i) =>
+        `<option value="${d.deviceId}">${d.label || 'Camera ' + (i+1)}</option>`).join('');
+    const audioOpts = audioDevices.map((d, i) =>
+        `<option value="${d.deviceId}">${d.label || 'Mic ' + (i+1)}</option>`).join('');
+
+    slot.innerHTML = `
+        <div class="p-2 border rounded mt-1" style="background:rgba(0,0,0,0.3);">
+            ${mediaKind === 'video' ? `
+            <div class="mb-2">
+                <label class="small text-muted">Camera</label>
+                <select id="bc-cam-${streamId}" class="form-select form-select-sm">${videoOpts}</select>
+            </div>` : ''}
+            <div class="mb-2">
+                <label class="small text-muted">Microphone</label>
+                <select id="bc-mic-${streamId}" class="form-select form-select-sm">${audioOpts}</select>
+            </div>
+            ${mediaKind === 'video' ? `<video id="bc-preview-${streamId}" autoplay muted playsinline class="w-100 mb-2" style="max-height:160px;border-radius:6px;background:#000;"></video>` : ''}
+            <div class="d-flex gap-2 align-items-center">
+                <button id="bc-btn-${streamId}" class="btn btn-sm btn-success" onclick="_toggleBroadcast('${streamId}', '${mediaKind}')">
+                    <i class="bi bi-broadcast"></i> Start Broadcasting
+                </button>
+                <span id="bc-status-${streamId}" class="small text-muted"></span>
+            </div>
+        </div>`;
+    slot.style.display = 'block';
+    slot.dataset.bcOpen = '1';
+
+    // Live preview
+    if (mediaKind === 'video') {
+        try {
+            const camId = document.getElementById(`bc-cam-${streamId}`)?.value;
+            const stream = await navigator.mediaDevices.getUserMedia({
+                video: camId ? { deviceId: { exact: camId } } : true,
+                audio: false,
+            });
+            const preview = document.getElementById(`bc-preview-${streamId}`);
+            if (preview) preview.srcObject = stream;
+            document.getElementById(`bc-cam-${streamId}`)?.addEventListener('change', async (e) => {
+                stream.getTracks().forEach(t => t.stop());
+                const ns = await navigator.mediaDevices.getUserMedia({ video: { deviceId: { exact: e.target.value } }, audio: false });
+                if (preview) preview.srcObject = ns;
+            });
+        } catch (_) {}
+    }
+}
+
+async function _toggleBroadcast(streamId, mediaKind) {
+    if (_activeBroadcasters[streamId]) { _stopLiveBroadcast(streamId); } else { await _startLiveBroadcast(streamId, mediaKind); }
+}
+
+async function _startLiveBroadcast(streamId, mode) {
+    const btn = document.getElementById(`bc-btn-${streamId}`);
+    const statusEl = document.getElementById(`bc-status-${streamId}`);
+    if (btn) { btn.disabled = true; btn.textContent = 'Starting…'; }
+
+    let tok;
+    try {
+        const tr = await apiCall(`/ajax/streams/${encodeURIComponent(streamId)}/ingest-token`, { method: 'POST' });
+        tok = tr.token;
+        if (!tok) throw new Error(tr.error || 'No token returned');
+    } catch (e) {
+        if (statusEl) statusEl.textContent = 'Auth failed: ' + e.message;
+        if (btn) { btn.disabled = false; btn.innerHTML = '<i class="bi bi-broadcast"></i> Start Broadcasting'; }
+        return;
+    }
+
+    const camId = document.getElementById(`bc-cam-${streamId}`)?.value;
+    const micId = document.getElementById(`bc-mic-${streamId}`)?.value;
+    let mediaStream;
+    try {
+        mediaStream = await navigator.mediaDevices.getUserMedia({
+            video: mode === 'video' ? (camId ? { deviceId: { exact: camId } } : true) : false,
+            audio: micId ? { deviceId: { exact: micId } } : true,
+        });
+    } catch (e) {
+        if (statusEl) statusEl.textContent = 'Media error: ' + e.message;
+        if (btn) { btn.disabled = false; btn.innerHTML = '<i class="bi bi-broadcast"></i> Start Broadcasting'; }
+        return;
+    }
+
+    // Prefer fMP4 (Chrome/Edge), fall back to WebM (Firefox)
+    const fmp4Mime = 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"';
+    const webmMime = 'video/webm; codecs=vp8,opus';
+    const useFmp4 = window.MediaRecorder && MediaRecorder.isTypeSupported(fmp4Mime);
+    const mimeType = useFmp4 ? fmp4Mime : webmMime;
+    const ext = useFmp4 ? 'mp4' : 'webm';
+
+    const rec = new MediaRecorder(mediaStream, { mimeType, videoBitsPerSecond: 1_500_000 });
+    let segIdx = 0, initSent = false, segNames = [], seqStart = 0;
+
+    _activeBroadcasters[streamId] = { rec, mediaStream, tok };
+
+    rec.ondataavailable = async (e) => {
+        if (!e.data || e.data.size === 0) return;
+        const buf = await e.data.arrayBuffer();
+        if (!initSent && ext === 'mp4') {
+            initSent = true;
+            await _pushBcSeg(streamId, tok, 'init.mp4', buf).catch(() => {});
+            return;
+        }
+        segIdx++;
+        const name = `seg${String(segIdx).padStart(4,'0')}.${ext}`;
+        segNames.push(name);
+        if (segNames.length > 10) { seqStart++; segNames.shift(); }
+        await _pushBcSeg(streamId, tok, name, buf).catch(() => {});
+        await _pushBcManifest(streamId, tok, _buildLiveMfst(ext, seqStart, segNames)).catch(() => {});
+    };
+
+    rec.start(2000);
+    if (btn) { btn.disabled = false; btn.innerHTML = '<i class="bi bi-stop-fill"></i> Stop'; btn.classList.replace('btn-success','btn-danger'); }
+    if (statusEl) statusEl.textContent = '● Live';
+}
+
+function _stopLiveBroadcast(streamId) {
+    const bc = _activeBroadcasters[streamId]; if (!bc) return;
+    try { bc.rec.stop(); } catch (_) {}
+    try { bc.mediaStream.getTracks().forEach(t => t.stop()); } catch (_) {}
+    delete _activeBroadcasters[streamId];
+    const btn = document.getElementById(`bc-btn-${streamId}`);
+    if (btn) { btn.innerHTML = '<i class="bi bi-broadcast"></i> Start Broadcasting'; btn.classList.replace('btn-danger','btn-success'); }
+    const s = document.getElementById(`bc-status-${streamId}`); if (s) s.textContent = 'Stopped';
+}
+
+async function _pushBcSeg(sid, tok, name, buf) {
+    const r = await fetch(`/api/v1/streams/${encodeURIComponent(sid)}/ingest/segments/${encodeURIComponent(name)}?token=${encodeURIComponent(tok)}`,
+        { method: 'PUT', body: buf, headers: { 'Content-Type': 'application/octet-stream' } });
+    if (!r.ok) throw new Error(`Segment push failed (${r.status})`);
+}
+async function _pushBcManifest(sid, tok, mfst) {
+    const r = await fetch(`/api/v1/streams/${encodeURIComponent(sid)}/ingest/manifest?token=${encodeURIComponent(tok)}`,
+        { method: 'PUT', body: mfst, headers: { 'Content-Type': 'application/vnd.apple.mpegurl' } });
+    if (!r.ok) throw new Error(`Manifest push failed (${r.status})`);
+}
+function _buildLiveMfst(ext, seqStart, names) {
+    const mp4 = ext === 'mp4';
+    const lines = ['#EXTM3U', `#EXT-X-VERSION:${mp4 ? 7 : 3}`, '#EXT-X-TARGETDURATION:3', `#EXT-X-MEDIA-SEQUENCE:${seqStart}`];
+    if (mp4) lines.push('#EXT-X-MAP:URI="init.mp4"');
+    names.forEach(n => lines.push('#EXTINF:2.000,', n));
+    return lines.join('\n') + '\n';
+}
+
+async function _startMSELiveViewer(streamId, playbackUrl, slot, mediaKind) {
+    const mime = 'video/webm; codecs=vp8,opus';
+    if (!window.MediaSource || !MediaSource.isTypeSupported(mime)) {
+        slot.innerHTML += '<p class="small text-warning mt-1">Live WebM not supported here. Try Chrome or Edge.</p>';
+        return;
+    }
+    const tag = mediaKind === 'video' ? 'video' : 'audio';
+    const el = document.createElement(tag);
+    el.controls = true; el.autoplay = true; el.className = 'w-100';
+    if (mediaKind === 'video') el.style.cssText = 'max-width:100%;border-radius:10px;background:#000;';
+    slot.innerHTML = ''; slot.appendChild(el); slot.style.display = 'block';
+    const ms = new MediaSource();
+    el.src = URL.createObjectURL(ms);
+    ms.addEventListener('sourceopen', () => {
+        const sb = ms.addSourceBuffer(mime);
+        let next = 1, stopped = false;
+        const base = playbackUrl.replace(/\/manifest\.m3u8.*$/, '');
+        const tm = playbackUrl.match(/[?&]token=([^&]+)/);
+        const tp = tm ? `?token=${tm[1]}` : '';
+        async function poll() {
+            if (stopped || ms.readyState !== 'open') return;
+            const seg = `seg${String(next).padStart(4,'0')}.webm`;
+            try {
+                const resp = await fetch(`${base}/segments/${encodeURIComponent(seg)}${tp}`);
+                if (resp.ok) {
+                    const buf = await resp.arrayBuffer();
+                    if (!sb.updating && ms.readyState === 'open') {
+                        sb.appendBuffer(buf);
+                        await new Promise(r => sb.addEventListener('updateend', r, { once: true }));
+                        next++; setTimeout(poll, 50);
+                    } else setTimeout(poll, 200);
+                } else { setTimeout(poll, resp.status === 404 ? 1500 : 3000); }
+            } catch (_) { setTimeout(poll, 3000); }
+        }
+        poll();
+        el.addEventListener('error', () => { stopped = true; });
+        ms.addEventListener('sourceclose', () => { stopped = true; });
+    });
 }
 
 function toggleFilePreview(previewId, url, isMarkdown) {

--- a/tests/test_ui_stream_setup_endpoint.py
+++ b/tests/test_ui_stream_setup_endpoint.py
@@ -1,0 +1,198 @@
+"""Regression tests for UI stream setup bundle endpoint."""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+# Ensure repository root is importable when running tests directly.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Provide a lightweight zeroconf stub for environments without optional deps.
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.core.streams import StreamManager
+from canopy.ui.routes import create_ui_blueprint
+
+
+class _FakeDbManager:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self.db_path = Path(':memory:')
+
+    @contextmanager
+    def get_connection(self):
+        yield self._conn
+
+    def get_user(self, user_id: str):
+        row = self._conn.execute(
+            "SELECT * FROM users WHERE id = ?",
+            (user_id,),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def get_instance_owner_user_id(self):
+        row = self._conn.execute(
+            "SELECT id FROM users ORDER BY rowid ASC LIMIT 1"
+        ).fetchone()
+        if not row:
+            return None
+        return row['id'] if isinstance(row, sqlite3.Row) else row[0]
+
+
+class TestUiStreamSetupEndpoint(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute('PRAGMA foreign_keys = ON')
+        self.conn.executescript(
+            """
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                username TEXT,
+                display_name TEXT
+            );
+            CREATE TABLE channels (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                privacy_mode TEXT
+            );
+            CREATE TABLE channel_members (
+                channel_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                role TEXT DEFAULT 'member'
+            );
+            """
+        )
+        self.conn.executemany(
+            "INSERT INTO users (id, username, display_name) VALUES (?, ?, ?)",
+            [
+                ('u-owner', 'owner', 'Owner'),
+                ('u-viewer', 'viewer', 'Viewer'),
+                ('u-outsider', 'outsider', 'Outsider'),
+            ],
+        )
+        self.conn.execute(
+            "INSERT INTO channels (id, name, privacy_mode) VALUES (?, ?, ?)",
+            ('C1', 'ops-stream', 'open'),
+        )
+        self.conn.executemany(
+            "INSERT INTO channel_members (channel_id, user_id, role) VALUES (?, ?, ?)",
+            [
+                ('C1', 'u-owner', 'member'),
+                ('C1', 'u-viewer', 'member'),
+            ],
+        )
+        self.conn.commit()
+
+        self.db_manager = _FakeDbManager(self.conn)
+        self.stream_manager = StreamManager(
+            db=self.db_manager,
+            channel_manager=MagicMock(),
+            data_root=self.tempdir.name,
+        )
+        self.stream_row, create_err = self.stream_manager.create_stream(
+            channel_id='C1',
+            created_by='u-owner',
+            title='Ops audio',
+            stream_kind='media',
+            media_kind='audio',
+            protocol='hls',
+        )
+        self.assertIsNone(create_err)
+        self.assertIsNotNone(self.stream_row)
+
+        components = (
+            self.db_manager,    # db_manager
+            MagicMock(),        # api_key_manager
+            MagicMock(),        # trust_manager
+            MagicMock(),        # message_manager
+            MagicMock(),        # channel_manager
+            MagicMock(),        # file_manager
+            MagicMock(),        # feed_manager
+            MagicMock(),        # interaction_manager
+            MagicMock(),        # profile_manager
+            MagicMock(),        # config
+            MagicMock(),        # p2p_manager
+        )
+        self.get_components_patcher = patch(
+            'canopy.ui.routes.get_app_components',
+            return_value=components,
+        )
+        self.get_components_patcher.start()
+        self.addCleanup(self.get_components_patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.config['STREAM_MANAGER'] = self.stream_manager
+        app.register_blueprint(create_ui_blueprint())
+        self.client = app.test_client()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    def _set_session(self, user_id: str) -> None:
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = user_id
+            sess['username'] = user_id
+            sess['_csrf_token'] = 'csrf-test-token'
+
+    def test_owner_gets_setup_bundle_for_media_stream(self) -> None:
+        self._set_session('u-owner')
+        stream_id = str((self.stream_row or {}).get('id') or '')
+        response = self.client.post(
+            f'/ajax/streams/{stream_id}/setup',
+            json={'ingest_ttl_seconds': 3600, 'view_ttl_seconds': 900},
+            headers={'X-CSRFToken': 'csrf-test-token'},
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        setup = payload.get('setup') or {}
+        ingest = setup.get('ingest') or {}
+        playback = setup.get('playback') or {}
+        commands = setup.get('commands') or {}
+        self.assertIn('/ingest/manifest?token=', ingest.get('manifest_url') or '')
+        self.assertIn('/ingest/segments/seg%06d.ts?token=', ingest.get('segment_url_template') or '')
+        self.assertIn('/manifest.m3u8?token=', playback.get('url') or '')
+        self.assertIn('ffmpeg', commands.get('posix') or '')
+        self.assertIn('ffmpeg', commands.get('powershell') or '')
+
+    def test_non_manager_gets_not_found_style_response(self) -> None:
+        self._set_session('u-viewer')
+        stream_id = str((self.stream_row or {}).get('id') or '')
+        response = self.client.post(
+            f'/ajax/streams/{stream_id}/setup',
+            json={'ingest_ttl_seconds': 3600},
+            headers={'X-CSRFToken': 'csrf-test-token'},
+        )
+        self.assertEqual(response.status_code, 404)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('error'), 'Not found')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Restores Go Live button, broadcaster panel, MSE live viewer, and hls.js fallback stripped by commit 557c9ec. Adds POST /ajax/streams/<id>/setup endpoint with ingest/view tokens and ffmpeg command templates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new authenticated endpoints that mint stream view/ingest tokens and expands client-side streaming/broadcasting logic, which could affect authorization and token leakage if misconfigured. Also introduces a CDN-loaded `hls.js` dependency and complex browser media/MSE code paths that may be brittle across browsers.
> 
> **Overview**
> Adds a suite of authenticated `/ajax/streams*` UI endpoints to list/create/get/start/stop streams, issue short-lived playback sessions, and return a new operator-focused `POST /ajax/streams/<id>/setup` bundle with ingest/view tokens, URLs, and ffmpeg/curl command templates.
> 
> Updates `channels.html` to support **stream card attachments** in channel messages, including quick-create stream post actions, one-click playback (HLS with `hls.js` fallback, WebM via MSE), a telemetry feed viewer, and a restored in-browser broadcaster panel that captures mic/camera and uploads live segments/manifests.
> 
> Adds a regression test covering the new setup endpoint, including expected URL templates and access behavior (authorized user succeeds; non-operator gets a 404-style response).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a634c808c697c09edcb1b96fa9162b999d2eb75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->