### PR TITLE
release: publish v0.4.59 reliability and DM updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [0.4.59] - 2026-03-09
+
+### Fixed
+- **DM remote-vs-local classification** — Ambiguous recipient rows with blank or stale `origin_peer` are no longer assumed to be local unless there is positive evidence that they belong to this instance. This prevents remote 1:1 and group DMs from being misclassified as `local_only`, preserves the correct DM security summary, and keeps mesh broadcast enabled for remote humans whose provenance metadata is incomplete.
+
+---
+
+## [0.4.58] - 2026-03-09
+
+### Fixed
+- **DM search and scroll layout fixes** — DM search now pages through relevant message history before filtering decrypted content and attachment metadata, so older encrypted-at-rest matches are no longer missed behind newer non-matching rows. The DM workspace layout also keeps the sidebar, thread, and composer in better-separated scrolling regions so the composer stays anchored more like a modern messaging client.
+
+---
+
+## [0.4.57] - 2026-03-09
+
+### Fixed
+- **Dead connection send-failure churn** — A send timeout or closed-socket error now retires the affected peer connection immediately before the asynchronous close finishes, so queued senders stop treating the socket as live and the terminal no longer floods with repeated `no close frame received` errors after the first dead-connection failure.
+
+---
+
+## [0.4.56] - 2026-03-09
+
+### Changed
+- **Mesh connectivity reliability hardening** — Reconnect now prefers current discovery-backed peer endpoints over stale persisted ones, while endpoint-level diagnostics retain source, attempt, and failure history so operators can see why a peer is not connectable instead of only seeing generic reconnect churn.
+
+### Fixed
+- **Discovery endpoint ownership and diagnostics accuracy** — Discovered endpoints are no longer claimed before a successful connection proves ownership, connected peers are classified correctly even when stale relay metadata lingers, reconnect scheduling only reports active tasks, and the diagnostics failure list now surfaces the newest failures first.
+
+---
+
 ## [0.4.55] - 2026-03-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.55-blue" alt="Version 0.4.55">
+  <img src="https://img.shields.io/badge/version-0.4.59-blue" alt="Version 0.4.59">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 License">
   <img src="https://img.shields.io/badge/encryption-ChaCha20--Poly1305-blueviolet" alt="ChaCha20-Poly1305">
@@ -23,7 +23,7 @@
   <a href="docs/QUICKSTART.md"><strong>Get Started</strong></a> ·
   <a href="docs/API_REFERENCE.md"><strong>API Reference</strong></a> ·
   <a href="docs/MCP_QUICKSTART.md"><strong>Agent Guide</strong></a> ·
-  <a href="docs/GITHUB_RELEASE_v0.4.55.md"><strong>Latest Release</strong></a> ·
+  <a href="docs/GITHUB_RELEASE_v0.4.59.md"><strong>Latest Release</strong></a> ·
   <a href="docs/WINDOWS_TRAY.md"><strong>Windows Tray</strong></a> ·
   <a href="CHANGELOG.md"><strong>Changelog</strong></a>
 </p>
@@ -79,6 +79,10 @@ Most chat products treat AI as bolt-on automation hanging off webhooks or extern
 
 Recent user-facing changes reflected in the app and docs:
 
+- **DM delivery and classification hardening** in `0.4.59`, preventing ambiguous remote human rows from being downgraded to `local_only` when `origin_peer` is blank or stale, so DM security summaries stay honest and remote messages still take the mesh path instead of being silently treated as same-instance traffic.
+- **DM search and messaging layout refinement** in `0.4.58`, making DM search page through older encrypted-at-rest history instead of only scanning a recent window, while improving sidebar/thread/composer scroll separation so the workspace behaves more like a dedicated messaging client.
+- **Dead-connection send churn fix** in `0.4.57`, retiring dead sockets immediately after a timeout or close failure so one broken peer no longer floods the terminal with repeated `no close frame received` errors from queued sends.
+- **Mesh connectivity reliability hardening** in `0.4.56`, making reconnect prefer current discovery-backed endpoints over stale persisted ones, tightening endpoint diagnostics, and avoiding misleading reconnect-state reporting.
 - **DM recipient search and incremental refresh** in `0.4.55`, making the DM composer recipient picker respond immediately on first interaction and replacing disruptive DM page reload behavior with incremental thread snapshots, active-thread polling, and smoother live updates while preserving scroll position.
 - **DM attachment parity, image paste, and security-indicator polish** in `0.4.54`, bringing the DM composer up to channel-level attachment support with broader file acceptance, screenshot/image paste handling, icon-first security markers, and tighter per-message action controls so the DM workspace feels more complete without losing visible trust cues.
 - **DM E2E hardening and security markers** in `0.4.53`, adding relay-compatible recipient-only encryption for direct messages when the destination peer supports `dm_e2e_v1`, preserving backward-compatible fallback for older peers, refreshing inbox payloads with DM security summaries, and surfacing explicit shield states in the DM workspace so operators can see whether a thread is `peer_e2e_v1`, `local_only`, `mixed`, or legacy plaintext.
@@ -522,7 +526,7 @@ Guides: [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md) and [docs/PEER_CONNECT_GUIDE.
 | [docs/MENTIONS.md](docs/MENTIONS.md) | Mentions polling and SSE for agents |
 | [docs/WINDOWS_TRAY.md](docs/WINDOWS_TRAY.md) | Windows tray runtime and installer flow |
 | [docs/IDENTITY_PORTABILITY_TESTING.md](docs/IDENTITY_PORTABILITY_TESTING.md) | Feature-flagged identity portability admin workflow |
-| [docs/GITHUB_RELEASE_v0.4.55.md](docs/GITHUB_RELEASE_v0.4.55.md) | Product-forward GitHub release copy for the current public release |
+| [docs/GITHUB_RELEASE_v0.4.59.md](docs/GITHUB_RELEASE_v0.4.59.md) | Product-forward GitHub release copy for the current public release |
 | [docs/GITHUB_RELEASE_TEMPLATE.md](docs/GITHUB_RELEASE_TEMPLATE.md) | Baseline structure for future public GitHub release notes |
 | [docs/RELEASE_NOTES_0.4.0.md](docs/RELEASE_NOTES_0.4.0.md) | Publish-ready `0.4.0` release notes copy |
 | [docs/SECURITY_ASSESSMENT.md](docs/SECURITY_ASSESSMENT.md) | Threat model and security assessment |

--- a/canopy/__init__.py
+++ b/canopy/__init__.py
@@ -11,7 +11,7 @@ License: Apache 2.0
 Development: AI-assisted implementation (Claude, Codex, GitHub Copilot, Cursor IDE, Ollama)
 """
 
-__version__ = "0.4.55"
+__version__ = "0.4.59"
 __protocol_version__ = 1
 __author__ = "Canopy Contributors"
 __license__ = "Apache-2.0"

--- a/canopy/core/messaging.py
+++ b/canopy/core/messaging.py
@@ -286,9 +286,40 @@ def is_local_dm_user(db_manager: Any, p2p_manager: Any, user_id: Optional[str]) 
     except Exception:
         local_peer_id = None
     origin_peer = str(row.get("origin_peer") or "").strip()
-    if origin_peer and origin_peer != str(local_peer_id or "").strip():
+    local_peer_id = str(local_peer_id or "").strip()
+    if origin_peer:
+        return bool(local_peer_id and origin_peer == local_peer_id)
+
+    # Blank origin metadata is ambiguous on legacy or partially synced peers.
+    # Only treat the recipient as local when we have positive local-account
+    # evidence, otherwise fall back to mesh delivery instead of silently
+    # downgrading the DM to local_only.
+    if str(row.get("password_hash") or "").strip():
+        return True
+    if bool(row.get("is_registered")):
+        return True
+
+    try:
+        with db_manager.get_connection() as conn:
+            row_user_key = None
+            row_api_key = None
+            try:
+                row_user_key = conn.execute(
+                    "SELECT 1 FROM user_keys WHERE user_id = ? LIMIT 1",
+                    (uid,),
+                ).fetchone()
+            except Exception:
+                row_user_key = None
+            try:
+                row_api_key = conn.execute(
+                    "SELECT 1 FROM api_keys WHERE user_id = ? AND COALESCE(revoked, 0) = 0 LIMIT 1",
+                    (uid,),
+                ).fetchone()
+            except Exception:
+                row_api_key = None
+        return bool(row_user_key or row_api_key)
+    except Exception:
         return False
-    return True
 
 
 def filter_local_dm_targets(db_manager: Any, p2p_manager: Any, user_ids: Sequence[str]) -> List[str]:
@@ -816,51 +847,77 @@ class MessageManager:
     def search_messages(self, user_id: str, query: str, limit: int = 20) -> List[Message]:
         """Search messages by content."""
         try:
+            clean_query = str(query or '').strip()
+            if not clean_query:
+                return []
+            query_folded = clean_query.casefold()
+            target_limit = max(int(limit or 20), 1)
+            fetch_limit = max(target_limit * 25, 400)
+            offset = 0
             with self.db.get_connection() as conn:
-                cursor = conn.execute("""
-                    SELECT m.*, u.username as sender_username 
-                    FROM messages m
-                    LEFT JOIN users u ON m.sender_id = u.id
-                    WHERE (
-                        m.sender_id = ?
-                        OR m.recipient_id = ?
-                        OR m.recipient_id IS NULL
-                        OR EXISTS (
-                            SELECT 1
-                            FROM json_each(
-                                CASE WHEN json_valid(m.metadata) THEN m.metadata ELSE '{}' END,
-                                '$.group_members'
-                            ) gm
-                            WHERE CAST(gm.value AS TEXT) = ?
-                        )
-                    )
-                    AND m.content LIKE ?
-                    ORDER BY m.created_at DESC
-                    LIMIT ?
-                """, (user_id, user_id, user_id, f"%{query}%", limit))
-                
                 messages = []
-                for row in cursor.fetchall():
-                    # Decrypt content if encrypted
-                    content = row['content']
-                    if self.data_encryptor and self.data_encryptor.is_enabled:
-                        content = self.data_encryptor.decrypt(content)
-                    
-                    message = Message(
-                        id=row['id'],
-                        sender_id=row['sender_id'],
-                        recipient_id=row['recipient_id'],
-                        content=content,
-                        message_type=MessageType(row['message_type']),
-                        status=MessageStatus.DELIVERED,
-                        created_at=datetime.fromisoformat(row['created_at']),
-                        metadata=json.loads(row['metadata']) if row['metadata'] else None,
-                        delivered_at=datetime.fromisoformat(row['delivered_at']) if row['delivered_at'] else None,
-                        read_at=datetime.fromisoformat(row['read_at']) if row['read_at'] else None,
-                        edited_at=datetime.fromisoformat(row['edited_at']) if row['edited_at'] else None
-                    )
-                    messages.append(message)
-                
+                while len(messages) < target_limit:
+                    cursor = conn.execute("""
+                        SELECT m.*, u.username as sender_username 
+                        FROM messages m
+                        LEFT JOIN users u ON m.sender_id = u.id
+                        WHERE (
+                            m.sender_id = ?
+                            OR m.recipient_id = ?
+                            OR m.recipient_id IS NULL
+                            OR EXISTS (
+                                SELECT 1
+                                FROM json_each(
+                                    CASE WHEN json_valid(m.metadata) THEN m.metadata ELSE '{}' END,
+                                    '$.group_members'
+                                ) gm
+                                WHERE CAST(gm.value AS TEXT) = ?
+                            )
+                        )
+                        ORDER BY m.created_at DESC
+                        LIMIT ? OFFSET ?
+                    """, (user_id, user_id, user_id, fetch_limit, offset))
+                    rows = cursor.fetchall()
+                    if not rows:
+                        break
+
+                    for row in rows:
+                        # Decrypt content if encrypted
+                        content = row['content']
+                        if self.data_encryptor and self.data_encryptor.is_enabled:
+                            content = self.data_encryptor.decrypt(content)
+
+                        metadata = json.loads(row['metadata']) if row['metadata'] else None
+                        searchable_chunks = [str(content or '')]
+                        if isinstance(metadata, dict):
+                            for attachment in metadata.get('attachments') or []:
+                                if isinstance(attachment, dict):
+                                    searchable_chunks.append(str(attachment.get('name') or ''))
+                                    searchable_chunks.append(str(attachment.get('type') or ''))
+                        if not any(query_folded in chunk.casefold() for chunk in searchable_chunks if chunk):
+                            continue
+
+                        message = Message(
+                            id=row['id'],
+                            sender_id=row['sender_id'],
+                            recipient_id=row['recipient_id'],
+                            content=content,
+                            message_type=MessageType(row['message_type']),
+                            status=MessageStatus.DELIVERED,
+                            created_at=datetime.fromisoformat(row['created_at']),
+                            metadata=metadata,
+                            delivered_at=datetime.fromisoformat(row['delivered_at']) if row['delivered_at'] else None,
+                            read_at=datetime.fromisoformat(row['read_at']) if row['read_at'] else None,
+                            edited_at=datetime.fromisoformat(row['edited_at']) if row['edited_at'] else None
+                        )
+                        messages.append(message)
+                        if len(messages) >= target_limit:
+                            break
+
+                    if len(rows) < fetch_limit:
+                        break
+                    offset += len(rows)
+
                 return messages
                 
         except Exception as e:

--- a/canopy/network/connection.py
+++ b/canopy/network/connection.py
@@ -17,7 +17,7 @@ import ssl
 import time
 import websockets
 from pathlib import Path
-from typing import Dict, Optional, Callable, Any, Awaitable
+from typing import Dict, Optional, Callable, Any, Awaitable, List
 from enum import Enum
 from dataclasses import dataclass, field
 
@@ -135,6 +135,12 @@ class PeerConnection:
     last_outbound_activity: Optional[float] = None
     is_outbound: bool = True  # True if we initiated connection
     capabilities: Optional[Dict[str, bool]] = None
+    last_ping_latency_ms: Optional[float] = None  # RTT from last keepalive ping
+    handshake_version: Optional[str] = None
+    canopy_version: Optional[str] = None
+    protocol_version: Optional[int] = None
+    failure_reason: Optional[str] = None
+    failure_detail: Optional[str] = None
     _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
     
     def is_connected(self) -> bool:
@@ -165,7 +171,11 @@ class ConnectionManager:
                  host: str = "0.0.0.0", port: int = 7771,
                  tls_cert_path: Optional[str] = None,
                  tls_key_path: Optional[str] = None,
-                 enable_tls: bool = False):
+                 enable_tls: bool = False,
+                 handshake_capabilities: Optional[List[str]] = None,
+                 canopy_version: str = "0.1.0",
+                 protocol_version: int = 1,
+                 reject_protocol_mismatch: bool = False):
         """
         Initialize connection manager.
         
@@ -182,6 +192,14 @@ class ConnectionManager:
         self.identity_manager = identity_manager
         self.host = host
         self.port = port
+        base_capabilities = handshake_capabilities or ['chat', 'files', 'voice']
+        self.handshake_capabilities = [
+            cap for cap in (str(item).strip() for item in base_capabilities)
+            if cap
+        ] or ['chat', 'files', 'voice']
+        self.local_canopy_version = str(canopy_version or '0.1.0').strip() or '0.1.0'
+        self.local_protocol_version = self._coerce_protocol_version(protocol_version, default=1)
+        self.reject_protocol_mismatch = bool(reject_protocol_mismatch)
         
         # TLS configuration
         self.enable_tls = enable_tls
@@ -200,6 +218,7 @@ class ConnectionManager:
         
         # Connection tracking
         self.connections: Dict[str, PeerConnection] = {}
+        self._last_connect_failures: Dict[str, Dict[str, Any]] = {}
         self.max_connections = 50
         
         # Server
@@ -210,7 +229,7 @@ class ConnectionManager:
         self.message_handlers: Dict[str, Callable[[PeerConnection, Dict[str, Any]], Awaitable[None]]] = {}
         
         # Callback fired when an incoming peer completes authentication
-        self.on_peer_authenticated: Optional[Callable[[str], None]] = None
+        self.on_peer_authenticated: Optional[Callable[..., None]] = None
         
         # Callback fired when a peer disconnects
         self.on_peer_disconnected: Optional[Callable[[str], None]] = None
@@ -222,6 +241,76 @@ class ConnectionManager:
         tls_tag = ' (TLS)' if self.enable_tls else ''
         logger.info(f"Initialized ConnectionManager for {local_peer_id} "
                      f"on {host}:{port}{tls_tag}")
+
+    @staticmethod
+    def _format_endpoint_host(host: str) -> str:
+        """Format a host for endpoint rendering, preserving IPv6 brackets."""
+        text = str(host or '').strip()
+        if ':' in text and not text.startswith('['):
+            return f"[{text}]"
+        return text
+
+    def _failure_key(self, peer_id: str, address: str, port: int) -> str:
+        return f"{peer_id}|{self._format_endpoint_host(address)}|{int(port)}"
+
+    def _record_connect_failure(self, peer_id: str, address: str, port: int,
+                                reason: str, detail: str) -> None:
+        self._last_connect_failures[self._failure_key(peer_id, address, port)] = {
+            'reason': str(reason or 'connection_failed'),
+            'detail': str(detail or reason or 'Connection failed'),
+            'timestamp': time.time(),
+        }
+
+    def _clear_connect_failure(self, peer_id: str, address: str, port: int) -> None:
+        self._last_connect_failures.pop(self._failure_key(peer_id, address, port), None)
+
+    def get_last_connect_failure(self, peer_id: str, address: str, port: int) -> Optional[Dict[str, Any]]:
+        return dict(self._last_connect_failures.get(self._failure_key(peer_id, address, port), {}) or {}) or None
+
+    def _get_handshake_capabilities(self) -> List[str]:
+        """Return deduplicated capability list advertised in handshakes."""
+        return self._normalize_capabilities(self.handshake_capabilities)
+
+    @staticmethod
+    def _normalize_capabilities(raw: Any) -> List[str]:
+        """Normalize capability payloads to a list of non-empty strings."""
+        if raw is None:
+            return []
+        values: List[Any]
+        if isinstance(raw, str):
+            values = [part.strip() for part in raw.split(',')]
+        elif isinstance(raw, (list, tuple, set)):
+            values = list(raw)
+        else:
+            values = []
+        out: List[str] = []
+        seen = set()
+        for cap in values:
+            cap = str(cap).strip()
+            if cap in seen:
+                continue
+            seen.add(cap)
+            out.append(cap)
+        return out
+
+    @staticmethod
+    def _coerce_protocol_version(raw: Any, default: int = 1) -> int:
+        """Parse protocol version from mixed payloads safely."""
+        try:
+            value = int(raw)
+            return value if value > 0 else int(default)
+        except Exception:
+            return int(default)
+
+    @staticmethod
+    def _signed_optional_handshake_fields(payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Return optional handshake fields exactly as signed on wire."""
+        extra: Dict[str, Any] = {}
+        if 'canopy_version' in payload:
+            extra['canopy_version'] = payload.get('canopy_version')
+        if 'protocol_version' in payload:
+            extra['protocol_version'] = payload.get('protocol_version')
+        return extra
     
     async def start(self) -> None:
         """Start connection manager and WebSocket server."""
@@ -261,6 +350,15 @@ class ConnectionManager:
             # Start connection monitor
             asyncio.create_task(self._monitor_connections())
 
+        except OSError as e:
+            if e.errno == 48:  # Address already in use (macOS/Linux)
+                logger.error(
+                    "Port %s is already in use. Stop the other process using it "
+                    "(e.g. another Canopy instance) or set CANOPY_MESH_PORT to a different port (e.g. 7775).",
+                    self.port,
+                )
+            logger.error(f"Failed to start ConnectionManager: {e}", exc_info=True)
+            raise
         except Exception as e:
             logger.error(f"Failed to start ConnectionManager: {e}", exc_info=True)
             raise
@@ -300,6 +398,7 @@ class ConnectionManager:
         # (e.g., ws://127.0.0.1:7771) gets associated with our own peer_id.
         if peer_id == self.local_peer_id:
             logger.warning("Refusing to connect to self (peer_id=%s) at %s:%s", peer_id, address, port)
+            self._record_connect_failure(peer_id, address, port, 'self_connect_blocked', 'Refusing to connect to self')
             return False
 
         # Check if already connected
@@ -312,6 +411,13 @@ class ConnectionManager:
         # Check connection limit
         if len(self.connections) >= self.max_connections:
             logger.warning(f"Connection limit reached ({self.max_connections})")
+            self._record_connect_failure(
+                peer_id,
+                address,
+                port,
+                'connection_limit_reached',
+                f'Connection limit reached ({self.max_connections})',
+            )
             return False
         
         logger.info(f"Connecting to peer {peer_id} at {address}:{port}...")
@@ -371,6 +477,7 @@ class ConnectionManager:
                 connection.state = ConnectionState.AUTHENTICATED
                 connection.connected_at = time.time()
                 connection.update_activity()
+                self._clear_connect_failure(peer_id, address, port)
 
                 logger.info(f"Successfully connected to {peer_id}")
 
@@ -379,7 +486,10 @@ class ConnectionManager:
 
                 return True
 
-            logger.warning(f"Handshake failed with {peer_id}")
+            reason = str(getattr(connection, 'failure_reason', None) or 'handshake_failed')
+            detail = str(getattr(connection, 'failure_detail', None) or f'Handshake failed with {peer_id}')
+            logger.warning(f"Handshake failed with {peer_id}: {detail}")
+            self._record_connect_failure(peer_id, address, port, reason, detail)
             await self._disconnect_connection(connection, notify=False)
             return False
 
@@ -390,6 +500,9 @@ class ConnectionManager:
                 "(will try other addresses or retry)"
             )
             connection.state = ConnectionState.FAILED
+            connection.failure_reason = 'timeout'
+            connection.failure_detail = 'Connection timed out'
+            self._record_connect_failure(peer_id, address, port, 'timeout', 'Connection timed out')
             await self._disconnect_connection(connection, notify=False)
             return False
         except Exception as e:
@@ -399,6 +512,9 @@ class ConnectionManager:
                 exc_info=True,
             )
             connection.state = ConnectionState.FAILED
+            connection.failure_reason = type(e).__name__
+            connection.failure_detail = str(e)
+            self._record_connect_failure(peer_id, address, port, type(e).__name__, str(e))
             await self._disconnect_connection(connection, notify=False)
             return False
     
@@ -441,13 +557,16 @@ class ConnectionManager:
                 await websocket.close()
                 return
             
-            # Reconstruct the signed payload (everything except type and signature)
+            # Reconstruct the signed payload using base fields only.
+            # canopy_version/protocol_version are unsigned metadata, NOT part of the signature.
             payload = {
                 'peer_id': peer_id,
                 'ed25519_public_key': ed25519_pub_b58,
                 'x25519_public_key': x25519_pub_b58,
                 'version': handshake_data.get('version', '0.1.0'),
-                'capabilities': handshake_data.get('capabilities', []),
+                'capabilities': self._normalize_capabilities(
+                    handshake_data.get('capabilities', [])
+                ),
                 'timestamp': handshake_data.get('timestamp', 0)
             }
             payload_bytes = json.dumps(payload, sort_keys=True).encode('utf-8')
@@ -468,7 +587,14 @@ class ConnectionManager:
             )
             
             signature = bytes.fromhex(signature_hex)
-            if not remote_identity.verify(payload_bytes, signature):
+            verified = remote_identity.verify(payload_bytes, signature)
+            if not verified:
+                # Fallback: peer may be running unpatched 0.4.30 that signed optional fields
+                fallback_payload = dict(payload)
+                fallback_payload.update(self._signed_optional_handshake_fields(handshake_data))
+                fallback_bytes = json.dumps(fallback_payload, sort_keys=True).encode('utf-8')
+                verified = remote_identity.verify(fallback_bytes, signature)
+            if not verified:
                 logger.warning(f"Handshake signature verification FAILED for {peer_id} - rejecting")
                 await websocket.close()
                 return
@@ -485,8 +611,44 @@ class ConnectionManager:
                 port=websocket.remote_address[1],
                 state=ConnectionState.HANDSHAKING,
                 websocket=websocket,
-                is_outbound=False
+                is_outbound=False,
+                handshake_version=str(handshake_data.get('version', '0.1.0') or '0.1.0'),
+                canopy_version=str(handshake_data.get('canopy_version') or handshake_data.get('version', '0.1.0') or '0.1.0'),
+                protocol_version=self._coerce_protocol_version(
+                    handshake_data.get('protocol_version', 1),
+                    default=1,
+                ),
             )
+            connection.capabilities = {
+                cap: True for cap in self._normalize_capabilities(
+                    handshake_data.get('capabilities', [])
+                )
+            }
+
+            remote_protocol = connection.protocol_version or 1
+            remote_canopy = str(connection.canopy_version or '0.1.0')
+            if remote_protocol != self.local_protocol_version:
+                logger.warning(
+                    "Protocol version mismatch with %s: local=%s remote=%s (canopy=%s)",
+                    peer_id,
+                    self.local_protocol_version,
+                    remote_protocol,
+                    remote_canopy,
+                )
+                if self.reject_protocol_mismatch:
+                    logger.warning(
+                        "Rejecting %s due to protocol mismatch (reject_protocol_mismatch enabled)",
+                        peer_id,
+                    )
+                    await websocket.close()
+                    return
+            elif remote_canopy != self.local_canopy_version:
+                logger.info(
+                    "Canopy version difference with %s: local=%s remote=%s",
+                    peer_id,
+                    self.local_canopy_version,
+                    remote_canopy,
+                )
             
             # Complete handshake (send our signed ack)
             success = await self._complete_handshake(connection, handshake_data)
@@ -508,6 +670,14 @@ class ConnectionManager:
                 # Notify manager so it can run channel-sync + catch-up
                 if self.on_peer_authenticated:
                     try:
+                        peer_meta = {
+                            'version': connection.handshake_version,
+                            'canopy_version': connection.canopy_version,
+                            'protocol_version': connection.protocol_version,
+                            'capabilities': list(connection.capabilities or {}),
+                        }
+                        self.on_peer_authenticated(peer_id, peer_meta)
+                    except TypeError:
                         self.on_peer_authenticated(peer_id)
                     except Exception as cb_err:
                         logger.error(f"on_peer_authenticated callback error for {peer_id}: {cb_err}", exc_info=True)
@@ -557,22 +727,25 @@ class ConnectionManager:
             identity = self.identity_manager.export_public_identity()
             timestamp = time.time()
             
-            handshake_payload = {
+            # Base fields are signed (backward compatible with all versions).
+            # canopy_version and protocol_version are sent as unsigned metadata.
+            signed_payload = {
                 'peer_id': self.local_peer_id,
                 'ed25519_public_key': identity['ed25519_public_key'],
                 'x25519_public_key': identity['x25519_public_key'],
                 'version': '0.1.0',
-                'capabilities': ['chat', 'files', 'voice'],
+                'capabilities': self._get_handshake_capabilities(),
                 'timestamp': timestamp
             }
             
-            # Sign the handshake payload with our Ed25519 key
-            payload_bytes = json.dumps(handshake_payload, sort_keys=True).encode('utf-8')
+            payload_bytes = json.dumps(signed_payload, sort_keys=True).encode('utf-8')
             signature = self.identity_manager.local_identity.sign(payload_bytes)
             
             handshake = {
                 'type': 'handshake',
-                **handshake_payload,
+                **signed_payload,
+                'canopy_version': self.local_canopy_version,
+                'protocol_version': self.local_protocol_version,
                 'signature': signature.hex()
             }
             
@@ -588,12 +761,16 @@ class ConnectionManager:
             
             if response.get('type') != 'handshake_ack':
                 logger.warning(f"Invalid handshake response: {response.get('type')}")
+                connection.failure_reason = 'invalid_handshake_response'
+                connection.failure_detail = f"Invalid handshake response: {response.get('type')}"
                 return False
             
             # Verify the peer's response signature
             resp_signature_hex = response.get('signature')
             if not resp_signature_hex:
                 logger.warning(f"Handshake response from {connection.peer_id} has no signature")
+                connection.failure_reason = 'missing_handshake_signature'
+                connection.failure_detail = 'Handshake response has no signature'
                 return False
             
             # Reconstruct the signed payload from the response
@@ -603,14 +780,19 @@ class ConnectionManager:
             
             if not all([resp_peer_id, resp_ed25519_pub, resp_x25519_pub]):
                 logger.warning("Handshake response missing required identity fields")
+                connection.failure_reason = 'missing_identity_fields'
+                connection.failure_detail = 'Handshake response missing required identity fields'
                 return False
             
+            # Base fields only for signature verification (backward compatible).
             resp_payload = {
                 'peer_id': resp_peer_id,
                 'ed25519_public_key': resp_ed25519_pub,
                 'x25519_public_key': resp_x25519_pub,
                 'version': response.get('version', '0.1.0'),
-                'capabilities': response.get('capabilities', []),
+                'capabilities': self._normalize_capabilities(
+                    response.get('capabilities', [])
+                ),
                 'timestamp': response.get('timestamp', 0)
             }
             resp_payload_bytes = json.dumps(resp_payload, sort_keys=True).encode('utf-8')
@@ -621,17 +803,19 @@ class ConnectionManager:
             # Verify peer_id matches the public key
             if not self.identity_manager.verify_peer_id(resp_peer_id, resp_ed25519_pub_bytes):
                 logger.warning(f"Peer ID {resp_peer_id} does not match public key!")
+                connection.failure_reason = 'peer_id_public_key_mismatch'
+                connection.failure_detail = f"Peer ID {resp_peer_id} does not match public key"
                 return False
 
             # Verify the responding peer is who we expected to connect to.
-            # A different (valid) peer could have taken the socket; reject
-            # that to prevent identity substitution attacks.
             if resp_peer_id != connection.peer_id:
                 logger.warning(
                     f"Handshake peer-id mismatch! Expected {connection.peer_id}, "
                     f"got {resp_peer_id}. Rejecting connection.")
-                # This endpoint is no longer associated with the requested peer_id;
-                # drop it so we don't thrash reconnect attempts forever.
+                connection.failure_reason = 'handshake_peer_id_mismatch'
+                connection.failure_detail = (
+                    f"Handshake peer-id mismatch: expected {connection.peer_id}, got {resp_peer_id}"
+                )
                 try:
                     host = connection.address
                     port = connection.port
@@ -650,20 +834,70 @@ class ConnectionManager:
             )
             
             resp_signature = bytes.fromhex(resp_signature_hex)
-            if not remote_identity.verify(resp_payload_bytes, resp_signature):
+            verified = remote_identity.verify(resp_payload_bytes, resp_signature)
+            if not verified:
+                # Fallback: peer may be running unpatched 0.4.30 that signed optional fields
+                fallback_payload = dict(resp_payload)
+                fallback_payload.update(self._signed_optional_handshake_fields(response))
+                fallback_bytes = json.dumps(fallback_payload, sort_keys=True).encode('utf-8')
+                verified = remote_identity.verify(fallback_bytes, resp_signature)
+            if not verified:
                 logger.warning(f"Handshake signature verification FAILED for {resp_peer_id}")
+                connection.failure_reason = 'handshake_signature_verification_failed'
+                connection.failure_detail = f'Handshake signature verification failed for {resp_peer_id}'
                 return False
             
             # Store the verified peer identity
             self.identity_manager.add_known_peer(remote_identity)
-            
-            connection.capabilities = {cap: True for cap in response.get('capabilities', [])}
+
+            connection.handshake_version = str(response.get('version', '0.1.0') or '0.1.0')
+            connection.canopy_version = str(response.get('canopy_version') or response.get('version', '0.1.0') or '0.1.0')
+            connection.protocol_version = self._coerce_protocol_version(
+                response.get('protocol_version', 1),
+                default=1,
+            )
+
+            connection.capabilities = {
+                cap: True for cap in self._normalize_capabilities(
+                    response.get('capabilities', [])
+                )
+            }
+
+            remote_protocol = connection.protocol_version or 1
+            remote_canopy = str(connection.canopy_version or '0.1.0')
+            if remote_protocol != self.local_protocol_version:
+                logger.warning(
+                    "Protocol version mismatch with %s: local=%s remote=%s (canopy=%s)",
+                    connection.peer_id,
+                    self.local_protocol_version,
+                    remote_protocol,
+                    remote_canopy,
+                )
+                if self.reject_protocol_mismatch:
+                    logger.warning(
+                        "Rejecting %s due to protocol mismatch (reject_protocol_mismatch enabled)",
+                        connection.peer_id,
+                    )
+                    connection.failure_reason = 'protocol_mismatch'
+                    connection.failure_detail = (
+                        f"Protocol mismatch: local={self.local_protocol_version} remote={remote_protocol}"
+                    )
+                    return False
+            elif remote_canopy != self.local_canopy_version:
+                logger.info(
+                    "Canopy version difference with %s: local=%s remote=%s",
+                    connection.peer_id,
+                    self.local_canopy_version,
+                    remote_canopy,
+                )
             
             logger.info(f"Handshake completed and verified with {connection.peer_id}")
             return True
             
         except Exception as e:
             logger.error(f"Handshake failed: {e}", exc_info=True)
+            connection.failure_reason = type(e).__name__
+            connection.failure_detail = str(e)
             return False
     
     async def _complete_handshake(self, connection: PeerConnection, 
@@ -686,22 +920,24 @@ class ConnectionManager:
             identity = self.identity_manager.export_public_identity()
             timestamp = time.time()
             
-            ack_payload = {
+            # Sign base fields only (backward compatible with all peer versions).
+            signed_payload = {
                 'peer_id': self.local_peer_id,
                 'ed25519_public_key': identity['ed25519_public_key'],
                 'x25519_public_key': identity['x25519_public_key'],
                 'version': '0.1.0',
-                'capabilities': ['chat', 'files', 'voice'],
+                'capabilities': self._get_handshake_capabilities(),
                 'timestamp': timestamp
             }
             
-            # Sign the ack payload
-            payload_bytes = json.dumps(ack_payload, sort_keys=True).encode('utf-8')
+            payload_bytes = json.dumps(signed_payload, sort_keys=True).encode('utf-8')
             signature = self.identity_manager.local_identity.sign(payload_bytes)
             
             ack = {
                 'type': 'handshake_ack',
-                **ack_payload,
+                **signed_payload,
+                'canopy_version': self.local_canopy_version,
+                'protocol_version': self.local_protocol_version,
                 'signature': signature.hex()
             }
             
@@ -791,10 +1027,13 @@ class ConnectionManager:
         try:
             data = json.dumps(message)
             async with connection._send_lock:
+                current = self.connections.get(peer_id)
+                if current is not connection or not connection.is_connected():
+                    return False
                 # 15-second timeout prevents hanging on dead connections
                 # where TCP hasn't detected the failure yet.
                 websocket = connection.websocket
-                if websocket is None:
+                if websocket is None or getattr(websocket, 'closed', False):
                     return False
                 await asyncio.wait_for(
                     websocket.send(data),
@@ -804,6 +1043,9 @@ class ConnectionManager:
             return True
 
         except asyncio.TimeoutError:
+            connection.state = ConnectionState.DISCONNECTED
+            connection.failure_reason = 'send_timeout'
+            connection.failure_detail = 'Send timed out'
             logger.error(f"Failed to send to {peer_id}: "
                          f"send timed out (15s), connection likely dead")
             # Force-close the dead connection so it can be re-established
@@ -812,7 +1054,12 @@ class ConnectionManager:
             return False
 
         except Exception as e:
+            connection.state = ConnectionState.DISCONNECTED
+            connection.failure_reason = type(e).__name__
+            connection.failure_detail = str(e)
             logger.error(f"Failed to send to {peer_id}: {e}")
+            asyncio.ensure_future(
+                self._disconnect_connection(connection, notify=False))
             return False
     
     async def _disconnect_connection(self, connection: PeerConnection, *, notify: bool = True) -> None:
@@ -896,6 +1143,7 @@ class ConnectionManager:
                     # Send keepalive ping through the send lock to avoid
                     # concurrent write assertions in the websockets library.
                     try:
+                        t_ping = time.time()
                         async with connection._send_lock:
                             websocket = connection.websocket
                             if websocket is None:
@@ -903,6 +1151,7 @@ class ConnectionManager:
                                 continue
                             pong = await websocket.ping()
                         await asyncio.wait_for(pong, timeout=30)
+                        connection.last_ping_latency_ms = round((time.time() - t_ping) * 1000, 1)
                     except asyncio.TimeoutError:
                         logger.warning(f"Keepalive ping to {peer_id} timed out — disconnecting")
                         await self.disconnect_peer(peer_id)

--- a/canopy/network/manager.py
+++ b/canopy/network/manager.py
@@ -26,6 +26,7 @@ from ..core.messaging import (
     DM_E2E_CAPABILITY,
     build_dm_security_summary,
     encrypt_dm_transport_bundle,
+    is_local_dm_user,
 )
 from .identity import IdentityManager, PeerIdentity
 from .discovery import PeerDiscovery, DiscoveredPeer
@@ -102,6 +103,8 @@ class P2PNetworkManager:
         # Recent peer activity events for UI (thread-safe; event-loop thread writes, Flask reads).
         self._activity_lock = threading.Lock()
         self._activity_events: Deque[Dict[str, Any]] = deque(maxlen=200)
+        self._endpoint_health_lock = threading.Lock()
+        self._endpoint_health: Dict[str, Dict[str, Dict[str, Any]]] = {}
         
         # Callback that returns list of public channels for sync
         self.get_public_channels_for_sync: Optional[Callable] = None
@@ -319,15 +322,14 @@ class P2PNetworkManager:
             if not row:
                 unknown_peer_ids.append(recipient_id)
                 continue
-            username = str(row.get('username') or '').strip()
-            origin_peer = str(row.get('origin_peer') or '').strip()
-            if username.startswith('peer-') and origin_peer and origin_peer != local_peer_id:
-                target_peer_id = origin_peer
-            elif not origin_peer or origin_peer == local_peer_id:
+            if is_local_dm_user(self.db, self, recipient_id):
                 local_recipient_ids.append(recipient_id)
                 continue
-            else:
-                target_peer_id = origin_peer
+            origin_peer = str(row.get('origin_peer') or '').strip()
+            if not origin_peer or origin_peer == local_peer_id:
+                unknown_peer_ids.append(recipient_id)
+                continue
+            target_peer_id = origin_peer
 
             if target_peer_id not in remote_peer_ids:
                 remote_peer_ids.append(target_peer_id)
@@ -724,21 +726,18 @@ class P2PNetworkManager:
         """
         await asyncio.sleep(3)  # Let WebSocket server and mDNS settle first
         
-        known_endpoints = self.identity_manager.peer_endpoints
+        known_peer_ids = set(self.identity_manager.peer_endpoints.keys())
+        known_peer_ids.update((getattr(self.identity_manager, 'known_peers', {}) or {}).keys())
         local_id = self.local_identity.peer_id if self.local_identity else ''
         attempted = 0
         connected = 0
 
-        # Iterate over a snapshot since we may prune endpoints as we go.
-        for peer_id, endpoints in list(known_endpoints.items()):
+        for peer_id in list(known_peer_ids):
             if peer_id == local_id:
                 continue
             if self.connection_manager and self.connection_manager.is_connected(peer_id):
                 continue
-            endpoints = self._sanitize_endpoints(peer_id, endpoints)
-            if endpoints != known_endpoints.get(peer_id, []):
-                self.identity_manager.peer_endpoints[peer_id] = endpoints
-                self.identity_manager._save_known_peers()
+            endpoints = self._get_connectable_peer_endpoints(peer_id, prefer_discovered=True)
             if not endpoints:
                 continue
 
@@ -877,6 +876,39 @@ class P2PNetworkManager:
             return stored
         return self._get_discovered_peer_endpoints(peer_id)
 
+    @staticmethod
+    def _merge_endpoint_lists(*endpoint_groups: list[str]) -> list[str]:
+        """Merge endpoint lists while preserving order and removing duplicates."""
+        merged: list[str] = []
+        seen: set[str] = set()
+        for group in endpoint_groups:
+            for endpoint in group or []:
+                if endpoint in seen:
+                    continue
+                seen.add(endpoint)
+                merged.append(endpoint)
+        return merged
+
+    def _get_connectable_peer_endpoints(self, peer_id: str, prefer_discovered: bool = True) -> list[str]:
+        """Return the best available endpoints for dialing a peer.
+
+        Live discovery is preferred for connection attempts because it is more
+        likely to reflect current LAN reality than persisted endpoint state.
+        """
+        stored = self._sanitize_endpoints(
+            peer_id,
+            self.identity_manager.peer_endpoints.get(peer_id, []),
+        )
+        if stored != self.identity_manager.peer_endpoints.get(peer_id, []):
+            self.identity_manager.peer_endpoints[peer_id] = stored
+            self.identity_manager._save_known_peers()
+        discovered = self._get_discovered_peer_endpoints(peer_id)
+        if discovered:
+            self._remember_discovered_peer_endpoints(peer_id)
+        if prefer_discovered:
+            return self._merge_endpoint_lists(discovered, stored)
+        return self._merge_endpoint_lists(stored, discovered)
+
     def _remember_discovered_peer_endpoints(self, peer_id: str) -> list[str]:
         """Persist endpoints learned from mDNS discovery for later reconnect."""
         endpoints = self._get_discovered_peer_endpoints(peer_id)
@@ -887,7 +919,10 @@ class P2PNetworkManager:
         for endpoint in endpoints:
             if endpoint in existing:
                 continue
-            self.identity_manager.record_endpoint(peer_id, endpoint, claim=True)
+            # Do not "claim" a discovered endpoint until a real connection
+            # succeeds. Discovery can be stale or wrong; successful connect
+            # paths already claim the endpoint authoritatively.
+            self.identity_manager.record_endpoint(peer_id, endpoint, claim=False)
             existing.add(endpoint)
             changed = True
         if changed:
@@ -897,6 +932,122 @@ class P2PNetworkManager:
                 peer_id,
             )
         return endpoints
+
+    def _record_endpoint_result(
+        self,
+        peer_id: str,
+        endpoint: Optional[str],
+        *,
+        success: bool,
+        reason: Optional[str] = None,
+        detail: Optional[str] = None,
+        sources: Optional[list[str]] = None,
+    ) -> None:
+        """Track endpoint-level health so diagnostics can explain failures."""
+        canon = self._canonicalize_endpoint(endpoint or '')
+        if not peer_id or not canon:
+            return
+        now = time.time()
+        with self._endpoint_health_lock:
+            peer_entries = self._endpoint_health.setdefault(peer_id, {})
+            entry = peer_entries.setdefault(
+                canon,
+                {
+                    'endpoint': canon,
+                    'attempt_count': 0,
+                    'success_count': 0,
+                    'consecutive_failures': 0,
+                    'last_attempt_at': None,
+                    'last_success_at': None,
+                    'last_failure_at': None,
+                    'last_failure_reason': None,
+                    'last_failure_detail': None,
+                    'last_status': None,
+                    'sources': [],
+                },
+            )
+            entry['attempt_count'] = int(entry.get('attempt_count') or 0) + 1
+            entry['last_attempt_at'] = now
+            if sources:
+                merged_sources = list(entry.get('sources') or [])
+                for source in sources:
+                    text = str(source or '').strip()
+                    if text and text not in merged_sources:
+                        merged_sources.append(text)
+                entry['sources'] = merged_sources
+            if success:
+                entry['success_count'] = int(entry.get('success_count') or 0) + 1
+                entry['consecutive_failures'] = 0
+                entry['last_success_at'] = now
+                entry['last_status'] = 'connected'
+            else:
+                entry['consecutive_failures'] = int(entry.get('consecutive_failures') or 0) + 1
+                entry['last_failure_at'] = now
+                entry['last_failure_reason'] = str(reason or 'connection_failed')
+                entry['last_failure_detail'] = str(detail or reason or 'Connection failed')
+                entry['last_status'] = 'failed'
+
+    def _current_connection_endpoint(self, peer_id: str) -> Optional[str]:
+        """Return the currently active endpoint for a peer, if known."""
+        if not self.connection_manager or not peer_id:
+            return None
+        conn = self.connection_manager.get_connection(peer_id)
+        if not conn:
+            return None
+        address = str(getattr(conn, 'address', '') or '').strip()
+        port = int(getattr(conn, 'port', 0) or 0)
+        if not address or port <= 0:
+            return None
+        return f"{self.ws_scheme}://{self._format_endpoint_host(address)}:{port}"
+
+    def get_peer_endpoint_diagnostics(self, peer_id: str) -> list[Dict[str, Any]]:
+        """Return endpoint-source and health information for one peer."""
+        stored = self._sanitize_endpoints(
+            peer_id,
+            self.identity_manager.peer_endpoints.get(peer_id, []),
+        )
+        discovered = self._get_discovered_peer_endpoints(peer_id)
+        active = self._current_connection_endpoint(peer_id)
+        endpoint_order = self._merge_endpoint_lists(
+            [active] if active else [],
+            discovered,
+            stored,
+        )
+
+        with self._endpoint_health_lock:
+            peer_health = dict(self._endpoint_health.get(peer_id, {}) or {})
+
+        rows: list[Dict[str, Any]] = []
+        endpoint_order = self._merge_endpoint_lists(endpoint_order, list(peer_health.keys()))
+        for endpoint in endpoint_order:
+            canon = self._canonicalize_endpoint(endpoint) or endpoint
+            health = dict(peer_health.get(canon, {}) or {})
+            sources: list[str] = []
+            if endpoint in discovered:
+                sources.append('discovered')
+            if endpoint in stored:
+                sources.append('stored')
+            if active and canon == active:
+                sources.append('active')
+            for source in health.get('sources') or []:
+                text = str(source or '').strip()
+                if text and text not in sources:
+                    sources.append(text)
+            rows.append({
+                'endpoint': canon,
+                'sources': sources,
+                'currently_connected': bool(active and canon == active),
+                'attempt_count': int(health.get('attempt_count') or 0),
+                'success_count': int(health.get('success_count') or 0),
+                'consecutive_failures': int(health.get('consecutive_failures') or 0),
+                'last_attempt_at': health.get('last_attempt_at'),
+                'last_success_at': health.get('last_success_at'),
+                'last_failure_at': health.get('last_failure_at'),
+                'last_failure_reason': health.get('last_failure_reason'),
+                'last_failure_detail': health.get('last_failure_detail'),
+                'last_status': health.get('last_status'),
+            })
+        return rows
 
     async def _connect_to_endpoint(self, peer_id: str, endpoint: str) -> bool:
         """Connect to a peer using a ws:// or wss:// endpoint string."""
@@ -921,6 +1072,18 @@ class P2PNetworkManager:
                 f"Reconnect: endpoint {endpoint} requires TLS, but TLS is disabled; "
                 f"connection may fail."
             )
+        endpoint_sources: list[str] = []
+        stored = set(
+            self._sanitize_endpoints(
+                peer_id,
+                self.identity_manager.peer_endpoints.get(peer_id, []),
+            )
+        )
+        discovered = set(self._get_discovered_peer_endpoints(peer_id))
+        if canon in discovered:
+            endpoint_sources.append('discovered')
+        if canon in stored:
+            endpoint_sources.append('stored')
         self._record_connection_event(
             peer_id,
             status='attempt',
@@ -931,6 +1094,13 @@ class P2PNetworkManager:
         if ok and canon:
             # Claim the endpoint so stale mappings don't keep retrying the wrong peer_id.
             self.identity_manager.record_endpoint(peer_id, canon, claim=True)
+            self._record_endpoint_result(
+                peer_id,
+                canon,
+                success=True,
+                detail='Connected successfully',
+                sources=endpoint_sources,
+            )
             self._record_connection_event(
                 peer_id,
                 status='connected',
@@ -938,10 +1108,28 @@ class P2PNetworkManager:
                 endpoint=canon,
             )
         elif not ok:
+            failure_reason = 'connection_failed'
+            failure_detail = 'Connection failed'
+            if hasattr(self.connection_manager, 'get_last_connect_failure'):
+                try:
+                    failure = self.connection_manager.get_last_connect_failure(peer_id, host, port)
+                except Exception:
+                    failure = None
+                if isinstance(failure, dict):
+                    failure_reason = str(failure.get('reason') or failure_reason)
+                    failure_detail = str(failure.get('detail') or failure_detail)
+            self._record_endpoint_result(
+                peer_id,
+                canon or endpoint,
+                success=False,
+                reason=failure_reason,
+                detail=failure_detail,
+                sources=endpoint_sources,
+            )
             self._record_connection_event(
                 peer_id,
                 status='failed',
-                detail='Connection failed',
+                detail=failure_detail,
                 endpoint=canon or endpoint,
             )
         return ok
@@ -991,13 +1179,7 @@ class P2PNetworkManager:
                 self._reconnect_tasks.pop(peer_id, None)
                 return
 
-            endpoints = self._sanitize_endpoints(
-                peer_id,
-                self.identity_manager.peer_endpoints.get(peer_id, []),
-            )
-            if endpoints != self.identity_manager.peer_endpoints.get(peer_id, []):
-                self.identity_manager.peer_endpoints[peer_id] = endpoints
-                self.identity_manager._save_known_peers()
+            endpoints = self._get_connectable_peer_endpoints(peer_id, prefer_discovered=True)
             if not endpoints:
                 logger.debug(f"Reconnect: no endpoints for {peer_id}, giving up")
                 self._reconnect_tasks.pop(peer_id, None)
@@ -1760,7 +1942,7 @@ class P2PNetworkManager:
         """Background task: try to upgrade a relay route to a direct connection."""
         if not self._event_loop or self._event_loop.is_closed():
             return
-        endpoints = list(self.identity_manager.peer_endpoints.get(peer_id, []))
+        endpoints = self._get_connectable_peer_endpoints(peer_id, prefer_discovered=True)
         if not endpoints:
             return
         connection_manager = self.connection_manager
@@ -1774,10 +1956,7 @@ class P2PNetworkManager:
                 return
             for ep in endpoints:
                 try:
-                    addr = ep.replace('ws://', '').replace('wss://', '')
-                    host, port_str = addr.rsplit(':', 1)
-                    port = int(port_str)
-                    ok = await connection_manager.connect_to_peer(peer_id, host, port)
+                    ok = await self._connect_to_endpoint(peer_id, ep)
                     if ok:
                         self._active_relays.pop(peer_id, None)
                         logger.info(
@@ -1911,10 +2090,7 @@ class P2PNetworkManager:
             # Stale/done entry — drop it so we can reschedule.
             self._reconnect_tasks.pop(peer_id, None)
 
-        endpoints = self._sanitize_endpoints(peer_id, self.identity_manager.peer_endpoints.get(peer_id, []))
-        if endpoints != self.identity_manager.peer_endpoints.get(peer_id, []):
-            self.identity_manager.peer_endpoints[peer_id] = endpoints
-            self.identity_manager._save_known_peers()
+        endpoints = self._get_connectable_peer_endpoints(peer_id, prefer_discovered=True)
 
         if endpoints and self._running:
             logger.info(
@@ -2536,13 +2712,8 @@ class P2PNetworkManager:
             return False
         local_peer_id = self.local_identity.peer_id if self.local_identity else ''
         recipient_row = self._get_dm_recipient_row(recipient_id)
-        recipient_username = str((recipient_row or {}).get('username') or '').strip()
         recipient_origin_peer = str((recipient_row or {}).get('origin_peer') or '').strip()
-        recipient_is_local = bool(
-            recipient_row
-            and (not recipient_origin_peer or recipient_origin_peer == local_peer_id)
-            and not recipient_username.startswith('peer-')
-        )
+        recipient_is_local = bool(recipient_row and is_local_dm_user(self.db, self, recipient_id))
         if recipient_is_local:
             logger.debug(
                 "Skipping P2P DM broadcast for local recipient %s (message=%s)",

--- a/canopy/ui/templates/messages.html
+++ b/canopy/ui/templates/messages.html
@@ -6,10 +6,18 @@
 {% block extra_css %}
 <style>
     .messages-page {
-        display: flex;
-        flex-direction: column;
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr);
         gap: 1rem;
         min-height: calc(100vh - 140px);
+        height: calc(100vh - 140px);
+    }
+
+    @supports (height: 100dvh) {
+        .messages-page {
+            min-height: calc(100dvh - 140px);
+            height: calc(100dvh - 140px);
+        }
     }
 
     .messages-topbar {
@@ -40,7 +48,8 @@
         display: grid;
         grid-template-columns: minmax(260px, 330px) minmax(0, 1fr);
         gap: 1rem;
-        min-height: calc(100vh - 250px);
+        min-height: 0;
+        height: 100%;
     }
 
     .dm-sidebar,
@@ -50,6 +59,7 @@
         border-radius: 22px;
         box-shadow: 0 20px 48px rgba(3, 10, 22, 0.28);
         min-width: 0;
+        min-height: 0;
     }
 
     .dm-sidebar {
@@ -57,7 +67,7 @@
         display: flex;
         flex-direction: column;
         gap: 0.9rem;
-        min-height: 0;
+        overflow: hidden;
     }
 
     .dm-sidebar-search {
@@ -86,6 +96,7 @@
     }
 
     .dm-sidebar-scroll {
+        flex: 1 1 auto;
         display: flex;
         flex-direction: column;
         gap: 1rem;
@@ -383,6 +394,7 @@
 
     .dm-thread-scroll {
         flex: 1 1 auto;
+        min-height: 0;
         overflow-y: auto;
         padding: 1rem;
         display: flex;
@@ -698,6 +710,21 @@
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
+        flex-shrink: 0;
+        position: sticky;
+        bottom: 0;
+        z-index: 5;
+    }
+
+    .dm-composer.dragover {
+        border-top-color: rgba(46, 214, 125, 0.34);
+        box-shadow: inset 0 0 0 1px rgba(46, 214, 125, 0.18);
+        background: linear-gradient(180deg, rgba(15, 31, 43, 0.98), rgba(11, 25, 37, 0.99));
+    }
+
+    .dm-composer.dragover .dm-composer-input-wrap {
+        border-radius: 18px;
+        box-shadow: 0 0 0 1px rgba(46, 214, 125, 0.24);
     }
 
     .dm-composer-topline {
@@ -942,7 +969,6 @@
     @media (max-width: 991.98px) {
         .messages-page {
             gap: 0.85rem;
-            min-height: auto;
         }
 
         .messages-shell {
@@ -951,11 +977,11 @@
 
         .messages-shell {
             grid-template-columns: 1fr;
-            min-height: auto;
+            grid-template-rows: minmax(180px, 32vh) minmax(0, 1fr);
         }
 
         .dm-sidebar {
-            max-height: 32vh;
+            max-height: none;
         }
 
         .dm-thread-scroll {
@@ -976,6 +1002,18 @@
 
         .messages-topbar {
             gap: 0.7rem;
+        }
+
+        .messages-page {
+            min-height: calc(100vh - 120px);
+            height: calc(100vh - 120px);
+        }
+
+        @supports (height: 100dvh) {
+            .messages-page {
+                min-height: calc(100dvh - 120px);
+                height: calc(100dvh - 120px);
+            }
         }
 
         .messages-topbar-copy h1 {
@@ -1379,6 +1417,7 @@
     let dmLastThreadToken = {{ thread_state_token|tojson }};
     let pendingDmSnapshot = null;
     let dmPollTimer = null;
+    let dmComposerDragDepth = 0;
 
     function matchesInitialRecipients() {
         const current = selectedRecipients.map(rec => rec.user_id).filter(Boolean).sort();
@@ -1791,11 +1830,6 @@
         if (messageInput) {
             messageInput.addEventListener('paste', handleMessagePaste);
         }
-
-        const threadPane = document.querySelector('.dm-thread-pane');
-        if (threadPane) {
-            threadPane.addEventListener('paste', handleMessagePaste);
-        }
     }
 
     function handleMessagePaste(e) {
@@ -1821,6 +1855,61 @@
         if (hasImage) {
             e.preventDefault();
         }
+    }
+
+    function setDmComposerDragState(active) {
+        const composer = document.getElementById('dm-composer');
+        if (!composer) return;
+        composer.classList.toggle('dragover', !!active);
+    }
+
+    function setupMessageDropzone() {
+        const composer = document.getElementById('dm-composer');
+        if (!composer) return;
+
+        const dragHasFiles = (event) => {
+            const transfer = event.dataTransfer;
+            if (!transfer) return false;
+            const types = Array.from(transfer.types || []);
+            return types.includes('Files') || !!(transfer.files && transfer.files.length);
+        };
+
+        composer.addEventListener('dragenter', (event) => {
+            if (!dragHasFiles(event)) return;
+            event.preventDefault();
+            dmComposerDragDepth += 1;
+            setDmComposerDragState(true);
+        });
+
+        composer.addEventListener('dragover', (event) => {
+            if (!dragHasFiles(event)) return;
+            event.preventDefault();
+            if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = 'copy';
+            }
+            setDmComposerDragState(true);
+        });
+
+        composer.addEventListener('dragleave', (event) => {
+            if (!dragHasFiles(event)) return;
+            event.preventDefault();
+            dmComposerDragDepth = Math.max(0, dmComposerDragDepth - 1);
+            if (dmComposerDragDepth === 0) {
+                setDmComposerDragState(false);
+            }
+        });
+
+        composer.addEventListener('drop', (event) => {
+            if (!dragHasFiles(event)) return;
+            event.preventDefault();
+            dmComposerDragDepth = 0;
+            setDmComposerDragState(false);
+            const files = Array.from(event.dataTransfer?.files || []);
+            if (!files.length) return;
+            addMessageFiles(files);
+            const textarea = document.getElementById('messageContent');
+            if (textarea) textarea.focus();
+        });
     }
 
     function normalizeRecipientInput(value) {
@@ -2584,6 +2673,7 @@
         updateComposerTarget();
         setupMessageFileUpload();
         setupMessagePasteHandler();
+        setupMessageDropzone();
         setupRecipientPicker();
         applyDmRichContent();
 

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -4,7 +4,7 @@ Get a new AI agent connected to the Canopy network in under 5 minutes.
 
 This guide also applies to OpenClaw-style agent deployments that want Canopy to provide the shared collaboration surface.
 
-> Version scope: aligned to Canopy `0.4.52`. Canonical endpoints are prefixed with `http://localhost:7770/api/v1`. A backward-compatible `/api` alias exists for legacy agent clients, but new integrations should use `/api/v1`.
+> Version scope: aligned to Canopy `0.4.59`. Canonical endpoints are prefixed with `http://localhost:7770/api/v1`. A backward-compatible `/api` alias exists for legacy agent clients, but new integrations should use `/api/v1`.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Canopy API Reference
 
-Version scope: this reference is aligned to Canopy `0.4.52`.
+Version scope: this reference is aligned to Canopy `0.4.59`.
 
 Canonical endpoints are prefixed with `/api/v1`.
 Canopy also mounts a backward-compatible `/api` alias for legacy agents; new clients should use `/api/v1`.

--- a/docs/GITHUB_RELEASE_v0.4.59.md
+++ b/docs/GITHUB_RELEASE_v0.4.59.md
@@ -1,0 +1,50 @@
+# Canopy v0.4.59 GitHub Release Copy
+
+Canopy `v0.4.59` makes the direct-message experience more trustworthy under real peer churn.
+
+This release brings together four practical improvements that matter in day-to-day use: more honest DM security classification, better DM search against older encrypted-at-rest history, cleaner messaging-layout behavior, and less noisy failure handling when a peer connection dies mid-send.
+
+## Highlights
+
+### More trustworthy DM delivery state
+Canopy is now more conservative about when it calls a DM recipient `local_only`. If a remote human row has blank or stale `origin_peer` metadata, Canopy no longer quietly assumes the message stayed on the instance. Instead, it keeps the remote delivery path alive unless there is positive evidence that the user is truly local.
+
+That means:
+- fewer false `Local only` security states
+- safer fallback behavior for legacy or partially synced remote user rows
+- less risk of suppressing mesh delivery for a real remote recipient
+
+### DM search now reaches older encrypted history
+The DM search path no longer depends on SQL-side plaintext matching. Search now pages through relevant DM history and matches after decrypting stored content, which means older encrypted-at-rest messages are less likely to disappear behind a wall of newer non-matching rows.
+
+Attachment metadata is also included in the searchable surface, so attachment-heavy conversations are easier to recover.
+
+### Better DM workspace scrolling
+The messages workspace continues the conversation-first DM redesign with a more stable scroll model. The sidebar, thread, and composer now behave more like coordinated regions of a messaging client instead of one drifting page surface.
+
+This makes it easier to:
+- browse the conversation list while reading a long thread
+- keep the active thread independently scrollable
+- keep the composer visually anchored at the bottom of the thread pane
+
+### Less terminal noise when a peer dies mid-send
+When a send times out or the websocket is already closing, Canopy now retires that connection immediately instead of letting queued sends keep hammering the same dead socket. In practice, that reduces the flood of repeated `no close frame received` errors that could follow one broken peer connection.
+
+## Why this matters
+
+Canopy is strongest when operators can trust what the product is telling them. `v0.4.59` improves that trust in two ways:
+
+1. It makes DM transport state more truthful instead of optimistically guessing that a recipient is local.
+2. It makes peer-failure behavior less noisy and easier to reason about when the mesh is under churn.
+
+The result is a DM workflow that feels more dependable without changing the overall product model.
+
+## Upgrade notes
+
+- No special migration steps are required for normal upgrades.
+- DM security summaries may now show a non-local transport mode for ambiguous recipient rows that were previously misclassified as `local_only`.
+- Mixed-version meshes remain supported; the new behavior prefers safer remote delivery instead of suppressing it when recipient provenance is incomplete.
+
+## Full changelog
+
+See [`CHANGELOG.md`](../CHANGELOG.md) for the detailed change history.

--- a/docs/MCP_QUICKSTART.md
+++ b/docs/MCP_QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Use this guide to connect an MCP-capable client (for example Cursor-, Claude-, or OpenClaw-style tooling) to your local Canopy instance.
 
-Version scope: this guide is aligned to Canopy `0.4.52`.
+Version scope: this guide is aligned to Canopy `0.4.59`.
 
 ---
 

--- a/docs/MENTIONS.md
+++ b/docs/MENTIONS.md
@@ -1,7 +1,7 @@
 # Mentions: Agent-Friendly Triggers
 
 This page shows how agents can consume mention events without scanning all posts. You can either poll or subscribe to the SSE stream.
-Version scope: examples below are aligned to Canopy `0.4.52`.
+Version scope: examples below are aligned to Canopy `0.4.59`.
 
 Canonical endpoints live under `/api/v1`. A backward-compatible `/api` alias also exists for older agents, and claim/ack routes expose compatibility aliases such as `/claim`, `/ack`, `/acknowledge`, and `/acknoledge`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,7 +1,7 @@
 # Canopy Quick Start
 
 This guide gets a fresh Canopy instance running and usable fast, with practical notes for VMs, routers, tray installs, and first peer connectivity.
-Version scope: this quick start is aligned to Canopy `0.4.52`.
+Version scope: this quick start is aligned to Canopy `0.4.59`.
 
 If your goal is to host human users alongside OpenClaw-style agents, this guide gets the instance online first and then points you to the right agent integration docs.
 

--- a/docs/WINDOWS_TRAY.md
+++ b/docs/WINDOWS_TRAY.md
@@ -13,7 +13,7 @@ It launches the local Canopy server, keeps runtime data under the user profile, 
 
 ## Compatibility Notes
 
-The tray app is reviewed against Canopy `0.4.52`.
+The tray app is reviewed against Canopy `0.4.59`.
 
 - Peer status uses `/api/v1/p2p/peers` with fallback to `/api/v1/p2p/known_peers`.
 - Message notifications use `/api/v1/channels` and `/api/v1/channels/<channel_id>/messages`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canopy"
-version = "0.4.55"
+version = "0.4.59"
 description = "Local-first peer-to-peer collaboration for humans and AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_connection_diagnostics_endpoint.py
+++ b/tests/test_connection_diagnostics_endpoint.py
@@ -1,0 +1,321 @@
+"""Tests for the /ajax/connection_diagnostics endpoint."""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+# Ensure repository root is importable when running tests directly.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Provide a lightweight zeroconf stub for environments without optional deps.
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.ui.routes import create_ui_blueprint
+
+
+def _make_mock_p2p_manager(
+    connected_peers=None,
+    active_relays=None,
+    relay_policy='broker_only',
+    activity_events=None,
+):
+    """Build a minimal p2p_manager mock for diagnostics tests."""
+    if connected_peers is None:
+        connected_peers = []
+    if active_relays is None:
+        active_relays = {}
+    if activity_events is None:
+        activity_events = []
+
+    im = MagicMock()
+    im.peer_display_names = {}
+    im.peer_endpoints = {}
+    im.known_peers = {}
+
+    conn_mgr = MagicMock()
+    conn_mgr.get_connection.return_value = None
+
+    p2p = MagicMock()
+    p2p.identity_manager = im
+    p2p.connection_manager = conn_mgr
+    p2p._active_relays = active_relays
+    p2p.get_connected_peers.return_value = connected_peers
+    p2p.get_discovered_peers.return_value = []
+    p2p.get_peer_endpoint_diagnostics.return_value = []
+    p2p.get_activity_events.return_value = activity_events
+    p2p.get_relay_status.return_value = {
+        'relay_policy': relay_policy,
+        'active_relays': active_relays,
+        'routing_table': {},
+    }
+    p2p._reconnect_tasks = {}
+    return p2p
+
+
+def _make_app(p2p_manager, mesh_port=7771):
+    """Build a Flask test app with the UI blueprint registered."""
+    config = MagicMock()
+    config.network.mesh_port = mesh_port
+
+    components = (
+        MagicMock(),   # db_manager
+        MagicMock(),   # api_key_manager
+        MagicMock(),   # trust_manager
+        MagicMock(),   # message_manager
+        MagicMock(),   # channel_manager
+        MagicMock(),   # file_manager
+        MagicMock(),   # feed_manager
+        MagicMock(),   # interaction_manager
+        MagicMock(),   # profile_manager
+        config,        # config
+        p2p_manager,   # p2p_manager
+    )
+
+    patcher = patch('canopy.ui.routes.get_app_components', return_value=components)
+    patcher.start()
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.secret_key = 'test-secret'
+    app.register_blueprint(create_ui_blueprint())
+
+    return app, patcher
+
+
+class TestConnectionDiagnosticsEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.p2p_manager = _make_mock_p2p_manager()
+        self.app, self.patcher = _make_app(self.p2p_manager)
+        self.addCleanup(self.patcher.stop)
+        self.client = self.app.test_client()
+
+    def _authenticate(self, user_id='test-user'):
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = user_id
+
+    def test_requires_login(self):
+        """Endpoint must redirect unauthenticated requests."""
+        response = self.client.get('/ajax/connection_diagnostics')
+        self.assertIn(response.status_code, (302, 401))
+
+    def test_returns_success_structure(self):
+        """Authenticated request returns success with expected keys."""
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertTrue(data.get('success'))
+        self.assertIn('peers', data)
+        self.assertIn('recent_failures', data)
+        self.assertIn('local', data)
+
+    def test_local_section_contains_mesh_port_and_relay_policy(self):
+        """local section must include mesh_port and relay_policy."""
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        local = data.get('local', {})
+        self.assertEqual(local.get('mesh_port'), 7771)
+        self.assertEqual(local.get('relay_policy'), 'broker_only')
+
+    def test_direct_peer_is_reported_as_direct(self):
+        """A peer not in active_relays is labelled as a direct connection."""
+        self.p2p_manager.get_connected_peers.return_value = ['peer-abc']
+        self.p2p_manager._active_relays = {}
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        peers = data.get('peers', [])
+        self.assertEqual(len(peers), 1)
+        self.assertEqual(peers[0]['peer_id'], 'peer-abc')
+        self.assertEqual(peers[0]['connection_type'], 'direct')
+        self.assertIsNone(peers[0]['relay_via'])
+
+    def test_relayed_peer_is_reported_as_relayed(self):
+        """A peer in active_relays is labelled as a relayed connection."""
+        self.p2p_manager.get_connected_peers.return_value = []
+        self.p2p_manager._active_relays = {'peer-abc': 'relay-xyz'}
+        self.p2p_manager.identity_manager.peer_display_names = {'relay-xyz': 'Relay Node'}
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        peers = data.get('peers', [])
+        self.assertEqual(len(peers), 1)
+        self.assertEqual(peers[0]['connection_type'], 'relayed')
+        self.assertEqual(peers[0]['relay_via'], 'relay-xyz')
+        self.assertEqual(peers[0]['relay_via_name'], 'Relay Node')
+
+    def test_connected_peer_wins_over_stale_relay_marker(self):
+        """A live connected peer should still be shown as direct."""
+        self.p2p_manager.get_connected_peers.return_value = ['peer-abc']
+        self.p2p_manager._active_relays = {'peer-abc': 'relay-xyz'}
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        peers = data.get('peers', [])
+        self.assertEqual(len(peers), 1)
+        self.assertEqual(peers[0]['connection_type'], 'direct')
+
+    def test_relay_only_peer_included_in_peers(self):
+        """A peer in active_relays but not directly connected appears in the list."""
+        self.p2p_manager.get_connected_peers.return_value = []
+        self.p2p_manager._active_relays = {'dest-peer': 'relay-xyz'}
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        peers = data.get('peers', [])
+        self.assertEqual(len(peers), 1)
+        self.assertEqual(peers[0]['peer_id'], 'dest-peer')
+        self.assertEqual(peers[0]['connection_type'], 'relayed')
+
+    def test_recent_failures_limited_to_five(self):
+        """recent_failures contains at most 5 entries."""
+        events = [
+            {
+                'kind': 'connection', 'status': 'failed',
+                'peer_id': f'peer-{i}', 'endpoint': f'ws://x:{i}',
+                'detail': 'timeout', 'timestamp': 1000.0 + i,
+            }
+            for i in range(10)
+        ]
+        self.p2p_manager.get_activity_events.return_value = events
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        self.assertLessEqual(len(data.get('recent_failures', [])), 5)
+
+    def test_recent_failures_prefers_most_recent_entries(self):
+        """The diagnostics feed should show the newest failures first."""
+        events = [
+            {
+                'kind': 'connection', 'status': 'failed',
+                'peer_id': f'peer-{i}', 'endpoint': f'ws://x:{i}',
+                'detail': f'failure-{i}', 'timestamp': 1000.0 + i,
+            }
+            for i in range(10)
+        ]
+        self.p2p_manager.get_activity_events.return_value = events
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        failures = data.get('recent_failures', [])
+        self.assertEqual([item['peer_id'] for item in failures[:3]], ['peer-9', 'peer-8', 'peer-7'])
+
+    def test_latency_included_when_available(self):
+        """Peer latency is included when the connection object tracks it."""
+        self.p2p_manager.get_connected_peers.return_value = ['peer-abc']
+        self.p2p_manager._active_relays = {}
+        mock_conn = MagicMock()
+        mock_conn.last_ping_latency_ms = 42.5
+        mock_conn.connected_at = 1000.0
+        mock_conn.last_activity = 1001.0
+        self.p2p_manager.connection_manager.get_connection.return_value = mock_conn
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        peers = data.get('peers', [])
+        self.assertEqual(peers[0]['latency_ms'], 42.5)
+
+    def test_no_p2p_manager_returns_503(self):
+        """If p2p_manager is None the endpoint returns 503."""
+        self.p2p_manager = None
+        app, patcher = _make_app(None)
+        self.addCleanup(patcher.stop)
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'test-user'
+        response = client.get('/ajax/connection_diagnostics')
+        self.assertEqual(response.status_code, 503)
+
+    def test_disconnected_known_peer_included_with_endpoint_details(self):
+        """Known but disconnected peers should still appear with endpoint diagnostics."""
+        self.p2p_manager.identity_manager.known_peers = {'peer-abc': object()}
+        self.p2p_manager.identity_manager.peer_endpoints = {
+            'peer-abc': ['ws://192.168.1.50:7771']
+        }
+        self.p2p_manager.get_discovered_peers.return_value = [
+            {
+                'peer_id': 'peer-abc',
+                'address': '192.168.1.50',
+                'addresses': ['192.168.1.50'],
+                'port': 7771,
+                'connected': False,
+            }
+        ]
+        self.p2p_manager.get_peer_endpoint_diagnostics.side_effect = lambda peer_id: (
+            [{
+                'endpoint': 'ws://192.168.1.50:7771',
+                'sources': ['stored', 'discovered'],
+                'currently_connected': False,
+                'attempt_count': 2,
+                'success_count': 0,
+                'consecutive_failures': 2,
+                'last_attempt_at': 2000.0,
+                'last_success_at': None,
+                'last_failure_at': 2000.0,
+                'last_failure_reason': 'timeout',
+                'last_failure_detail': 'Connection timed out',
+                'last_status': 'failed',
+            }] if peer_id == 'peer-abc' else []
+        )
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        peers = data.get('peers', [])
+        self.assertEqual(len(peers), 1)
+        self.assertEqual(peers[0]['peer_id'], 'peer-abc')
+        self.assertEqual(peers[0]['connection_type'], 'known')
+        self.assertTrue(peers[0]['discovered'])
+        self.assertEqual(peers[0]['endpoint_details'][0]['sources'], ['stored', 'discovered'])
+        self.assertEqual(peers[0]['last_failure']['reason'], 'timeout')
+
+    def test_completed_reconnect_task_is_not_reported_as_scheduled(self):
+        """Finished reconnect tasks should not look active in diagnostics."""
+        class _DoneTask:
+            def cancelled(self):
+                return False
+
+            def done(self):
+                return True
+
+        self.p2p_manager.identity_manager.known_peers = {'peer-abc': object()}
+        self.p2p_manager._reconnect_tasks = {'peer-abc': _DoneTask()}
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        peers = data.get('peers', [])
+        self.assertEqual(len(peers), 1)
+        self.assertFalse(peers[0]['reconnect_scheduled'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_connection_send_failures.py
+++ b/tests/test_connection_send_failures.py
@@ -1,0 +1,95 @@
+"""Regression tests for dead-connection send handling."""
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+# Ensure repository root is importable when running tests directly.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Provide a lightweight zeroconf stub for environments without optional deps.
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.network.connection import ConnectionManager, ConnectionState, PeerConnection
+
+
+class _FakeIdentityManager:
+    local_identity = None
+
+
+class _BlockingWebSocket:
+    def __init__(self) -> None:
+        self.closed = False
+        self.send_calls = 0
+        self.first_send_started = asyncio.Event()
+
+    async def send(self, _message: str) -> None:
+        self.send_calls += 1
+        self.first_send_started.set()
+        await asyncio.sleep(3600)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestConnectionSendFailures(unittest.IsolatedAsyncioTestCase):
+    async def test_timeout_marks_connection_dead_before_waiting_senders_retry(self):
+        manager = ConnectionManager(
+            local_peer_id='peer-local',
+            identity_manager=_FakeIdentityManager(),
+        )
+        websocket = _BlockingWebSocket()
+        connection = PeerConnection(
+            peer_id='peer-remote',
+            address='127.0.0.1',
+            port=7771,
+            state=ConnectionState.AUTHENTICATED,
+            websocket=websocket,
+        )
+        manager.connections['peer-remote'] = connection
+
+        wait_for_calls = 0
+
+        async def fake_wait_for(awaitable, timeout):
+            nonlocal wait_for_calls
+            wait_for_calls += 1
+            task = asyncio.create_task(awaitable)
+            await websocket.first_send_started.wait()
+            await asyncio.sleep(0)
+            task.cancel()
+            raise asyncio.TimeoutError()
+
+        with patch('canopy.network.connection.asyncio.wait_for', new=fake_wait_for):
+            first = asyncio.create_task(
+                manager.send_to_peer('peer-remote', {'type': 'p2p_message', 'message': {'id': 'one'}})
+            )
+            await websocket.first_send_started.wait()
+            second = asyncio.create_task(
+                manager.send_to_peer('peer-remote', {'type': 'p2p_message', 'message': {'id': 'two'}})
+            )
+            first_ok = await first
+            second_ok = await second
+
+        self.assertFalse(first_ok)
+        self.assertFalse(second_ok)
+        self.assertEqual(wait_for_calls, 1)
+        self.assertEqual(websocket.send_calls, 1)
+        self.assertEqual(connection.state, ConnectionState.DISCONNECTED)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dm_security_classification.py
+++ b/tests/test_dm_security_classification.py
@@ -1,0 +1,209 @@
+import asyncio
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.core.messaging import is_local_dm_user
+from canopy.network.manager import P2PNetworkManager
+
+
+class _DbWrapper:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def get_connection(self):
+        return self._conn
+
+    def get_user(self, user_id: str):
+        row = self._conn.execute(
+            "SELECT * FROM users WHERE id = ?",
+            (user_id,),
+        ).fetchone()
+        return dict(row) if row else None
+
+
+class _FakeRouter:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def send_dm_broadcast(self, content, metadata):
+        self.calls.append({'content': content, 'metadata': metadata})
+        return True
+
+
+class _FakeFuture:
+    def __init__(self, value):
+        self._value = value
+
+    def result(self, timeout=None):
+        return self._value
+
+
+class _FakeIdentityManager:
+    def get_peer(self, peer_id):
+        return None
+
+
+class _FakeP2PView:
+    def get_peer_id(self) -> str:
+        return 'peer-local'
+
+
+class TestDmSecurityClassification(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        db_path = Path(self.tempdir.name) / 'dm_security.db'
+        self.conn = sqlite3.connect(str(db_path))
+        self.conn.row_factory = sqlite3.Row
+        self.conn.executescript(
+            """
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                username TEXT,
+                display_name TEXT,
+                public_key TEXT,
+                password_hash TEXT,
+                account_type TEXT,
+                status TEXT,
+                origin_peer TEXT,
+                bio TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE api_keys (
+                id TEXT PRIMARY KEY,
+                user_id TEXT,
+                key_hash TEXT,
+                permissions TEXT,
+                created_at TEXT,
+                expires_at TEXT,
+                revoked INTEGER DEFAULT 0
+            );
+            CREATE TABLE user_keys (
+                user_id TEXT PRIMARY KEY,
+                ed25519_public_key TEXT,
+                ed25519_private_key TEXT,
+                x25519_public_key TEXT,
+                x25519_private_key TEXT
+            );
+            """
+        )
+        self.conn.executemany(
+            """
+            INSERT INTO users (
+                id, username, display_name, public_key, password_hash,
+                account_type, status, origin_peer, bio, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    'local-user', 'local_user', 'Local User', 'pk-local', 'pw-local',
+                    'human', 'active', None, '', '2026-03-08T00:00:00+00:00'
+                ),
+                (
+                    'remote-human', 'homie', 'Homie', 'pk-remote', None,
+                    'human', 'active', None, '', '2026-03-08T00:01:00+00:00'
+                ),
+                (
+                    'remote-shadow', 'peer-remote-shadow', 'Remote Shadow', 'pk-shadow', None,
+                    'human', 'active', 'peer-remote', '', '2026-03-08T00:02:00+00:00'
+                ),
+            ],
+        )
+        self.conn.commit()
+        self.db = _DbWrapper(self.conn)
+        self.p2p_view = _FakeP2PView()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    def test_registered_user_with_blank_origin_is_local(self) -> None:
+        self.assertTrue(is_local_dm_user(self.db, self.p2p_view, 'local-user'))
+
+    def test_unregistered_user_with_blank_origin_is_not_assumed_local(self) -> None:
+        self.assertFalse(is_local_dm_user(self.db, self.p2p_view, 'remote-human'))
+
+    def test_security_summary_does_not_downgrade_ambiguous_remote_user_to_local_only(self) -> None:
+        manager = P2PNetworkManager.__new__(P2PNetworkManager)
+        manager.db = self.db
+        manager.local_identity = type('LocalIdentity', (), {'peer_id': 'peer-local'})()
+        manager.identity_manager = _FakeIdentityManager()
+        manager.peer_supports_capability = lambda peer_id, capability: False
+
+        summary = manager.describe_direct_message_security(['remote-human'])
+
+        self.assertEqual(summary.get('mode'), 'legacy_plaintext')
+        self.assertFalse(summary.get('local_only'))
+        self.assertIn('remote-human', summary.get('unknown_peer_ids') or [])
+
+    def test_group_summary_with_ambiguous_remote_member_is_not_local_only(self) -> None:
+        manager = P2PNetworkManager.__new__(P2PNetworkManager)
+        manager.db = self.db
+        manager.local_identity = type('LocalIdentity', (), {'peer_id': 'peer-local'})()
+        manager.identity_manager = _FakeIdentityManager()
+        manager.peer_supports_capability = lambda peer_id, capability: False
+
+        summary = manager.describe_direct_message_security(['remote-human', 'local-user'])
+
+        self.assertEqual(summary.get('mode'), 'legacy_plaintext')
+        self.assertFalse(summary.get('local_only'))
+        self.assertIn('local-user', summary.get('local_recipient_ids') or [])
+        self.assertIn('remote-human', summary.get('unknown_peer_ids') or [])
+
+    def test_broadcast_still_runs_for_ambiguous_remote_user(self) -> None:
+        manager = P2PNetworkManager.__new__(P2PNetworkManager)
+        manager._running = True
+        manager._event_loop = object()
+        manager.message_router = _FakeRouter()
+        manager.db = self.db
+        manager.local_identity = type('LocalIdentity', (), {'peer_id': 'peer-local'})()
+        manager.identity_manager = _FakeIdentityManager()
+        manager.peer_supports_capability = lambda peer_id, capability: False
+        manager.file_manager = None
+
+        def _run_coroutine(coro, _loop):
+            loop = asyncio.new_event_loop()
+            try:
+                return _FakeFuture(loop.run_until_complete(coro))
+            finally:
+                loop.close()
+
+        with patch('canopy.network.manager.asyncio.run_coroutine_threadsafe', side_effect=_run_coroutine):
+            ok = manager.broadcast_direct_message(
+                sender_id='local-user',
+                recipient_id='remote-human',
+                content='still relay this',
+                message_id='DM-ambiguous',
+                timestamp='2026-03-08T12:00:00+00:00',
+                metadata={},
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(len(manager.message_router.calls), 1)
+        security = manager.message_router.calls[0]['metadata']['metadata']['security']
+        self.assertEqual(security.get('mode'), 'legacy_plaintext')
+        self.assertFalse(security.get('local_only'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_messages_ui_workspace.py
+++ b/tests/test_messages_ui_workspace.py
@@ -1,0 +1,378 @@
+"""Regression tests for the redesigned DM workspace UI and composer."""
+
+import json
+import os
+import re
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.core.messaging import MessageManager
+from canopy.core.messaging import compute_group_id
+from canopy.ui.routes import create_ui_blueprint
+
+
+class _FakeDbManager:
+    def __init__(self, conn: sqlite3.Connection, db_path: Path) -> None:
+        self._conn = conn
+        self.db_path = db_path
+
+    def get_connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def get_user(self, user_id: str):
+        row = self._conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+        return dict(row) if row else None
+
+    def store_message(self, message_id, sender_id, recipient_id, content, message_type, metadata):
+        self._conn.execute(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, datetime('now'), NULL, NULL, NULL, ?)
+            """,
+            (
+                message_id,
+                sender_id,
+                recipient_id,
+                content,
+                message_type,
+                'pending',
+                json.dumps(metadata) if metadata else None,
+            ),
+        )
+        self._conn.commit()
+        return True
+
+
+class _FakeP2PManager:
+    def __init__(self) -> None:
+        self.direct_messages = []
+
+    def is_running(self) -> bool:
+        return True
+
+    def broadcast_direct_message(self, **kwargs):
+        self.direct_messages.append(dict(kwargs))
+
+    def get_peer_id(self) -> str:
+        return 'peer-local'
+
+    def describe_direct_message_security(self, recipient_ids):
+        return {
+            'mode': 'peer_e2e_v1',
+            'state': 'encrypted',
+            'label': 'E2E over mesh',
+            'e2e': True,
+            'relay_confidential': True,
+            'local_only': False,
+            'recipient_ids': list(recipient_ids or []),
+        }
+
+
+class TestMessagesUiWorkspace(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+
+        db_path = Path(self.tempdir.name) / 'messages_ui.db'
+        self.conn = sqlite3.connect(str(db_path))
+        self.conn.row_factory = sqlite3.Row
+        self.conn.executescript(
+            """
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                username TEXT,
+                display_name TEXT,
+                avatar_file_id TEXT,
+                account_type TEXT,
+                origin_peer TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                sender_id TEXT NOT NULL,
+                recipient_id TEXT,
+                content TEXT,
+                message_type TEXT,
+                status TEXT,
+                created_at TEXT,
+                delivered_at TEXT,
+                read_at TEXT,
+                edited_at TEXT,
+                metadata TEXT
+            );
+            """
+        )
+        self.conn.executemany(
+            "INSERT INTO users (id, username, display_name, avatar_file_id, account_type, origin_peer, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ('owner', 'owner', 'Owner', None, 'human', None, '2026-03-07T08:00:00+00:00'),
+                ('peer-a', 'peer_a', 'Alice', None, 'agent', None, '2026-03-07T08:01:00+00:00'),
+                ('peer-b', 'peer_b', 'Bob', None, 'agent', None, '2026-03-07T08:02:00+00:00'),
+                ('peer-c', 'peer_c', 'Cara', None, 'human', None, '2026-03-07T08:03:00+00:00'),
+            ],
+        )
+        self.conn.executemany(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    'DM-root', 'peer-a', 'owner', 'Hello owner', 'text', 'delivered',
+                    '2026-03-07T10:00:00+00:00', '2026-03-07T10:00:01+00:00', None, None, None,
+                ),
+                (
+                    'DM-reply', 'owner', 'peer-a', 'Need update', 'text', 'delivered',
+                    '2026-03-07T10:05:00+00:00', '2026-03-07T10:05:01+00:00', None, None,
+                    json.dumps({'reply_to': 'DM-root'}),
+                ),
+                (
+                    'DM-group', 'peer-b', 'group:abc123', 'Group check-in', 'text', 'delivered',
+                    '2026-03-07T10:06:00+00:00', '2026-03-07T10:06:01+00:00', None, None,
+                    json.dumps({'group_id': 'group:abc123', 'group_members': ['owner', 'peer-b', 'peer-c']}),
+                ),
+                (
+                    'DM-group-relayed', 'peer-c', 'owner', 'Relay delivered through broker', 'text', 'delivered',
+                    '2026-03-07T10:07:00+00:00', '2026-03-07T10:07:02+00:00', None, None,
+                    json.dumps({'group_id': 'group:relay-alias', 'group_members': ['owner', 'peer-b', 'peer-c']}),
+                ),
+            ],
+        )
+        self.conn.commit()
+
+        self.db_manager = _FakeDbManager(self.conn, db_path)
+        self.message_manager = MessageManager(self.db_manager, MagicMock())
+        self.profile_manager = MagicMock()
+        self.profile_manager.get_profile.return_value = None
+        self.p2p_manager = _FakeP2PManager()
+
+        components = (
+            self.db_manager,
+            MagicMock(),
+            MagicMock(),
+            self.message_manager,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            self.profile_manager,
+            MagicMock(),
+            self.p2p_manager,
+        )
+
+        self.get_components_patcher = patch('canopy.ui.routes.get_app_components', return_value=components)
+        self.get_components_patcher.start()
+        self.addCleanup(self.get_components_patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.register_blueprint(create_ui_blueprint())
+        self.app = app
+        self.client = app.test_client()
+        self._set_authenticated_session()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    def _set_authenticated_session(self, csrf_token: str = 'csrf-ui-messages') -> None:
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'owner'
+            sess['username'] = 'owner'
+            sess['display_name'] = 'Owner'
+            sess['_csrf_token'] = csrf_token
+
+    def test_messages_page_renders_conversation_workspace(self) -> None:
+        response = self.client.get('/messages?with=peer-a')
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+        self.assertIn('Direct Messages', body)
+        self.assertIn('Alice', body)
+        self.assertIn('Bob, Cara', body)
+        self.assertIn('Need update', body)
+        self.assertIn('Hello owner', body)
+        self.assertIn('New conversation', body)
+        self.assertIn('E2E over mesh', body)
+        active_direct_card = re.search(
+            r'<a href="/messages\?with=peer-a" class="dm-conversation-card active">([\s\S]*?)</a>',
+            body,
+        )
+        self.assertIsNotNone(active_direct_card)
+        self.assertNotIn('dm-unread-pill', active_direct_card.group(1))
+        self.assertIn('.7z,.rar', body)
+        self.assertIn('.html,.css,.sh,.bat,.cfg,.ini,.toml', body)
+        self.assertIn('/ajax/messages/thread_snapshot', body)
+        self.assertIn("function refreshMessages() {\n        loadDmSnapshot(", body)
+        self.assertIn('/ajax/mention_suggestions?', body)
+        self.assertIn('setupMessageDropzone();', body)
+        self.assertIn("composer.addEventListener('drop'", body)
+        self.assertNotIn("threadPane.addEventListener('paste'", body)
+        self.assertIn('grid-template-rows: auto minmax(0, 1fr);', body)
+        self.assertIn('position: sticky;', body)
+
+    def test_messages_search_renders_matching_results(self) -> None:
+        response = self.client.get('/messages?search=relay')
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+        self.assertIn('Search DMs and group chats', body)
+        self.assertIn('Relay delivered through broker', body)
+
+    def test_message_search_decrypts_before_matching(self) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                'DM-encrypted', 'peer-a', 'owner', 'cipher:relay', 'text', 'delivered',
+                '2026-03-07T10:09:00+00:00', '2026-03-07T10:09:01+00:00', None, None, None,
+            ),
+        )
+        self.conn.commit()
+        self.message_manager.data_encryptor = types.SimpleNamespace(
+            is_enabled=True,
+            decrypt=lambda value: 'relay decrypted note' if value == 'cipher:relay' else value,
+        )
+
+        results = self.message_manager.search_messages('owner', 'decrypted', limit=20)
+
+        self.assertTrue(any(message.id == 'DM-encrypted' for message in results))
+
+    def test_message_search_pages_past_recent_non_matches_for_older_encrypted_hit(self) -> None:
+        newer_rows = []
+        for index in range(405):
+            newer_rows.append(
+                (
+                    f'DM-filler-{index}',
+                    'peer-a',
+                    'owner',
+                    f'noise message {index}',
+                    'text',
+                    'delivered',
+                    f'2026-03-08T11:{index // 60:02d}:{index % 60:02d}+00:00',
+                    f'2026-03-08T11:{index // 60:02d}:{index % 60:02d}+00:00',
+                    None,
+                    None,
+                    None,
+                )
+            )
+        self.conn.executemany(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            newer_rows,
+        )
+        self.conn.execute(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                'DM-older-encrypted',
+                'peer-a',
+                'owner',
+                'cipher:older-hit',
+                'text',
+                'delivered',
+                '2026-03-07T09:59:00+00:00',
+                '2026-03-07T09:59:01+00:00',
+                None,
+                None,
+                None,
+            ),
+        )
+        self.conn.commit()
+        self.message_manager.data_encryptor = types.SimpleNamespace(
+            is_enabled=True,
+            decrypt=lambda value: 'very old relay search hit' if value == 'cipher:older-hit' else value,
+        )
+
+        results = self.message_manager.search_messages('owner', 'relay search hit', limit=20)
+
+        self.assertTrue(any(message.id == 'DM-older-encrypted' for message in results))
+
+    def test_ajax_messages_thread_snapshot_returns_partial_fragments(self) -> None:
+        response = self.client.get('/ajax/messages/thread_snapshot?with=peer-a')
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        self.assertEqual((payload.get('active_thread') or {}).get('user_id'), 'peer-a')
+        self.assertIn('Alice', payload.get('sidebar_html') or '')
+        self.assertIn('Hello owner', payload.get('thread_body_html') or '')
+        self.assertIn('Need update', payload.get('thread_body_html') or '')
+        self.assertIn('E2E over mesh', payload.get('thread_header_html') or '')
+        self.assertTrue(payload.get('thread_state_token'))
+        self.assertTrue(payload.get('sidebar_state_token'))
+
+    def test_ajax_send_message_preserves_reply_to_metadata(self) -> None:
+        response = self.client.post(
+            '/ajax/send_message',
+            json={
+                'recipient_id': 'peer-a',
+                'content': 'Follow-up with context',
+                'reply_to': 'DM-root',
+            },
+            headers={'X-CSRFToken': 'csrf-ui-messages'},
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+
+        row = self.conn.execute(
+            'SELECT recipient_id, metadata FROM messages WHERE id = ?',
+            (payload['message']['id'],),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row['recipient_id'], 'peer-a')
+        metadata = json.loads(row['metadata']) if row['metadata'] else {}
+        self.assertEqual(metadata.get('reply_to'), 'DM-root')
+        self.assertEqual(self.p2p_manager.direct_messages[-1]['metadata'].get('reply_to'), 'DM-root')
+
+    def test_group_thread_view_uses_canonical_identity_for_relayed_group_messages(self) -> None:
+        canonical_group_id = compute_group_id(['owner', 'peer-b', 'peer-c'])
+
+        response = self.client.get(f'/messages?group={canonical_group_id}')
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+
+        self.assertIn('Group check-in', body)
+        self.assertIn('Relay delivered through broker', body)
+        self.assertIn(f'/messages?group={canonical_group_id}', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_network_connectivity_regressions.py
+++ b/tests/test_network_connectivity_regressions.py
@@ -1,0 +1,309 @@
+"""Regression tests for P2P connectivity durability and endpoint truth."""
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure repository root is importable when running tests directly.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Provide a lightweight zeroconf stub for environments without optional deps.
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.network.discovery import DiscoveredPeer, PeerDiscovery
+from canopy.network.invite import InviteCode, import_invite
+from canopy.network.manager import P2PNetworkManager
+from canopy.network.identity import IdentityManager
+
+
+class _DummyConfig:
+    def __init__(self, tempdir: str) -> None:
+        self.storage = types.SimpleNamespace(
+            database_path=os.path.join(tempdir, 'canopy.db')
+        )
+        self.network = types.SimpleNamespace(
+            mesh_port=7771,
+            enable_tls=False,
+            tls_cert_path=None,
+            tls_key_path=None,
+        )
+        self.security = types.SimpleNamespace(
+            allow_unverified_relay_messages=False,
+            sync_digest_enabled=False,
+            sync_digest_require_capability=True,
+            sync_digest_max_channels_per_request=200,
+            e2e_private_channels=False,
+            e2e_private_channels_enforce=False,
+            identity_portability_enabled=False,
+        )
+
+
+class _FakeServiceInfo:
+    def __init__(self, peer_id: str, addresses: list[bytes], port: int = 7771) -> None:
+        self.properties = {
+            b'peer_id': peer_id.encode('utf-8'),
+            b'version': b'0.4.0',
+            b'capabilities': b'chat,files',
+        }
+        self.addresses = addresses
+        self.port = port
+
+
+class _FakeZeroconf:
+    def __init__(self, info: _FakeServiceInfo) -> None:
+        self._info = info
+
+    def get_service_info(self, _service_type: str, _name: str):
+        return self._info
+
+
+class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.mkdtemp(prefix='canopy-connectivity-')
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def _build_manager(self) -> P2PNetworkManager:
+        manager = P2PNetworkManager(_DummyConfig(self.tempdir), MagicMock())
+        manager.local_identity = types.SimpleNamespace(peer_id='local-peer')
+        return manager
+
+    def test_import_invite_persists_only_sanitized_endpoints_for_reconnect(self) -> None:
+        identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
+        identity_manager.initialize()
+        identity_manager.verify_peer_id = lambda _pid, _pub: True  # type: ignore[assignment]
+
+        invite = InviteCode(
+            peer_id='peer-remote',
+            ed25519_public_key_b58='11111111111111111111111111111111',
+            x25519_public_key_b58='11111111111111111111111111111111',
+            endpoints=[
+                ' ws://192.168.1.50:7771 ',
+                'ws://[2001:db8::10]:7771',
+                'ws://192.168.1.50:7771',
+                'localhost:7771',
+                'ws://0.0.0.0:7771',
+                'not-an-endpoint',
+            ],
+        )
+
+        imported = import_invite(identity_manager, None, invite)
+
+        self.assertEqual(
+            identity_manager.peer_endpoints.get('peer-remote'),
+            ['ws://192.168.1.50:7771', 'ws://[2001:db8::10]:7771'],
+        )
+        self.assertEqual(
+            imported['endpoints'],
+            ['ws://192.168.1.50:7771', 'ws://[2001:db8::10]:7771'],
+        )
+
+    def test_discovery_preserves_all_advertised_addresses(self) -> None:
+        discovery = PeerDiscovery('local-peer')
+        captured: list[DiscoveredPeer] = []
+        discovery.on_peer_discovered(lambda peer, added: captured.append(peer) if added else None)
+
+        zeroconf = _FakeZeroconf(
+            _FakeServiceInfo(
+                peer_id='peer-remote',
+                addresses=[b'\x0a\x00\x00\x02', b'\xc0\xa8\x01\x64'],
+            )
+        )
+
+        discovery._on_service_added(zeroconf, discovery.service_type, 'peer-remote._canopy._tcp.local.')
+
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0].address, '10.0.0.2')
+        self.assertEqual(captured[0].addresses, ['10.0.0.2', '192.168.1.100'])
+
+    async def test_connect_to_discovered_peer_tries_all_advertised_addresses(self) -> None:
+        manager = self._build_manager()
+        attempts: list[str] = []
+        sync_calls: list[str] = []
+
+        async def _connect(peer_id: str, endpoint: str) -> bool:
+            attempts.append(endpoint)
+            return endpoint.endswith('192.168.1.100:7771')
+
+        async def _sync(peer_id: str) -> None:
+            sync_calls.append(peer_id)
+
+        manager._connect_to_endpoint = _connect  # type: ignore[assignment]
+        manager._run_post_connect_sync = _sync  # type: ignore[assignment]
+        manager.connection_manager = types.SimpleNamespace(enable_tls=False)
+
+        peer = DiscoveredPeer(
+            peer_id='peer-remote',
+            address='10.0.0.2',
+            addresses=['10.0.0.2', '192.168.1.100'],
+            port=7771,
+            discovered_at=0.0,
+        )
+
+        await manager._connect_to_discovered_peer(peer)
+
+        self.assertEqual(
+            attempts,
+            ['ws://10.0.0.2:7771', 'ws://192.168.1.100:7771'],
+        )
+        self.assertEqual(sync_calls, ['peer-remote'])
+
+    def test_discovered_peer_endpoints_format_ipv6_for_dialing(self) -> None:
+        manager = self._build_manager()
+        peer = DiscoveredPeer(
+            peer_id='peer-remote',
+            address='2001:db8::10',
+            addresses=['2001:db8::10'],
+            port=7771,
+            discovered_at=0.0,
+        )
+
+        self.assertEqual(
+            manager._discovered_peer_endpoints(peer),
+            ['ws://[2001:db8::10]:7771'],
+        )
+
+    async def test_peer_announcement_uses_stored_endpoints_not_socket_origin(self) -> None:
+        manager = self._build_manager()
+        manager.identity_manager.peer_display_names['peer-remote'] = 'Remote Node'
+        manager.identity_manager.peer_endpoints['peer-remote'] = ['ws://192.168.1.55:7771']
+        manager.identity_manager.known_peers['peer-remote'] = types.SimpleNamespace(
+            ed25519_public_key=b'1' * 32,
+            x25519_public_key=b'2' * 32,
+        )
+        manager.connection_manager = types.SimpleNamespace(
+            get_connected_peers=lambda: ['peer-remote'],
+            get_connection=lambda peer_id: types.SimpleNamespace(capabilities={}),
+            connections={'peer-remote': types.SimpleNamespace(address='10.99.0.8')},
+        )
+        manager.get_peer_device_profile = None
+
+        captured: list[list[dict]] = []
+
+        class _Router:
+            async def send_peer_announcement(self, to_peer: str, introduced_peers: list[dict]) -> bool:
+                captured.append(introduced_peers)
+                return True
+
+        manager.message_router = _Router()
+
+        await manager._send_peer_announcement_to('peer-target')
+
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(
+            captured[0][0]['endpoints'],
+            ['ws://192.168.1.55:7771'],
+        )
+
+    async def test_reconnect_keeps_retrying_after_backoff_cap(self) -> None:
+        manager = self._build_manager()
+        manager._running = True
+        manager._event_loop = asyncio.get_running_loop()
+        manager.connection_manager = types.SimpleNamespace(
+            is_connected=lambda _peer_id: False
+        )
+        manager.identity_manager.peer_endpoints['peer-remote'] = ['ws://192.168.1.50:7771']
+        manager._record_connection_event = lambda *args, **kwargs: None  # type: ignore[assignment]
+
+        async def _connect_to_endpoint(peer_id: str, endpoint: str) -> bool:
+            return False
+
+        manager._connect_to_endpoint = _connect_to_endpoint  # type: ignore[assignment]
+
+        attempts: list[int] = []
+        original_schedule = manager._schedule_reconnect
+
+        def _wrapped_schedule(peer_id: str, attempt: int = 1) -> None:
+            attempts.append(attempt)
+            if attempt > manager._RECONNECT_MAX_BACKOFF_STAGE + 1:
+                return
+            original_schedule(peer_id, attempt)
+
+        manager._schedule_reconnect = _wrapped_schedule  # type: ignore[assignment]
+
+        async def _fast_sleep(_delay: float) -> None:
+            return None
+
+        original_sleep = asyncio.sleep
+        with patch('canopy.network.manager.asyncio.sleep', new=_fast_sleep):
+            manager._schedule_reconnect('peer-remote', attempt=manager._RECONNECT_MAX_BACKOFF_STAGE)
+            await original_sleep(0.05)
+
+        for task in list(manager._reconnect_tasks.values()):
+            try:
+                task.cancel()
+            except Exception:
+                pass
+
+        self.assertIn(manager._RECONNECT_MAX_BACKOFF_STAGE + 1, attempts)
+
+    async def test_startup_reconnect_prefers_discovered_endpoints_over_stale_persisted(self) -> None:
+        manager = self._build_manager()
+        manager.identity_manager.known_peers['peer-remote'] = types.SimpleNamespace()
+        manager.identity_manager.peer_endpoints['peer-remote'] = ['ws://10.0.0.2:7771']
+        manager.discovery = types.SimpleNamespace(
+            get_peer=lambda peer_id: DiscoveredPeer(
+                peer_id=peer_id,
+                address='192.168.1.100',
+                addresses=['192.168.1.100'],
+                port=7771,
+                discovered_at=0.0,
+            )
+        )
+        attempts: list[str] = []
+        sync_calls: list[str] = []
+        connected_peers: set[str] = set()
+
+        async def _connect(peer_id: str, endpoint: str) -> bool:
+            attempts.append(endpoint)
+            if endpoint == 'ws://192.168.1.100:7771':
+                connected_peers.add(peer_id)
+                return True
+            return False
+
+        async def _enqueue(peer_id: str) -> None:
+            sync_calls.append(peer_id)
+
+        manager._connect_to_endpoint = _connect  # type: ignore[assignment]
+        manager._enqueue_sync = _enqueue  # type: ignore[assignment]
+        manager.connection_manager = types.SimpleNamespace(
+            is_connected=lambda peer_id: peer_id in connected_peers
+        )
+
+        original_sleep = asyncio.sleep
+
+        async def _fast_sleep(_delay: float) -> None:
+            return None
+
+        with patch('canopy.network.manager.asyncio.sleep', new=_fast_sleep):
+            await manager._reconnect_known_peers()
+        await original_sleep(0)
+
+        self.assertEqual(attempts, ['ws://192.168.1.100:7771'])
+        self.assertEqual(sync_calls, ['peer-remote'])
+        self.assertIn(
+            'ws://192.168.1.100:7771',
+            manager.identity_manager.peer_endpoints.get('peer-remote', []),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- publish Canopy v0.4.59 with mesh reconnect hardening, dead-connection send cleanup, and safer DM remote-vs-local classification
- improve DM search and workspace scrolling behavior, and refresh public docs/version framing to match the current release
- add the public-safe regression tests that cover endpoint diagnostics, dead-connection send failures, DM workspace search/layout, and DM security classification

## Test plan
- [x] ./venv/bin/python -m pytest -q tests/test_connection_diagnostics_endpoint.py tests/test_network_connectivity_regressions.py tests/test_connection_send_failures.py tests/test_messages_ui_workspace.py tests/test_dm_security_classification.py tests/test_dm_e2e_transport.py tests/test_dm_group_message_access.py tests/test_dm_agent_endpoint_regressions.py
- [x] python3 -m py_compile canopy/core/messaging.py canopy/network/manager.py canopy/network/connection.py canopy/ui/routes.py tests/test_connection_diagnostics_endpoint.py tests/test_network_connectivity_regressions.py tests/test_connection_send_failures.py tests/test_messages_ui_workspace.py tests/test_dm_security_classification.py
