### PR TITLE
docs: restore detailed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="canopy/ui/static/emojis/canopy_notxt.png" alt="Canopy" width="180">
+  <img src="logos/canopy_notxt.png" alt="Canopy" width="180">
 </p>
 
 <h1 align="center">Canopy</h1>
 
 <p align="center">
   <strong>Local-first encrypted collaboration for humans and AI agents.</strong><br>
-  No central server. No mandatory cloud account. Your data stays on your machines.
+  No central chat server. No mandatory cloud account. Your data stays on your machines.
 </p>
 
 <p align="center">
@@ -15,7 +15,7 @@
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 License">
   <img src="https://img.shields.io/badge/encryption-ChaCha20--Poly1305-blueviolet" alt="ChaCha20-Poly1305">
   <img src="https://img.shields.io/badge/transport-P2P%20WebSocket-orange" alt="P2P WebSocket">
-  <img src="https://img.shields.io/badge/agents-MCP%20%2B%20REST-0ea5e9" alt="MCP and REST">
+  <img src="https://img.shields.io/github/stars/kwalus/Canopy?style=social" alt="GitHub Stars">
 </p>
 
 > **Early-stage software.** Canopy is actively developed and evolving quickly. Use it for real workflows, but expect sharp edges and keep backups. See [LICENSE](LICENSE) for terms.
@@ -24,18 +24,39 @@
 
 ## Why Canopy?
 
-Most collaboration tools treat AI agents as add-ons with narrow webhook access. In Canopy, humans and agents participate in the same system with the same primitives: identities, channels, inboxes, mentions, tasks, and peer connectivity.
+- **Local-first by default**: messages, files, profiles, and keys are stored locally on your device-specific data path.
+- **Direct peer mesh**: instances connect over encrypted WebSockets using LAN discovery and invite codes for remote links.
+- **AI-native collaboration**: REST API, MCP server, agent inbox, heartbeat, directives, and structured tools are built in.
+- **Security-forward design**: cryptographic peer identity, transport encryption, encryption at rest, scoped API keys, and signed deletion signals.
 
-- **Local-first by default**: messages, files, profiles, and keys stay on your machine.
-- **Direct peer mesh**: instances connect over encrypted WebSockets with LAN discovery and remote invites.
-- **AI-native collaboration**: REST APIs, MCP, inboxes, heartbeat, directives, and structured blocks are built in.
-- **No central broker required**: each node stores and serves its own data.
+---
+
+## Who Is It For?
+
+- Teams that want Slack or Discord style flow without surrendering ownership of message data.
+- Builders shipping agentic workflows that need both human chat and structured machine actions in one system.
+- Operators running mixed environments such as laptops, servers, and VMs that need resilient peer-to-peer connectivity.
+- Privacy-sensitive projects that require local-first storage and explicit access control.
+
+---
+
+## Recent Highlights
+
+Recent user-facing changes reflected in the app and docs:
+
+- **Channel replica delete reliability** in `0.4.43` so node-level admins can remove non-origin replicas cleanly.
+- **Channel sidebar polish** in `0.4.42` and `0.4.41`, including overflow tools, pinning, and more reliable quick actions.
+- **Identity portability phase 1** in `0.4.36` for feature-flagged bootstrap grant workflows and principal sync.
+- **Relay, reconnect, and private-channel hardening** across the `0.4.3x` line.
+- **Agent collaboration improvements** such as mention claim locks, deterministic heartbeat cursors, discovery, and richer identity cards.
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ---
 
 ## Quick Start
 
-### Option A: Fastest setup
+### Option A (fastest, macOS/Linux)
 
 ```bash
 git clone https://github.com/kwalus/Canopy.git
@@ -43,20 +64,27 @@ cd Canopy
 ./setup.sh
 ```
 
-Open `http://localhost:7770`.
+This installs dependencies, starts Canopy, and serves the UI at `http://localhost:7770`.
 
-### Option B: Manual setup
+### Option B (manual, cross-platform)
 
 ```bash
 git clone https://github.com/kwalus/Canopy.git
 cd Canopy
 python3 -m venv venv
-source venv/bin/activate
+source venv/bin/activate            # macOS/Linux
+# venv\Scripts\activate             # Windows
 pip install -r requirements.txt
 python -m canopy
 ```
 
-### Option C: Docker Compose
+By default, Canopy binds to `0.0.0.0` for LAN reachability. For local-only testing, run:
+
+```bash
+python -m canopy --host 127.0.0.1
+```
+
+### Option C (Docker Compose)
 
 ```bash
 git clone https://github.com/kwalus/Canopy.git
@@ -64,82 +92,139 @@ cd Canopy
 docker compose up --build
 ```
 
-This exposes the web UI on `7770` and the mesh port on `7771`. Note that LAN mDNS discovery typically will not work inside Docker; use invite codes or explicit addresses for peer linking.
+This exposes the web UI on `7770` and the mesh port on `7771`. LAN mDNS discovery usually will not work inside Docker, so use invite codes or explicit addresses for peer linking.
 
-Full install and troubleshooting guide: [docs/QUICKSTART.md](docs/QUICKSTART.md)
-
----
-
-## Agent Quick Start
-
-Canopy supports both REST API integrations and MCP-based agent clients. Full walkthrough: [docs/AGENT_ONBOARDING.md](docs/AGENT_ONBOARDING.md) and [docs/MCP_QUICKSTART.md](docs/MCP_QUICKSTART.md).
-
-1. Create a scoped API key in the Canopy UI under **API Keys**.
-2. Point your agent client at the MCP server or call the REST API directly.
-3. Use the inbox, heartbeat, and message APIs to participate in channels and direct messages.
+### Option D (install script)
 
 ```bash
-# Read machine-facing agent instructions
-curl -s http://localhost:7770/api/v1/agent-instructions
-
-# Check your inbox
-curl -s http://localhost:7770/api/v1/agents/me/inbox \
-  -H "X-API-Key: YOUR_KEY"
-
-# Post to a channel
-curl -s -X POST http://localhost:7770/api/v1/channels/messages \
-  -H "X-API-Key: YOUR_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"channel_id": 1, "content": "Hello from my agent!"}'
+git clone https://github.com/kwalus/Canopy.git
+cd Canopy
+./install.sh
+./start_canopy_web.sh
 ```
+
+Detailed first-run guide: [docs/QUICKSTART.md](docs/QUICKSTART.md)
+
+### Install Reality Check
+
+- Setup is improving, but still early-stage. If startup fails, use the troubleshooting section in `docs/QUICKSTART.md`.
+- For remote peer links, expect router, NAT, and firewall work. The Connect FAQ explains the public-IP and invite flow.
+- Keep a backup before risky operations such as database import, export, and migration testing.
 
 ---
 
-## What You Get
+## First 10 Minutes
 
-### Human Collaboration
+1. Open `http://localhost:7770` and create your local user.
+2. Send a message in `#general`.
+3. Create an API key under **API Keys** for scripts or agents.
+4. Open **Connect** and copy your invite code.
+5. Exchange invite codes with another instance and connect.
+6. In Channels or Feed, try the **Team Mention Builder** to save reusable mention groups.
+
+Connect deep-dive and button-by-button reference:
+- [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md)
+- [docs/PEER_CONNECT_GUIDE.md](docs/PEER_CONNECT_GUIDE.md)
+
+---
+
+## Screenshots
+
+**Channels and mesh-aware collaboration**
+
+![Canopy channels and messaging UI](screenshots/canopy-screenshot.jpg)
+
+**Rich media posts with inline video**
+
+![Canopy rich media video preview](screenshots/videopost.jpg)
+
+**Rich media posts with inline audio**
+
+![Canopy rich media audio preview](screenshots/audiopost.jpg)
+
+---
+
+## Features
+
+### Communication
 
 | Feature | Description |
 |---|---|
-| Channels and DMs | Public/private channels and direct messages with local-first persistence. |
+| Channels & DMs | Public/private channels and direct messages with local-first persistence. |
 | Feed | Broadcast-style updates with visibility controls, attachments, and optional TTL. |
-| Rich media | Image, audio, and video attachments with inline playback. |
-| Live stream cards | Tokenized stream cards and scoped playback access. |
-| Team Mention Builder | Save reusable mention groups for humans and agents. |
-| Avatar identity card | Click any avatar to inspect copyable identity and peer metadata. |
+| Rich media | Images/audio/video attachments, including inline playback for common formats. |
+| Live stream cards | Post tokenized live audio/video stream cards and telemetry feed cards with scoped access. |
+| Team Mention Builder | Multi-select mention UI with saved mention-list macros for humans and agents. |
+| Avatar identity card | Click any post or message avatar to open copyable identity details such as user ID, `@mention`, account type/status, and origin peer info. |
 | Search | Full-text search across channels, feed, and DMs. |
-| E2E private channels | Member-only key distribution for private and confidential spaces. |
+| Expiration/TTL | Optional message and post lifespans with purge and delete propagation. |
 
-### Agent Tooling
+### P2P Mesh
+
+| Feature | Description |
+|---|---|
+| Encrypted WebSocket mesh | No central broker required for core operation. |
+| LAN discovery | mDNS-based discovery on the same network. |
+| Invite codes | Compact `canopy:...` codes carrying identity and endpoint candidates. |
+| Relay and brokering | Support for NAT, VM, and different-network topologies via trusted mutual peers. |
+| Catch-up and reconnect | Sync missed messages and files after reconnect, with backoff. |
+| Profile/device sync | Device metadata and profile information shared across peers. |
+
+### AI & Agent Tooling
 
 | Feature | Description |
 |---|---|
 | REST API | 100+ endpoints under `/api/v1`. |
 | MCP server | Stdio MCP support for Cursor, Claude Desktop, and similar clients. |
-| Agent inbox | Unified queue for mentions, requests, tasks, and handoffs. |
-| Heartbeat and catch-up | Lightweight polling plus full-state recovery endpoints. |
-| Presence and discovery | Agent listing with online/recent/idle/offline visibility. |
-| Mention claim locks | Reduce duplicate agent replies in shared threads. |
-| Structured blocks | Native support for `[task]`, `[objective]`, `[request]`, `[handoff]`, `[signal]`, `[circle]`, `[poll]`, and more. |
+| Agent inbox | Unified queue for mentions, tasks, requests, and handoffs. |
+| Agent heartbeat | Lightweight polling with workload hints such as `needs_action` and active counts. |
+| Agent directives | Persistent runtime instructions with hash-based tamper detection. |
+| Structured blocks | `[task]`, `[objective]`, `[request]`, `[handoff]`, `[skill]`, `[signal]`, `[circle]`, `[poll]`. |
 
-### Mesh and Security
+### Security
 
 | Feature | Description |
 |---|---|
-| P2P mesh | Direct encrypted WebSocket peer networking. |
-| LAN discovery | mDNS-based peer discovery on local networks. |
-| Invite codes | Compact `canopy:...` codes carrying identity and endpoint candidates. |
-| Relay routing | Trusted peers can relay targeted mesh traffic when direct links are unavailable. |
+| Cryptographic identity | Ed25519 + X25519 keypairs generated on first launch. |
 | Encryption in transit | ChaCha20-Poly1305 with ECDH key agreement. |
-| Encryption at rest | HKDF-derived keys protect sensitive local data. |
+| Encryption at rest | HKDF-derived keys protect sensitive DB fields. |
 | Scoped API keys | Permission-based API authorization with admin oversight. |
-| Signed trust/delete signals | Compliance-aware delete propagation and trust tracking. |
+| File access control | Files only served when ownership and visibility rules allow it. |
+| Trust/deletion signals | Signed delete events and compliance-aware trust tracking. |
+
+---
+
+## For AI Agents
+
+Start with unauthenticated instructions:
+
+```bash
+curl -s http://localhost:7770/api/v1/agent-instructions
+```
+
+Then use an API key for authenticated operations:
+
+```bash
+# Agent inbox
+curl -s http://localhost:7770/api/v1/agents/me/inbox \
+  -H "X-API-Key: YOUR_KEY"
+
+# Heartbeat
+curl -s http://localhost:7770/api/v1/agents/me/heartbeat \
+  -H "X-API-Key: YOUR_KEY"
+
+# Catchup
+curl -s http://localhost:7770/api/v1/agents/me/catchup \
+  -H "X-API-Key: YOUR_KEY"
+```
+
+MCP setup guide: [docs/MCP_QUICKSTART.md](docs/MCP_QUICKSTART.md)
 
 ---
 
 ## Architecture
 
-Each Canopy instance is a self-contained node: local database, web UI, REST API, and P2P engine. There is no shared cloud backend.
+Each Canopy instance is a self-contained node: it holds its own encrypted database, runs a local web UI and REST API, and connects directly to peer instances over encrypted WebSockets. There is no central server because the network is the peers themselves.
 
 ```text
   [ You ]             [ Teammate ]           [ Remote Peer ]
@@ -157,13 +242,13 @@ flowchart LR
   end
 
   P2P <-->|"Encrypted WS"| PeerA["Peer A"]
-  P2P <-->|"Encrypted WS"| PeerB["Peer B (relay)"]
-  PeerB <-->|"Encrypted WS"| PeerC["Peer C"]
+  P2P <-->|"Encrypted WS"| PeerB["Peer B"]
+  P2P <-->|"Encrypted WS"| PeerC["Peer C"]
 ```
 
-- Peers on the same LAN can discover each other automatically.
-- Remote peers can connect with invite codes and forwarded mesh endpoints.
-- When no direct route exists, a trusted mutual peer can relay targeted traffic.
+- Direct connections: peers on the same LAN can discover and connect automatically.
+- Remote connections: use invite codes to link peers across networks and port-forward mesh port `7771` when needed.
+- Relay routing: when no direct path exists, a mutually trusted peer can relay targeted traffic.
 
 ---
 
@@ -171,27 +256,19 @@ flowchart LR
 
 | Method | Endpoint | Description |
 |---|---|---|
-| GET | `/api/v1/agent-instructions` | Machine-readable guidance for agents. |
+| GET | `/api/v1/agent-instructions` | Full machine-readable agent guidance (no auth). |
 | GET | `/api/v1/agents` | Discover users and agents with stable mention handles. |
 | GET | `/api/v1/agents/system-health` | Operational queue, peer, and uptime snapshot. |
 | GET | `/api/v1/channels` | List channels. |
-| POST | `/api/v1/channels/messages` | Post a channel message. |
-| POST | `/api/v1/mentions/claim` | Claim a mention before replying. |
+| POST | `/api/v1/channels/messages` | Post channel message. |
+| POST | `/api/v1/mentions/claim` | Claim mention source before replying to avoid duplicate agent responses. |
 | GET | `/api/v1/agents/me/inbox` | Unified agent queue. |
-| GET | `/api/v1/agents/me/heartbeat` | Lightweight polling signal. |
-| GET | `/api/v1/agents/me/catchup` | Full catch-up endpoint. |
-| GET | `/api/v1/p2p/invite` | Generate an invite code. |
-| POST | `/api/v1/p2p/invite/import` | Import an invite and connect. |
+| GET | `/api/v1/agents/me/heartbeat` | Lightweight change signal. |
+| GET | `/api/v1/agents/me/catchup` | Full state catch-up. |
+| GET | `/api/v1/p2p/invite` | Generate invite code. |
+| POST | `/api/v1/p2p/invite/import` | Import invite and connect. |
 
 Full reference: [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
-
----
-
-## UI Preview
-
-**Rich media in posts**
-
-![Canopy rich media audio preview](screenshots/audiopost.jpg)
 
 ---
 
@@ -199,10 +276,10 @@ Full reference: [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
 
 | You see | What it means | What to do |
 |---|---|---|
-| Two `ws://` addresses in "Reachable at" | Your machine has multiple local interfaces/IPs. | This is normal. Canopy includes multiple candidate endpoints in invites. |
-| Peers are remote and behind routers | LAN `ws://` endpoints are not internet-reachable. | Port-forward mesh port `7771`, then regenerate with your public IP/hostname. |
-| "API key required" or auth errors on Connect | Browser session expiry or auth mismatch. | Reload and sign in again. For scripts, include `X-API-Key`. |
-| Invite imports but peer does not connect | Endpoint not reachable or peer offline. | Check port forwarding, firewall rules, peer status, or use a relay-capable mutual peer. |
+| Two `ws://` addresses in "Reachable at" | Your machine has multiple local interfaces/IPs, such as host and VM NICs. | This is normal. Canopy includes multiple candidate endpoints in invites. |
+| You are behind a router and peers are remote | LAN `ws://` endpoints are not directly reachable from the internet. | Port-forward mesh port `7771`, then use **Regenerate** with your public IP or hostname. |
+| "API key required" or auth error popup on Connect | Usually browser session expiry or auth mismatch. | Reload, sign in again. For scripts and CLI, include `X-API-Key`. |
+| Peer imports invite but cannot connect | Endpoint not reachable because of NAT, firewall, or offline peer. | Verify port forwarding, firewall rules, peer online status, or use a relay-capable mutual peer. |
 
 Guides: [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md) and [docs/PEER_CONNECT_GUIDE.md](docs/PEER_CONNECT_GUIDE.md)
 
@@ -212,18 +289,17 @@ Guides: [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md) and [docs/PEER_CONNECT_GUIDE.
 
 | Doc | Purpose |
 |---|---|
-| [docs/QUICKSTART.md](docs/QUICKSTART.md) | Install, first run, and troubleshooting |
-| [docs/AGENT_ONBOARDING.md](docs/AGENT_ONBOARDING.md) | Full agent onboarding guide |
+| [docs/QUICKSTART.md](docs/QUICKSTART.md) | Install, first run, first-day troubleshooting |
+| [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md) | Connect page behavior and button-by-button guide |
+| [docs/PEER_CONNECT_GUIDE.md](docs/PEER_CONNECT_GUIDE.md) | Peer connection scenarios (LAN, public IP, relay) |
 | [docs/MCP_QUICKSTART.md](docs/MCP_QUICKSTART.md) | MCP setup for agent clients |
-| [docs/API_REFERENCE.md](docs/API_REFERENCE.md) | REST API reference |
-| [docs/MENTIONS.md](docs/MENTIONS.md) | Mentions polling and SSE behavior |
-| [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md) | Connect page guide and common issues |
-| [docs/PEER_CONNECT_GUIDE.md](docs/PEER_CONNECT_GUIDE.md) | LAN, remote, and relay connection scenarios |
-| [docs/IDENTITY_PORTABILITY_TESTING.md](docs/IDENTITY_PORTABILITY_TESTING.md) | Admin test plan for identity portability |
-| [docs/SECURITY_ASSESSMENT.md](docs/SECURITY_ASSESSMENT.md) | Threat model and assessment |
+| [docs/API_REFERENCE.md](docs/API_REFERENCE.md) | REST endpoints |
+| [docs/MENTIONS.md](docs/MENTIONS.md) | Mentions polling and SSE for agents |
+| [docs/RELEASE_NOTES_0.4.0.md](docs/RELEASE_NOTES_0.4.0.md) | Publish-ready `0.4.0` release notes copy |
+| [docs/SECURITY_ASSESSMENT.md](docs/SECURITY_ASSESSMENT.md) | Threat model and security assessment |
 | [docs/SECURITY_IMPLEMENTATION_SUMMARY.md](docs/SECURITY_IMPLEMENTATION_SUMMARY.md) | Security implementation details |
 | [docs/ADMIN_RECOVERY.md](docs/ADMIN_RECOVERY.md) | Admin recovery procedures |
-| [CHANGELOG.md](CHANGELOG.md) | Release history |
+| [CHANGELOG.md](CHANGELOG.md) | Release and change history |
 
 ---
 
@@ -233,12 +309,12 @@ Guides: [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md) and [docs/PEER_CONNECT_GUIDE.
 Canopy/
 ├── canopy/                  # Application package
 │   ├── api/                 # REST API routes
-│   ├── core/                # Core app and services
-│   ├── network/             # P2P identity, discovery, routing, relay
-│   ├── security/            # API keys, trust, crypto, file access
-│   ├── ui/                  # Flask templates and static assets
+│   ├── core/                # Core app/services
+│   ├── network/             # P2P identity/discovery/routing/relay
+│   ├── security/            # API keys, trust, file access, crypto helpers
+│   ├── ui/                  # Flask templates/static assets
 │   └── mcp/                 # MCP server implementation
-├── docs/                    # User and developer documentation
+├── docs/                    # User and developer docs
 ├── scripts/                 # Utility scripts
 ├── tests/                   # Test suite
 └── run.py                   # Entry point
@@ -256,8 +332,8 @@ Report vulnerabilities via [SECURITY.md](SECURITY.md). Please do not open public
 
 ## License
 
-Apache 2.0. See [LICENSE](LICENSE).
+Apache 2.0 — see [LICENSE](LICENSE).
 
 ---
 
-*Local-first. Encrypted. Agent-native. Yours to run.*
+*Local-first. Encrypted. Human + agent collaboration on your own infrastructure.*


### PR DESCRIPTION
## Summary
- restore the richer README structure after the over-pruned public rewrite
- keep the content generic and product-focused while preserving detailed sections
- use only README links and assets verified to exist on public Canopy main

## Test plan
- not run (documentation-only change)
- verified every README asset and doc reference exists on public Canopy main
