### PR TITLE
release: publish v0.4.83 rich media reliability updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.4.83] - 2026-03-14
+
+### Fixed
+- **Active channel thread refresh parity** - The Channels UI now refreshes the currently open thread when the sidebar receives a new-message event for that same channel, preventing cases where the unread bell increments but the visible thread stays stale until a manual reload.
+- **Plain-text structured composer tolerance** - Structured block validation now ignores unknown bracketed section headers when they are not recognized Canopy tool aliases, so pasted `.ini` and similar config text can still be posted as plain text.
+- **Inbound inline attachment ID remapping** - Incoming peer-synced channel messages now rewrite both `/files/FILE_ID` and `file:FILE_ID` references to locally materialized attachment IDs so inline uploaded images keep rendering after cross-peer attachment normalization.
+
+## [0.4.82] - 2026-03-13
+
+### Fixed
+- **Active channel live-update recovery** - Channel thread polling now falls back to direct snapshot refresh more aggressively when workspace-event polling misses or fails, reducing cases where an already-open channel stops showing newly arrived messages on a peer.
+- **Channel-scoped workspace event visibility** - Workspace event visibility checks now explicitly allow channel-scoped events for actual channel members with message-read permission instead of relying on only per-user fanout semantics.
+
+## [0.4.81] - 2026-03-13
+
+### Added
+- **Inline uploaded-image anchors** - Rich content now supports `![caption](file:FILE_ID)` so uploaded Canopy images can appear directly inside post and message body copy while still using the local file service and lightbox viewer.
+
+### Changed
+- **Responsive attachment gallery hints** - Channel, feed, and DM image attachments now honor validated `layout_hint` values (`grid`, `hero`, `strip`, `stack`) with a shared mobile-first gallery renderer across surfaces.
+
 ## [0.4.80] - 2026-03-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.80-blue" alt="Version 0.4.80">
+  <img src="https://img.shields.io/badge/version-0.4.83-blue" alt="Version 0.4.83">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 License">
   <img src="https://img.shields.io/badge/encryption-ChaCha20--Poly1305-blueviolet" alt="ChaCha20-Poly1305">
@@ -23,7 +23,7 @@
   <a href="docs/QUICKSTART.md"><strong>Get Started</strong></a> ·
   <a href="docs/API_REFERENCE.md"><strong>API Reference</strong></a> ·
   <a href="docs/MCP_QUICKSTART.md"><strong>Agent Guide</strong></a> ·
-  <a href="docs/GITHUB_RELEASE_v0.4.80.md"><strong>Release Notes</strong></a> ·
+  <a href="docs/GITHUB_RELEASE_v0.4.83.md"><strong>Release Notes</strong></a> ·
   <a href="docs/WINDOWS_TRAY.md"><strong>Windows Tray</strong></a> ·
   <a href="CHANGELOG.md"><strong>Changelog</strong></a>
 </p>
@@ -80,6 +80,9 @@ Most chat products treat AI as bolt-on automation hanging off webhooks or extern
 
 Recent user-facing changes reflected in the app and docs:
 
+- **Cross-peer channel update and inline-image repair** in `0.4.83`, so active channel threads refresh when a new message lands in the channel you already have open, plain-text `.ini`-style config snippets can be posted without structured-composer false positives, and peer-synced inline `file:` images remap cleanly to local attachment IDs.
+- **Channel live-update recovery hardening** in `0.4.82`, so channel-thread polling falls back more aggressively to direct snapshots and channel-scoped workspace events are explicitly visible to actual channel members with message-read permission.
+- **Rich media composition pass** in `0.4.81`, adding inline uploaded-image anchors with `![caption](file:FILE_ID)` plus validated attachment `layout_hint` gallery rendering (`grid`, `hero`, `strip`, `stack`) across channels, feed, and DMs.
 - **Inbox audit and quiet-feed hardening** in `0.4.80`, so `seen` inbox items remain actionable until resolved, reopened items keep their last terminal evidence for operators, intentionally empty agent event subscriptions stay quiet, and message-bearing channel events remain permission-filtered.
 - **Durable agent event subscriptions** in `0.4.79`, so agents can store their preferred workspace event families server-side, inspect the effective feed in heartbeat/admin diagnostics, and intentionally run a quiet feed without falling back to defaults.
 - **Group-DM attachment fan-out hardening** in `0.4.78`, so one slow or dead peer no longer stalls later peers during broadcast mesh delivery and attachment sends no longer block the request thread while fan-out finishes in the background.
@@ -87,7 +90,7 @@ Recent user-facing changes reflected in the app and docs:
 - **Incremental channel-state updates** in `0.4.75`, so the Channels UI now applies common lifecycle, privacy, notification, member-count, and deletion state changes in place instead of forcing a sidebar snapshot refresh for every state event.
 - **Channel thread cursor isolation hardening** in `0.4.75`, so the active channel thread no longer skips unseen message edit/delete events when unrelated sidebar state events advance first.
 - **Request coordination reliability hardening** in `0.4.74`, preventing nested SQLite self-locks during request member upsert/update so assignee and reviewer membership persists reliably, while restoring authenticated `/api/v1/info` trust statistics.
-- **Docs/version alignment refresh** across `0.4.78` to `0.4.80`, updating the README, operator guides, and current release copy so public-facing pointers match the latest development surface.
+- **Docs/version alignment refresh** across `0.4.78` to `0.4.83`, updating the README, operator guides, and current release copy so public-facing pointers match the latest development surface.
 - **Workspace event journal rollout** across `0.4.69` to `0.4.71`, moving the DM workspace, shared recent-DM rail, and channel sidebar onto journal-driven change detection while preserving the existing snapshot render paths and safety resync behavior.
 - **Event-consumer race hardening** in `0.4.69` to `0.4.71`, so the DM thread view, recent-DM rail, and channel sidebar now capture their workspace-event cursors before rebuilding snapshot state and do not advance past unseen changes during concurrent activity.
 - **Structured block correction feedback** in `0.4.68`, so feed and channel composer send paths now reject semantically incomplete canonical `signal` and `request` blocks before save and surface explicit correction feedback instead of silently materializing nothing.
@@ -257,7 +260,7 @@ Canopy is designed so agents collaborate under your control instead of leaking c
 |---|---|
 | Channels & DMs | Public/private channels and direct messages with local-first persistence, a conversation-first DM workspace, group threads, inline replies, grouped message bubbles, and DM security markers that distinguish peer E2E, local-only, mixed, and legacy plaintext threads. |
 | Feed | Broadcast-style updates with visibility controls, attachments, and optional TTL. |
-| Rich media | Images/audio/video attachments, including inline playback for common formats. |
+| Rich media | Images/audio/video attachments, inline uploaded-image anchors with `file:FILE_ID`, responsive attachment gallery hints (`grid`, `hero`, `strip`, `stack`), and inline playback for common formats. |
 | Spreadsheet sharing | Upload `.csv`, `.tsv`, `.xlsx`, and `.xlsm` attachments with bounded read-only inline previews, plus editable inline computed `sheet` blocks for lightweight operational tables; macro-enabled workbooks are previewed safely with VBA disabled. |
 | Live stream cards | Post tokenized live audio/video stream cards and telemetry feed cards with scoped access. |
 | Team Mention Builder | Multi-select mention UI with saved mention-list macros for humans and agents. |
@@ -522,7 +525,7 @@ Guides: [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md) and [docs/PEER_CONNECT_GUIDE.
 | [docs/MENTIONS.md](docs/MENTIONS.md) | Mentions polling and SSE for agents |
 | [docs/WINDOWS_TRAY.md](docs/WINDOWS_TRAY.md) | Windows tray runtime and installer flow |
 | [docs/IDENTITY_PORTABILITY_TESTING.md](docs/IDENTITY_PORTABILITY_TESTING.md) | Feature-flagged identity portability admin workflow |
-| [docs/GITHUB_RELEASE_v0.4.79.md](docs/GITHUB_RELEASE_v0.4.79.md) | Product-forward GitHub release copy for the current release candidate |
+| [docs/GITHUB_RELEASE_v0.4.83.md](docs/GITHUB_RELEASE_v0.4.83.md) | Product-forward GitHub release copy for the current release candidate |
 | [docs/GITHUB_RELEASE_TEMPLATE.md](docs/GITHUB_RELEASE_TEMPLATE.md) | Baseline structure for future public GitHub release notes |
 | [docs/RELEASE_NOTES_0.4.0.md](docs/RELEASE_NOTES_0.4.0.md) | Historical publish-ready `0.4.0` release notes copy |
 | [docs/SECURITY_ASSESSMENT.md](docs/SECURITY_ASSESSMENT.md) | Threat model and security assessment |

--- a/canopy/__init__.py
+++ b/canopy/__init__.py
@@ -11,7 +11,7 @@ License: Apache 2.0
 Development: AI-assisted implementation (Claude, Codex, GitHub Copilot, Cursor IDE, Ollama)
 """
 
-__version__ = "0.4.80"
+__version__ = "0.4.83"
 __protocol_version__ = 1
 __author__ = "Canopy Contributors"
 __license__ = "Apache-2.0"

--- a/canopy/api/routes.py
+++ b/canopy/api/routes.py
@@ -174,6 +174,7 @@ _GENERIC_UPLOAD_FILENAMES = {
     'attachment',
     'unnamed_file',
 }
+_VALID_ATTACHMENT_LAYOUT_HINTS = {'grid', 'hero', 'strip', 'stack'}
 
 
 def _is_generic_upload_metadata(filename: Any, content_type: Any) -> bool:
@@ -246,6 +247,12 @@ def _normalize_channel_attachments(raw_attachments: Any, file_manager: Any) -> l
                 att['size'] = int(att.get('size'))
             except (TypeError, ValueError):
                 pass
+
+        layout_hint = str(att.get('layout_hint') or '').strip().lower()
+        if layout_hint in _VALID_ATTACHMENT_LAYOUT_HINTS:
+            att['layout_hint'] = layout_hint
+        else:
+            att.pop('layout_hint', None)
 
         normalized.append(att)
 

--- a/canopy/core/app.py
+++ b/canopy/core/app.py
@@ -221,6 +221,22 @@ def _apply_inbound_dm_delete(
     return True
 
 
+def _rewrite_incoming_attachment_links(
+    content: Optional[str],
+    file_id_map: dict[str, str],
+) -> Optional[str]:
+    """Rewrite sender-side attachment references to local file IDs."""
+    if not content or not file_id_map:
+        return content
+    rewritten = str(content)
+    for orig_id, local_id in file_id_map.items():
+        if not orig_id or not local_id or orig_id == local_id:
+            continue
+        rewritten = rewritten.replace(f'/files/{orig_id}', f'/files/{local_id}')
+        rewritten = rewritten.replace(f'file:{orig_id}', f'file:{local_id}')
+    return rewritten
+
+
 def create_app(config: Optional[Config] = None) -> Flask:
     """Create and configure the Flask application."""
     
@@ -1505,14 +1521,12 @@ def create_app(config: Optional[Config] = None) -> Flask:
 
                     if processed_attachments:
                         message_type = 'file'
-                    # Rewrite /files/SENDER_ID in content to /files/LOCAL_ID so inline images load
+                    # Rewrite sender-side attachment references so inline embeds load locally.
                     if content_rewritten and file_id_map and crypto_state_db in {'plaintext', 'decrypted'}:
-                        for orig_id, local_id in file_id_map.items():
-                            if orig_id and local_id and orig_id != local_id:
-                                content_rewritten = content_rewritten.replace(
-                                    f'/files/{orig_id}',
-                                    f'/files/{local_id}',
-                                )
+                        content_rewritten = _rewrite_incoming_attachment_links(
+                            content_rewritten,
+                            file_id_map,
+                        )
 
                 # Store the message — reuse the original message_id to avoid dupes
                 import secrets as _sec2

--- a/canopy/core/events.py
+++ b/canopy/core/events.py
@@ -455,6 +455,7 @@ class WorkspaceEventManager:
         event_type = str(row["event_type"] or "").strip().lower()
         visibility_scope = str(row["visibility_scope"] or "").strip().lower()
         target_user_id = str(row["target_user_id"] or "").strip()
+        channel_id = str(row["channel_id"] or "").strip()
         message_id = str(row["message_id"] or "").strip()
 
         if (
@@ -469,6 +470,20 @@ class WorkspaceEventManager:
 
         if visibility_scope == "user" and target_user_id:
             return target_user_id == user_id
+
+        if (
+            event_type in {
+                EVENT_CHANNEL_MESSAGE_CREATED,
+                EVENT_CHANNEL_MESSAGE_EDITED,
+                EVENT_CHANNEL_MESSAGE_DELETED,
+                EVENT_CHANNEL_MESSAGE_READ,
+                EVENT_CHANNEL_STATE_UPDATED,
+            }
+            and visibility_scope == "channel"
+        ):
+            if not can_read_messages or not channel_id:
+                return False
+            return self._can_user_view_channel(user_id, channel_id)
 
         if event_type.startswith("mention.") or event_type.startswith("inbox.item."):
             return bool(target_user_id and target_user_id == user_id)
@@ -492,6 +507,22 @@ class WorkspaceEventManager:
             return False
 
         return False
+
+    def _can_user_view_channel(self, user_id: str, channel_id: str) -> bool:
+        try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT 1
+                    FROM channel_members
+                    WHERE channel_id = ? AND user_id = ?
+                    LIMIT 1
+                    """,
+                    (channel_id, user_id),
+                ).fetchone()
+            return bool(row)
+        except Exception:
+            return False
 
     def _user_visible_via_payload(self, row: Any, *, user_id: str) -> bool:
         try:

--- a/canopy/ui/static/js/canopy-main.js
+++ b/canopy/ui/static/js/canopy-main.js
@@ -62,6 +62,7 @@
             `;
             
             const container = document.querySelector('.flash-messages');
+            if (!container) return;
             container.appendChild(alertDiv);
             
             // Auto-dismiss after 5 seconds
@@ -278,14 +279,16 @@
                     const rawTag = String(tagMatch[2] || '').trim();
                     const tag = rawTag.toLowerCase();
                     if (!SUPPORTED_TAGS.has(tag)) {
+                        const suggestedTag = TAG_SUGGESTIONS[tag] || null;
+                        if (!suggestedTag) {
+                            return;
+                        }
                         issues.push({
                             kind: 'unknown_tag',
                             line: index + 1,
                             tag,
-                            suggestedTag: TAG_SUGGESTIONS[tag] || null,
-                            message: TAG_SUGGESTIONS[tag]
-                                ? `Line ${index + 1}: [${rawTag}] is not a canonical block. Use [${TAG_SUGGESTIONS[tag]}] instead.`
-                                : `Line ${index + 1}: [${rawTag}] is not a supported Canopy tool block.`,
+                            suggestedTag,
+                            message: `Line ${index + 1}: [${rawTag}] is not a canonical block. Use [${suggestedTag}] instead.`,
                         });
                         return;
                     }
@@ -339,6 +342,7 @@
         const canopyInitialPeerRev = window.CANOPY_VARS ? (window.CANOPY_VARS.peerRev || '') : '';
         const canopyInitialRecentDmContacts = window.CANOPY_VARS ? (window.CANOPY_VARS.recentDmContacts || []) : [];
         const canopyInitialDmRev = window.CANOPY_VARS ? (window.CANOPY_VARS.dmRev || '') : '';
+        const canopyInitialDmEventCursor = window.CANOPY_VARS ? Number(window.CANOPY_VARS.dmEventCursor || 0) : 0;
         const canopyLocalPeerId = window.CANOPY_VARS ? String(window.CANOPY_VARS.localPeerId || '').trim() : '';
         const SIDEBAR_VISIBLE_PEER_LIMIT = 12;
         window.canopyPeerProfiles = canopyPeerProfiles || {};
@@ -705,7 +709,19 @@
         const canopySidebarDmState = {
             contacts: Array.isArray(canopyInitialRecentDmContacts) ? canopyInitialRecentDmContacts.slice(0) : [],
             currentRev: canopyInitialDmRev || '',
+            currentEventCursor: Number.isFinite(canopyInitialDmEventCursor) ? canopyInitialDmEventCursor : 0,
+            pollInFlight: false,
+            snapshotInFlight: false,
+            queuedSnapshot: false,
+            pollHandle: null,
+            safetyHandle: null,
         };
+        const SIDEBAR_DM_EVENT_TYPES = [
+            'dm.message.created',
+            'dm.message.edited',
+            'dm.message.deleted',
+            'dm.message.read',
+        ];
 
         function canopyRenderSidebarDmContacts(contacts) {
             const listEl = document.getElementById('sidebar-dm-list');
@@ -802,6 +818,9 @@
                 canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
                 return;
             }
+            if (Number(payload.workspace_event_cursor || 0) > Number(canopySidebarDmState.currentEventCursor || 0)) {
+                canopySidebarDmState.currentEventCursor = Number(payload.workspace_event_cursor || 0);
+            }
             if (payload && payload.dm_rev) {
                 canopySidebarDmState.currentRev = String(payload.dm_rev || '');
             }
@@ -816,8 +835,117 @@
             canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
         };
 
+        function requestCanopySidebarDmRefresh(options) {
+            const opts = options || {};
+            if (canopySidebarDmState.snapshotInFlight) {
+                canopySidebarDmState.queuedSnapshot = true;
+                return Promise.resolve({ queued: true });
+            }
+
+            canopySidebarDmState.snapshotInFlight = true;
+            const query = new URLSearchParams();
+            if (!opts.force && canopySidebarDmState.currentRev) {
+                query.set('dm_rev', String(canopySidebarDmState.currentRev || ''));
+            }
+
+            return fetch(`/ajax/sidebar_dm_snapshot${query.toString() ? `?${query.toString()}` : ''}`, {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+                .then((res) => {
+                    if (!res.ok) {
+                        throw new Error(`Sidebar DM snapshot failed (${res.status})`);
+                    }
+                    return res.json();
+                })
+                .then((data) => {
+                    if (!data || data.success === false) return data || null;
+                    if (window.syncCanopySidebarDmContacts) {
+                        window.syncCanopySidebarDmContacts(data);
+                    }
+                    return data;
+                })
+                .catch(() => null)
+                .finally(() => {
+                    canopySidebarDmState.snapshotInFlight = false;
+                    if (canopySidebarDmState.queuedSnapshot) {
+                        canopySidebarDmState.queuedSnapshot = false;
+                        window.setTimeout(() => {
+                            requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
+                        }, 0);
+                    }
+                });
+        }
+
+        function pollCanopySidebarDmEvents() {
+            if (canopySidebarDmState.pollInFlight) {
+                return;
+            }
+            const listEl = document.getElementById('sidebar-dm-list');
+            if (!listEl) {
+                return;
+            }
+
+            canopySidebarDmState.pollInFlight = true;
+            const query = new URLSearchParams();
+            query.set('after_seq', String(Number(canopySidebarDmState.currentEventCursor || 0)));
+            query.set('limit', '100');
+            SIDEBAR_DM_EVENT_TYPES.forEach((eventType) => query.append('types', eventType));
+
+            fetch(`/api/v1/events?${query.toString()}`, {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+                .then((res) => {
+                    if (!res.ok) {
+                        throw new Error(`Sidebar DM event poll failed (${res.status})`);
+                    }
+                    return res.json();
+                })
+                .then((data) => {
+                    if (!data || typeof data !== 'object') return;
+                    const nextSeq = Number(data.next_after_seq || 0);
+                    if (nextSeq > Number(canopySidebarDmState.currentEventCursor || 0)) {
+                        canopySidebarDmState.currentEventCursor = nextSeq;
+                    }
+                    const items = Array.isArray(data.items) ? data.items : [];
+                    if (!items.length) {
+                        return;
+                    }
+                    requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
+                })
+                .catch(() => {})
+                .finally(() => {
+                    canopySidebarDmState.pollInFlight = false;
+                });
+        }
+
+        function startCanopySidebarDmPolling() {
+            const listEl = document.getElementById('sidebar-dm-list');
+            if (!listEl) return;
+            if (canopySidebarDmState.pollHandle) {
+                window.clearInterval(canopySidebarDmState.pollHandle);
+                canopySidebarDmState.pollHandle = null;
+            }
+            if (canopySidebarDmState.safetyHandle) {
+                window.clearInterval(canopySidebarDmState.safetyHandle);
+                canopySidebarDmState.safetyHandle = null;
+            }
+
+            pollCanopySidebarDmEvents();
+            canopySidebarDmState.pollHandle = window.setInterval(pollCanopySidebarDmEvents, 2500);
+            canopySidebarDmState.safetyHandle = window.setInterval(() => {
+                requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
+            }, 30000);
+        }
+
+        window.requestCanopySidebarDmRefresh = requestCanopySidebarDmRefresh;
+
         document.addEventListener('DOMContentLoaded', function() {
             canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
+            startCanopySidebarDmPolling();
         });
 
         window.renderAvatarStack = function(container, options) {
@@ -2071,6 +2199,17 @@
             html = html.replace(/!\[([^\]]*)\]\((\/files\/[A-Za-z0-9_-]+)\)/g, function(match, alt, src) {
                 var altEsc = (alt || '').replace(/"/g, '&quot;');
                 return '<span class="channel-inline-image-wrap"><img src="' + src + '" alt="' + altEsc + '" class="channel-inline-image" style="max-width:100%;max-height:400px;height:auto;vertical-align:middle;border-radius:8px;" onerror="this.onerror=null;this.style.display=\'none\';var s=this.nextElementSibling;if(s)s.classList.remove(\'d-none\');"><span class="d-none small text-muted">Image unavailable</span></span>';
+            });
+            html = html.replace(/!\[([^\]]*)\]\(file:([A-Za-z0-9_-]+)\)/g, function(match, alt, fileId) {
+                var src = '/files/' + fileId;
+                var altEsc = (alt || '').replace(/"/g, '&quot;');
+                var encodedUrls = encodeURIComponent(JSON.stringify([src]));
+                return '<span class="channel-inline-image-wrap channel-inline-image-block">' +
+                    '<img src="' + src + '" alt="' + altEsc + '" class="channel-inline-image channel-inline-image-full" ' +
+                    'onclick="openLightbox(0, \'' + encodedUrls + '\')" ' +
+                    'onerror="this.onerror=null;this.style.display=\'none\';var s=this.nextElementSibling;if(s)s.classList.remove(\'d-none\');">' +
+                    '<span class="d-none small text-muted">Image unavailable</span>' +
+                    '</span>';
             });
             html = html.replace(/!\[([^\]]*)\]\((\/custom_emojis\/[^)]+)\)/g, function(match, alt, src) {
                 var altEsc = (alt || '').replace(/"/g, '&quot;');
@@ -3896,9 +4035,6 @@
                 if (canopySidebarPeerState.currentRev) {
                     params.set('peer_rev', canopySidebarPeerState.currentRev);
                 }
-                if (canopySidebarDmState.currentRev) {
-                    params.set('dm_rev', canopySidebarDmState.currentRev);
-                }
                 const query = params.toString();
                 fetch(`/ajax/peer_activity${query ? `?${query}` : ''}`)
                     .then(r => r.json())
@@ -3906,9 +4042,6 @@
                         if (!data || data.success === false) return;
                         if (window.syncCanopySidebarPeers && (data.peer_changed !== false || data.peer_rev)) {
                             window.syncCanopySidebarPeers(data);
-                        }
-                        if (window.syncCanopySidebarDmContacts && (data.dm_changed !== false || data.dm_rev)) {
-                            window.syncCanopySidebarDmContacts(data);
                         }
                         const incoming = data.events || [];
                         if (!initialized) {

--- a/canopy/ui/templates/_messages_macros.html
+++ b/canopy/ui/templates/_messages_macros.html
@@ -26,6 +26,45 @@
     </div>
 {%- endmacro %}
 
+{% macro render_image_gallery(images, gallery_id, layout_hint='') -%}
+    {% set gallery_layout = (layout_hint or '')|lower %}
+    {% set hinted_layout = gallery_layout if gallery_layout in ['grid', 'hero', 'strip', 'stack'] else '' %}
+    {% set show_all = hinted_layout in ['grid', 'strip', 'stack'] %}
+    {% set show_count = images|length if show_all else [images|length, 4]|min %}
+    {% set img_count = [images|length, 5]|min %}
+    {% set image_urls = images | map(attribute='url') | list %}
+    <div class="media-grid"
+         data-count="{{ img_count }}"
+         {% if hinted_layout %}data-layout="{{ hinted_layout }}"{% endif %}
+         {% if gallery_id %}data-gallery-id="{{ gallery_id }}"{% endif %}>
+        {% for img in images[:show_count] %}
+            {% set has_url = img.url and img.url|trim %}
+            {% if has_url %}
+                <div class="mg-cell" onclick="openLightbox({{ loop.index0 }}, '{{ image_urls | tojson | urlencode }}')">
+                    <img src="{{ img.url }}/thumb" alt="{{ img.name or 'image' }}" loading="lazy">
+                    <a class="mg-download"
+                       href="{{ img.url }}"
+                       download="{{ img.name or 'image' }}"
+                       title="Download full resolution"
+                       onclick="event.stopPropagation();">
+                        <i class="bi bi-download"></i>
+                    </a>
+                    {% if not show_all and loop.last and images|length > show_count %}
+                        <div class="mg-more-overlay">+{{ images|length - show_count }}</div>
+                    {% endif %}
+                </div>
+            {% else %}
+                <div class="mg-cell mg-cell-unavailable d-flex align-items-center justify-content-center p-2">
+                    <span class="small text-muted text-center">
+                        {{ img.name or 'Image' }}<br>
+                        <span class="opacity-75">Not on this device yet — will appear when synced</span>
+                    </span>
+                </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+{%- endmacro %}
+
 {% macro render_dm_attachment(attachment, message_id, idx) -%}
     {% set attachment_file_id = attachment.id or attachment.file_id or ((attachment.url.split('/files/')[1].split('/')[0]) if attachment.url and '/files/' in attachment.url else None) %}
     {% set remote_large = attachment.large_attachment or attachment.storage_mode == 'remote_large' %}
@@ -134,4 +173,35 @@
             {% endif %}
         </div>
     {% endif %}
+{%- endmacro %}
+
+{% macro render_dm_attachments(attachments, message_id) -%}
+    {% set images = [] %}
+    {% set non_images = [] %}
+    {% set ns = namespace(layout_hint='') %}
+    {% for attachment in attachments or [] %}
+        {% if attachment.type and attachment.type.startswith('image/') %}
+            {% if images.append(attachment) %}{% endif %}
+            {% if not ns.layout_hint %}
+                {% set candidate = (attachment.layout_hint or '')|lower %}
+                {% if candidate in ['grid', 'hero', 'strip', 'stack'] %}
+                    {% set ns.layout_hint = candidate %}
+                {% endif %}
+            {% endif %}
+        {% else %}
+            {% if non_images.append(attachment) %}{% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {% if images and ns.layout_hint and images|length > 1 %}
+        {{ render_image_gallery(images, 'dm-' ~ message_id, ns.layout_hint) }}
+    {% else %}
+        {% for attachment in images %}
+            {{ render_dm_attachment(attachment, message_id, loop.index0) }}
+        {% endfor %}
+    {% endif %}
+
+    {% for attachment in non_images %}
+        {{ render_dm_attachment(attachment, message_id, loop.index0 + images|length) }}
+    {% endfor %}
 {%- endmacro %}

--- a/canopy/ui/templates/_messages_thread_body.html
+++ b/canopy/ui/templates/_messages_thread_body.html
@@ -1,4 +1,4 @@
-{% from "_messages_macros.html" import avatar_badge, render_dm_attachment with context %}
+{% from "_messages_macros.html" import avatar_badge, render_dm_attachments with context %}
 
 {% if search_query %}
     <div class="dm-search-results">
@@ -72,9 +72,7 @@
                             {% endif %}
                             {% if message.attachments %}
                                 <div class="dm-attachment-list">
-                                    {% for attachment in message.attachments %}
-                                        {{ render_dm_attachment(attachment, message.id, loop.index0) }}
-                                    {% endfor %}
+                                    {{ render_dm_attachments(message.attachments, message.id) }}
                                 </div>
                             {% endif %}
                         </div>

--- a/canopy/ui/templates/base.html
+++ b/canopy/ui/templates/base.html
@@ -3798,6 +3798,89 @@
             .media-grid[data-count="5"] .mg-cell { height: 140px; }
         }
 
+        /* Explicit attachment layout hints override the default count-based grid. */
+        .media-grid[data-layout] {
+            max-width: min(100%, 680px);
+        }
+        .media-grid[data-layout="stack"] {
+            grid-template-columns: 1fr !important;
+            grid-template-rows: none !important;
+        }
+        .media-grid[data-layout="stack"] .mg-cell {
+            height: auto !important;
+            max-height: none !important;
+        }
+        .media-grid[data-layout="stack"] .mg-cell img {
+            height: auto;
+            max-height: 520px;
+            object-fit: cover;
+        }
+        .media-grid[data-layout="strip"] {
+            display: grid;
+            grid-template-columns: none !important;
+            grid-auto-flow: column;
+            grid-auto-columns: minmax(220px, 85%);
+            overflow-x: auto;
+            overscroll-behavior-x: contain;
+            padding-bottom: 2px;
+        }
+        .media-grid[data-layout="strip"] .mg-cell {
+            height: 220px !important;
+        }
+        .media-grid[data-layout="grid"] {
+            grid-template-columns: 1fr !important;
+            grid-template-rows: none !important;
+        }
+        .media-grid[data-layout="grid"] .mg-cell {
+            height: 220px;
+        }
+        .media-grid[data-layout="hero"] {
+            grid-template-columns: 1fr !important;
+            grid-template-rows: none !important;
+        }
+        .media-grid[data-layout="hero"] .mg-cell {
+            height: 220px !important;
+        }
+        .media-grid .mg-cell.mg-cell-unavailable {
+            min-height: 96px;
+            background: var(--canopy-bg-tertiary);
+            border-radius: 8px;
+        }
+        @media (min-width: 480px) {
+            .media-grid[data-layout="grid"] {
+                grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)) !important;
+            }
+            .media-grid[data-layout="hero"] {
+                grid-template-columns: 2fr 1fr !important;
+                grid-template-rows: repeat(2, minmax(156px, 1fr)) !important;
+            }
+            .media-grid[data-layout="hero"] .mg-cell:first-child {
+                grid-row: 1 / span 2;
+                height: 100% !important;
+                min-height: 316px;
+            }
+            .media-grid[data-layout="hero"] .mg-cell:not(:first-child) {
+                height: 156px !important;
+            }
+        }
+
+        .channel-inline-image-block {
+            display: block;
+            margin: 0.75rem 0;
+        }
+        .channel-inline-image-full {
+            max-width: 100%;
+            max-height: 520px;
+            height: auto;
+            border-radius: 10px;
+            cursor: zoom-in;
+        }
+        @media (min-width: 768px) {
+            .channel-inline-image-full {
+                max-width: min(100%, 680px);
+            }
+        }
+
         /* ============================================
            Embed Grid — 2-col for multiple embeds
            ============================================ */
@@ -5366,6 +5449,7 @@
             peerRev: {{ sidebar_peer_rev|tojson if sidebar_peer_rev is defined else '""' }},
             recentDmContacts: {{ sidebar_recent_dm_contacts|tojson if sidebar_recent_dm_contacts is defined else '[]' }},
             dmRev: {{ sidebar_dm_rev|tojson if sidebar_dm_rev is defined else '""' }},
+            dmEventCursor: {{ sidebar_dm_event_cursor|tojson if sidebar_dm_event_cursor is defined else '0' }},
             userId: {{ (user_id or 'local_user')|tojson }},
             profileTheme: {{ (profile.theme_preference if profile else 'dark')|tojson }},
             localUserId: {{ session.get('user_id')|tojson }},

--- a/canopy/ui/templates/channels.html
+++ b/canopy/ui/templates/channels.html
@@ -7770,6 +7770,9 @@ function applyChannelSidebarEventItems(items) {
             if (!incrementSidebarChannelUnreadCount(channelId, 1)) {
                 needsSnapshotRefresh = true;
             }
+            if (currentChannelId && channelId === currentChannelId) {
+                requestChannelThreadRefresh();
+            }
             return;
         }
         if (eventType === 'channel.message.read') {
@@ -7972,7 +7975,10 @@ function pollChannelThreadEvents() {
             }
             applyChannelThreadEventItems(items);
         })
-        .catch(() => {})
+        .catch(() => {
+            // Fall back to a direct snapshot refresh if the event poll fails.
+            requestChannelThreadRefresh();
+        })
         .finally(() => {
             channelThreadEventPollInFlight = false;
         });
@@ -7995,7 +8001,7 @@ function startChannelThreadEventPolling() {
     channelThreadSafetyHandle = window.setInterval(() => {
         if (document.hidden) return;
         requestChannelThreadRefresh();
-    }, 45000);
+    }, 10000);
 }
 
 function pollChannelMessages() {
@@ -8082,10 +8088,26 @@ function isMarkdownFile(filename, contentType) {
 // Unique ID counter for preview containers
 let _previewIdCounter = 0;
 
+function normalizeAttachmentLayoutHint(value) {
+    const hint = String(value || '').trim().toLowerCase();
+    return ['grid', 'hero', 'strip', 'stack'].includes(hint) ? hint : '';
+}
+
+function resolveAttachmentLayoutHint(images) {
+    if (!Array.isArray(images)) return '';
+    for (const image of images) {
+        const hint = normalizeAttachmentLayoutHint(image && image.layout_hint);
+        if (hint) return hint;
+    }
+    return '';
+}
+
 // Build a Facebook-style media grid for image attachments
-function buildMediaGrid(images) {
+function buildMediaGrid(images, layoutHint = '') {
     if (!images || images.length === 0) return '';
-    const show = Math.min(images.length, 4); // show up to 4 in the grid
+    const normalizedLayout = normalizeAttachmentLayoutHint(layoutHint);
+    const showAll = ['grid', 'strip', 'stack'].includes(normalizedLayout);
+    const show = showAll ? images.length : Math.min(images.length, 4); // show up to 4 in the grid
     const count = Math.min(images.length, 5); // data-count caps at 5 for CSS
     const extraCount = images.length - show;
 
@@ -8097,7 +8119,7 @@ function buildMediaGrid(images) {
     for (let i = 0; i < show; i++) {
         const img = images[i];
         const hasUrl = img.url && String(img.url).trim();
-        const isLast = (i === show - 1) && extraCount > 0;
+        const isLast = (i === show - 1) && extraCount > 0 && !showAll;
         if (hasUrl) {
             const thumbUrl = img.url + '/thumb';
             cells += `<div class="mg-cell" onclick="openLightbox(${i}, '${urlsAttr}')">
@@ -8115,7 +8137,8 @@ function buildMediaGrid(images) {
         }
     }
 
-    return `<div class="media-grid" data-count="${count}">${cells}</div>`;
+    const layoutAttr = normalizedLayout ? ` data-layout="${normalizedLayout}"` : '';
+    return `<div class="media-grid" data-count="${count}"${layoutAttr}>${cells}</div>`;
 }
 
 function renderHandoffCards(message, userInfo) {
@@ -8426,9 +8449,11 @@ function displayAttachments(attachments) {
         `;
     });
 
+    const imageLayout = resolveAttachmentLayoutHint(images);
+
     // Render image grid
     if (images.length > 0) {
-        html += buildMediaGrid(images);
+        html += buildMediaGrid(images, imageLayout);
     }
 
     const escapeAttr = (value) => String(value || '').replace(/"/g, '&quot;');

--- a/canopy/ui/templates/feed.html
+++ b/canopy/ui/templates/feed.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_messages_macros.html" import render_image_gallery %}
 
 {% block title %}Feed - Canopy{% endblock %}
 
@@ -556,9 +557,16 @@
                                     {% set images = [] %}
                                     {% set audio_files = [] %}
                                     {% set others = [] %}
+                                    {% set image_layout = namespace(value='') %}
                                     {% for attachment in post.metadata.attachments %}
                                         {% if attachment.type.startswith('image/') and attachment.url %}
                                             {% if images.append(attachment) %}{% endif %}
+                                            {% if not image_layout.value %}
+                                                {% set candidate = (attachment.layout_hint or '')|lower %}
+                                                {% if candidate in ['grid', 'hero', 'strip', 'stack'] %}
+                                                    {% set image_layout.value = candidate %}
+                                                {% endif %}
+                                            {% endif %}
                                         {% elif attachment.type.startswith('audio/') %}
                                             {% if audio_files.append(attachment) %}{% endif %}
                                         {% else %}
@@ -567,22 +575,7 @@
                                     {% endfor %}
                                     <div class="post-attachments mt-2">
                                         {% if images %}
-                                            {% set img_count = [images|length, 5]|min %}
-                                            {% set show_count = [images|length, 4]|min %}
-                                            {% set img_urls = images | map(attribute='url') | list %}
-                                            <div class="media-grid" data-count="{{ img_count }}">
-                                                {% for img in images[:show_count] %}
-                                                    <div class="mg-cell" onclick="openLightbox({{ loop.index0 }}, '{{ img_urls | tojson | urlencode }}')">
-                                                        <img src="{{ img.url }}/thumb" alt="{{ img.name }}" loading="lazy">
-                                                        <a class="mg-download" href="{{ img.url }}" download="{{ img.name }}" title="Download full resolution" onclick="event.stopPropagation();">
-                                                            <i class="bi bi-download"></i>
-                                                        </a>
-                                                        {% if loop.last and images|length > show_count %}
-                                                            <div class="mg-more-overlay">+{{ images|length - show_count }}</div>
-                                                        {% endif %}
-                                                    </div>
-                                                {% endfor %}
-                                            </div>
+                                            {{ render_image_gallery(images, 'feed-' ~ post.id, image_layout.value) }}
                                         {% endif %}
                                         {% for attachment in audio_files %}
                                             {% set remote_large = attachment.large_attachment or attachment.storage_mode == 'remote_large' %}

--- a/canopy/ui/templates/messages.html
+++ b/canopy/ui/templates/messages.html
@@ -668,6 +668,10 @@
         margin-top: 0.65rem;
     }
 
+    .dm-attachment-list .media-grid {
+        max-width: 100%;
+    }
+
     .dm-attachment-image img {
         display: block;
         width: 100%;
@@ -1511,11 +1515,17 @@
     let composerUsesActiveThread = !!ACTIVE_THREAD;
     const dmInlineEditStates = {};
     let dmSnapshotSerial = 0;
+    let dmEventCursor = {{ workspace_event_cursor|tojson }};
     let dmLastSidebarToken = {{ sidebar_state_token|tojson }};
     let dmLastThreadToken = {{ thread_state_token|tojson }};
     let pendingDmSnapshot = null;
     let dmPollTimer = null;
+    let dmResyncTimer = null;
+    let dmEventPollInFlight = false;
+    let dmSnapshotInFlight = false;
+    let dmQueuedSnapshotOptions = null;
     let dmComposerDragDepth = 0;
+    const DM_WORKSPACE_EVENT_TYPES = ['dm.message.created', 'dm.message.edited', 'dm.message.deleted', 'attachment.available'];
 
     function matchesInitialRecipients() {
         const current = selectedRecipients.map(rec => rec.user_id).filter(Boolean).sort();
@@ -1585,6 +1595,18 @@
         hidePendingDmSnapshotNotice();
     }
 
+    function queueDmSnapshot(options) {
+        const opts = options || {};
+        const existing = dmQueuedSnapshotOptions || {};
+        dmQueuedSnapshotOptions = {
+            targetUrl: opts.targetUrl || existing.targetUrl || null,
+            pushHistory: !!(existing.pushHistory || opts.pushHistory),
+            forceBottom: !!(existing.forceBottom || opts.forceBottom),
+            allowDeferred: !(existing.allowDeferred === false || opts.allowDeferred === false),
+            hardFallback: !!(existing.hardFallback || opts.hardFallback),
+        };
+    }
+
     function applyDmSnapshot(data, options) {
         const opts = options || {};
         if (!data || !data.success) return;
@@ -1607,6 +1629,7 @@
 
         ACTIVE_THREAD = data.active_thread || null;
         INITIAL_RECIPIENTS = Array.isArray(data.composer_recipients) ? data.composer_recipients : [];
+        dmEventCursor = Math.max(Number(dmEventCursor || 0), Number(data.workspace_event_cursor || 0));
         dmLastSidebarToken = data.sidebar_state_token || '';
         dmLastThreadToken = data.thread_state_token || '';
 
@@ -1626,6 +1649,9 @@
         if (typeof formatTimestamps === 'function') {
             formatTimestamps();
         }
+        if (typeof window.requestCanopySidebarDmRefresh === 'function') {
+            window.requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
+        }
         startDmPolling();
     }
 
@@ -1635,11 +1661,16 @@
             if (opts.hardFallback) window.location.reload();
             return Promise.resolve(null);
         }
+        if (dmSnapshotInFlight) {
+            queueDmSnapshot(opts);
+            return Promise.resolve({ queued: true });
+        }
 
         const targetUrl = getDmQueryUrl(opts.targetUrl);
         const url = new URL(targetUrl, window.location.origin);
         url.searchParams.delete('partial');
         const serial = ++dmSnapshotSerial;
+        dmSnapshotInFlight = true;
 
         return fetch(`/ajax/messages/thread_snapshot${url.search || ''}`, {
             headers: {
@@ -1689,6 +1720,16 @@
                     window.location.reload();
                 }
                 return Promise.reject(error);
+            })
+            .finally(() => {
+                dmSnapshotInFlight = false;
+                if (dmQueuedSnapshotOptions) {
+                    const queued = dmQueuedSnapshotOptions;
+                    dmQueuedSnapshotOptions = null;
+                    window.setTimeout(() => {
+                        loadDmSnapshot(queued).catch(() => {});
+                    }, 0);
+                }
             });
     }
 
@@ -1697,21 +1738,72 @@
             window.clearInterval(dmPollTimer);
             dmPollTimer = null;
         }
+        if (dmResyncTimer) {
+            window.clearInterval(dmResyncTimer);
+            dmResyncTimer = null;
+        }
+    }
+
+    function pollDmEvents() {
+        if (dmEventPollInFlight || window.location.search.includes('search=')) {
+            return;
+        }
+        dmEventPollInFlight = true;
+        const query = new URLSearchParams();
+        query.set('after_seq', String(Number(dmEventCursor || 0)));
+        query.set('limit', '100');
+        DM_WORKSPACE_EVENT_TYPES.forEach((eventType) => query.append('types', eventType));
+        fetch(`/api/v1/events?${query.toString()}`, {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        })
+            .then((res) => {
+                if (!res.ok) {
+                    throw new Error(`DM events poll failed (${res.status})`);
+                }
+                return res.json();
+            })
+            .then((data) => {
+                if (!data || typeof data !== 'object') return;
+                const nextSeq = Number(data.next_after_seq || 0);
+                if (nextSeq > Number(dmEventCursor || 0)) {
+                    dmEventCursor = nextSeq;
+                }
+                const items = Array.isArray(data.items) ? data.items : [];
+                if (!items.length) {
+                    return;
+                }
+                loadDmSnapshot({
+                    allowDeferred: true,
+                    forceBottom: false,
+                    hardFallback: false,
+                }).catch(() => {});
+            })
+            .catch(() => {})
+            .finally(() => {
+                dmEventPollInFlight = false;
+            });
     }
 
     function startDmPolling() {
         stopDmPolling();
-        if (!ACTIVE_THREAD || window.location.search.includes('search=')) {
+        if (window.location.search.includes('search=')) {
             return;
         }
+        pollDmEvents();
         dmPollTimer = window.setInterval(() => {
+            if (document.hidden) return;
+            pollDmEvents();
+        }, 2500);
+        dmResyncTimer = window.setInterval(() => {
             if (document.hidden) return;
             loadDmSnapshot({
                 allowDeferred: true,
                 forceBottom: false,
                 hardFallback: false,
             }).catch(() => {});
-        }, 4000);
+        }, 45000);
     }
 
     function refreshMessages() {
@@ -2822,6 +2914,7 @@
         startDmPolling();
         document.addEventListener('visibilitychange', () => {
             if (!document.hidden) {
+                pollDmEvents();
                 loadDmSnapshot({
                     allowDeferred: true,
                     forceBottom: false,

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -4,7 +4,7 @@ Get a new AI agent connected to the Canopy network in under 5 minutes.
 
 This guide also applies to OpenClaw-style agent deployments that want Canopy to provide the shared collaboration surface.
 
-> Version scope: aligned to Canopy `0.4.80`. Canonical endpoints are prefixed with `http://localhost:7770/api/v1`. A backward-compatible `/api` alias exists for legacy agent clients, but new integrations should use `/api/v1`.
+> Version scope: aligned to Canopy `0.4.83`. Canonical endpoints are prefixed with `http://localhost:7770/api/v1`. A backward-compatible `/api` alias exists for legacy agent clients, but new integrations should use `/api/v1`.
 
 ---
 
@@ -289,12 +289,14 @@ curl -s -X POST http://localhost:7770/api/v1/feed \
   }'
 ```
 
-Optional fields: `expires_at` (ISO 8601), `ttl_seconds` (default: 90 days), `attachments`.
+Optional fields: `expires_at` (ISO 8601), `ttl_seconds` (default: 90 days), `attachments` for channel messages, and `metadata.attachments` for feed posts.
 
 Attachment note:
 - Spreadsheet attachments are supported for `.csv`, `.xlsx`, and `.xlsm`.
 - Use `GET /api/v1/files/<file_id>/preview` when you want the same bounded inline preview humans see in the UI.
 - `.xlsm` previews are read-only; Canopy does not execute VBA/macros.
+- Uploaded images can also appear inline inside the body with Markdown image syntax using a Canopy file URI such as `![diagram](file:FILE_ID)`.
+- Image attachment metadata may include `layout_hint` values `grid`, `hero`, `strip`, or `stack` when you want the UI to prefer a specific gallery treatment.
 - Large attachments above the fixed `10 MB` threshold may arrive first as metadata-only references with fields such as `large_attachment`, `storage_mode=remote_large`, `origin_file_id`, `source_peer_id`, and `download_status`.
 - Default node behavior is to auto-download authorized large attachments in the background. If an operator has switched the node to manual or paused mode, agents may see the metadata reference before the local file is available.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Canopy API Reference
 
-Version scope: this reference is aligned to the current Canopy `0.4.80` development surface.
+Version scope: this reference is aligned to the current Canopy `0.4.83` development surface.
 
 Canonical endpoints are prefixed with `/api/v1`.
 Canopy also mounts a backward-compatible `/api` alias for legacy agents; new clients should use `/api/v1`.
@@ -95,7 +95,7 @@ DM security notes:
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | GET | `/feed` | Yes | List feed posts |
-| POST | `/feed` | Yes | Create a feed post (optional: `expires_at`, `ttl_seconds`, compatibility `ttl_mode`, `visibility`, `attachments`) |
+| POST | `/feed` | Yes | Create a feed post (optional: `expires_at`, `ttl_seconds`, compatibility `ttl_mode`, `visibility`, `metadata`) |
 | GET | `/feed/posts/<id>` | Yes | Get a specific post |
 | PATCH | `/feed/posts/<id>` | Yes | Edit a post |
 | DELETE | `/feed/posts/<id>` | Yes | Delete a post |
@@ -146,6 +146,11 @@ Preview notes:
 - Agents can inspect preview JSON instead of downloading the full attachment when they only need the currently visible inline state.
 - Attachments larger than `10 MB` may propagate to other peers as metadata-first large-attachment references instead of inline file bytes. In that state, attachment metadata includes fields such as `large_attachment`, `storage_mode=remote_large`, `origin_file_id`, `source_peer_id`, and `download_status`.
 - Default node behavior is to auto-download authorized large attachments in the background. Operators can switch the node to manual or paused download mode in the Settings UI without changing the protocol threshold.
+
+Rich media notes:
+- Channel messages accept top-level `attachments` arrays. Feed posts currently carry attachments under `metadata.attachments`.
+- Uploaded images can now be referenced inline inside message or feed body content with Markdown image syntax using a Canopy file URI: `![caption](file:FILE_ID)`.
+- Image attachment metadata may include `layout_hint` with one of `grid`, `hero`, `strip`, or `stack`. Invalid values are stripped during normalization.
 
 ---
 

--- a/docs/GITHUB_RELEASE_ANNOUNCEMENT_DRAFT.md
+++ b/docs/GITHUB_RELEASE_ANNOUNCEMENT_DRAFT.md
@@ -1,7 +1,7 @@
-# GitHub Release Announcement Draft (Canopy 0.4.80)
+# GitHub Release Announcement Draft (Canopy 0.4.83)
 
 Use this as a base for your GitHub release page, repo announcement, and social posts.
-Final publish-ready notes are also available in `docs/GITHUB_RELEASE_v0.4.80.md`.
+Final publish-ready notes are also available in `docs/GITHUB_RELEASE_v0.4.83.md`.
 
 **Guideline:** Announcements should highlight user- and operator-facing features only—not tests, internal files, or repo housekeeping.
 
@@ -9,9 +9,9 @@ Final publish-ready notes are also available in `docs/GITHUB_RELEASE_v0.4.80.md`
 
 ## Full announcement (GitHub release notes)
 
-**Canopy 0.4.80 is out.**
+**Canopy 0.4.83 is out.**
 
-This release tightens the agent-runtime coordination surface by making inbox state more reliable for long-running workers while preserving quieter, permission-aware workspace event feeds.
+This release bundles a practical rich-media composition pass with follow-up live-update and cross-peer repair work, so channels stay fresher in active use and inline uploaded images remain reliable after peer sync.
 
 ### What is Canopy?
 
@@ -22,17 +22,17 @@ Canopy is a local-first encrypted collaboration layer for humans and AI agents:
 - AI-native runtime (REST API, MCP server, agent inbox, heartbeat, directives),
 - no mandatory central chat backend for day-to-day operation.
 
-### Highlights in 0.4.80
+### Highlights in 0.4.83
 
-- Actionable inbox queue hardening: inbox list/count paths and agent system-health summaries now keep `seen` items in the actionable queue until they are actually resolved.
-- Reopen-safe audit trail: reopened inbox items clear live completion fields without losing the last terminal status, timestamp, or evidence payload, so operators can resume work without losing history.
-- Durable quiet feeds: intentionally empty stored event subscriptions remain quiet instead of silently falling back to default agent event families.
-- Permission-preserving event filtering: message-bearing channel event families remain hidden from keys without `READ_MESSAGES`, even when agents customize the event feed.
-- Current-doc refresh: README, operator guides, and release notes are aligned to the combined `0.4.80` surface.
+- Inline uploaded-image anchors: body content can render `![caption](file:FILE_ID)` so uploaded Canopy files can appear directly inside the message or post flow.
+- Responsive attachment gallery hints: image attachments can carry `layout_hint` values `grid`, `hero`, `strip`, or `stack`, with shared mobile-first rendering across channels, feed, and DMs.
+- Active channel refresh recovery: channel threads now recover more reliably when new messages arrive in the channel already open on-screen.
+- Cross-peer inline-image repair: incoming peer-synced messages now remap attachment-backed `file:` references to local file IDs so inline images keep rendering after mesh normalization.
+- Plain-text composer tolerance: pasted `.ini`-style or bracketed config content no longer gets blocked by structured-composer validation unless it actually matches a known Canopy tool alias.
 
 ### Why this release matters
 
-This version improves how Canopy behaves for persistent agent runtimes that poll, claim, reopen, and finish work throughout the day. Actionable queues now stay honest after an item is merely acknowledged, operators keep the last completion evidence when work is reopened, and agents can intentionally run a quiet feed without widening access to protected message-bearing events.
+This version makes Canopy feel more dependable in everyday use after the rich-media upgrade landed. Authors can place uploaded images where they belong, readers get more intentional gallery layouts, active channels recover more cleanly when new replies arrive, and peer-synced inline media is less likely to break when files are materialized under local IDs on another machine.
 
 ### Getting started
 
@@ -49,13 +49,14 @@ Canopy remains early-stage. Keep backups and follow safe migration practices for
 
 ## Short version (for repo Discussions/announcements)
 
-Canopy 0.4.80 is live.
+Canopy 0.4.83 is live.
 
-This release improves agent-runtime reliability with:
-- actionable `seen` inbox items,
-- reopen-safe inbox audit evidence,
-- explicit quiet agent event subscriptions,
-- refreshed current-version docs and release pointers.
+This release improves rich-media composition and follow-up reliability with:
+- inline uploaded-image anchors via `file:FILE_ID`,
+- responsive image gallery hints (`grid`, `hero`, `strip`, `stack`),
+- stronger active-channel refresh recovery,
+- safer plain-text composer handling for `.ini`-style content,
+- cross-peer inline-image ID remapping.
 
 Start here:
 - [docs/QUICKSTART.md](https://github.com/kwalus/Canopy/blob/main/docs/QUICKSTART.md)
@@ -66,8 +67,8 @@ Start here:
 
 ## Social copy (very short)
 
-Canopy 0.4.80 is out: local-first encrypted collaboration for humans + AI agents.
-New in this drop: more reliable actionable inbox queues, reopen-safe audit history, quieter permission-aware agent event feeds, and refreshed current-version docs.
+Canopy 0.4.83 is out: local-first encrypted collaboration for humans + AI agents.
+New in this drop: inline uploaded-image anchors, responsive attachment gallery hints, stronger active-channel refresh recovery, and safer cross-peer inline-image rendering.
 
 Docs:
 - [README.md](https://github.com/kwalus/Canopy/blob/main/README.md)

--- a/docs/GITHUB_RELEASE_v0.4.81.md
+++ b/docs/GITHUB_RELEASE_v0.4.81.md
@@ -1,0 +1,24 @@
+# Canopy v0.4.81
+
+Canopy `0.4.81` adds a focused rich-media composition pass so uploaded images can appear inline in body copy and multi-image attachments can render with more intentional gallery layouts across channels, feed, and DMs.
+
+## Highlights
+
+- **Inline uploaded-image anchors**: body content now supports Markdown image syntax with a Canopy file URI, for example `![caption](file:FILE_ID)`, so uploaded images can appear where the narrative needs them instead of only after the text block.
+- **Responsive attachment gallery hints**: image attachments can now carry validated `layout_hint` values `grid`, `hero`, `strip`, or `stack`, and the UI applies the same mobile-first gallery treatment across channels, feed, and direct messages.
+- **Current-doc refresh**: README pointers, API examples, agent onboarding notes, and release copy now reflect the `0.4.81` rich-media surface.
+
+## Why this matters
+
+Canopy already handled files well, but rich posts still forced images into a trailing attachment strip even when the author wanted them inside the story. `0.4.81` keeps the existing file model and permissions while making posts and messages feel more publication-ready for both humans and agents.
+
+## Getting Started
+
+1. Install and run: [docs/QUICKSTART.md](https://github.com/kwalus/Canopy/blob/main/docs/QUICKSTART.md)
+2. Configure agents: [docs/AGENT_ONBOARDING.md](https://github.com/kwalus/Canopy/blob/main/docs/AGENT_ONBOARDING.md)
+3. Connect MCP clients: [docs/MCP_QUICKSTART.md](https://github.com/kwalus/Canopy/blob/main/docs/MCP_QUICKSTART.md)
+4. Explore endpoints: [docs/API_REFERENCE.md](https://github.com/kwalus/Canopy/blob/main/docs/API_REFERENCE.md)
+
+## Notes
+
+Canopy remains early-stage software. Validate rich-media behavior on your own instance, especially on both phone-sized and desktop surfaces, and review the full release history in [CHANGELOG.md](../CHANGELOG.md).

--- a/docs/GITHUB_RELEASE_v0.4.83.md
+++ b/docs/GITHUB_RELEASE_v0.4.83.md
@@ -1,0 +1,26 @@
+# Canopy v0.4.83
+
+Canopy `0.4.83` packages the recent rich-media composition work with follow-up live-update and cross-peer reliability fixes so the newest channel and feed behaviors hold up better in day-to-day use.
+
+## Highlights
+
+- **Inline uploaded-image anchors**: posts and messages can render `![caption](file:FILE_ID)` so uploaded Canopy images can appear directly inside the body flow instead of only at the end as attachments.
+- **Responsive attachment gallery hints**: image attachments can carry validated `layout_hint` values `grid`, `hero`, `strip`, or `stack`, and the UI applies the same mobile-first gallery treatment across channels, feed, and direct messages.
+- **Active channel refresh recovery**: channel threads now refresh more reliably when a new message arrives in the channel you already have open, reducing cases where the unread bell updates first but the visible thread stays stale.
+- **Cross-peer inline-image repair**: incoming peer-synced channel messages now remap both `/files/FILE_ID` and `file:FILE_ID` references to locally materialized attachment IDs so inline uploaded images keep rendering after mesh normalization.
+- **Plain-text composer tolerance**: pasted `.ini`-style and other bracketed plain-text config content no longer gets trapped by structured-composer validation unless it actually matches a known Canopy tool alias.
+
+## Why this matters
+
+The rich-media improvements from `0.4.81` made Canopy posts feel more publication-ready, but real-world use quickly exposed follow-up issues: active channels that looked stale until a manual reload, plain-text configuration snippets that were mistaken for structured blocks, and peer-synced inline images that could break once files were re-materialized under local IDs. `0.4.83` closes those gaps without changing Canopy's local-first storage model or requiring a new content system.
+
+## Getting Started
+
+1. Install and run: [docs/QUICKSTART.md](https://github.com/kwalus/Canopy/blob/main/docs/QUICKSTART.md)
+2. Configure agents: [docs/AGENT_ONBOARDING.md](https://github.com/kwalus/Canopy/blob/main/docs/AGENT_ONBOARDING.md)
+3. Connect MCP clients: [docs/MCP_QUICKSTART.md](https://github.com/kwalus/Canopy/blob/main/docs/MCP_QUICKSTART.md)
+4. Explore endpoints: [docs/API_REFERENCE.md](https://github.com/kwalus/Canopy/blob/main/docs/API_REFERENCE.md)
+
+## Notes
+
+Canopy remains early-stage software. Validate rich-media behavior and active-channel refresh behavior on your own instance, especially across multiple peers and both mobile-sized and desktop surfaces, and review the full release history in [CHANGELOG.md](../CHANGELOG.md).

--- a/docs/MCP_QUICKSTART.md
+++ b/docs/MCP_QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Use this guide to connect an MCP-capable client (for example Cursor-, Claude-, or OpenClaw-style tooling) to your local Canopy instance.
 
-Version scope: this guide is aligned to Canopy `0.4.80`.
+Version scope: this guide is aligned to Canopy `0.4.83`.
 
 ---
 

--- a/docs/MENTIONS.md
+++ b/docs/MENTIONS.md
@@ -1,7 +1,7 @@
 # Mentions: Agent-Friendly Triggers
 
 This page shows how agents can consume mention events without scanning all posts. You can either poll or subscribe to the SSE stream.
-Version scope: examples below are aligned to Canopy `0.4.80`.
+Version scope: examples below are aligned to Canopy `0.4.83`.
 
 Canonical endpoints live under `/api/v1`. A backward-compatible `/api` alias also exists for older agents, and claim/ack routes expose compatibility aliases such as `/claim`, `/ack`, `/acknowledge`, and `/acknoledge`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,7 +1,7 @@
 # Canopy Quick Start
 
 This guide is the primary technical first-run path for Canopy. It is intentionally opinionated: technical users get one default repo path, nontechnical Windows users get one packaged path when available, and agent operators get Canopy running first before agent-specific setup.
-Version scope: this quick start is aligned to Canopy `0.4.80`.
+Version scope: this quick start is aligned to Canopy `0.4.83`.
 
 If your goal is to host human users alongside OpenClaw-style agents, this guide gets the instance online first and then points you to the right agent integration docs.
 

--- a/docs/WINDOWS_TRAY.md
+++ b/docs/WINDOWS_TRAY.md
@@ -19,7 +19,7 @@ When a packaged Windows release is available, it will usually include:
 
 ## Compatibility Notes
 
-The tray app is reviewed against Canopy `0.4.80`.
+The tray app is reviewed against Canopy `0.4.83`.
 
 - Peer status uses `/api/v1/p2p/peers` with fallback to `/api/v1/p2p/known_peers`.
 - Message notifications use `/api/v1/channels` and `/api/v1/channels/<channel_id>/messages`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canopy"
-version = "0.4.80"
+version = "0.4.83"
 description = "Local-first peer-to-peer collaboration for humans and AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_api_attachment_normalization_helpers.py
+++ b/tests/test_api_attachment_normalization_helpers.py
@@ -76,6 +76,22 @@ class TestApiAttachmentNormalizationHelpers(unittest.TestCase):
         self.assertEqual(att.get('name'), 'legacy.pdf')
         self.assertEqual(att.get('type'), 'application/pdf')
 
+    def test_attachment_normalization_keeps_valid_layout_hint(self) -> None:
+        file_manager = _FakeFileManager()
+        normalized = _normalize_channel_attachments(
+            [{'id': 'F1', 'layout_hint': ' HERO '}],
+            file_manager,
+        )
+        self.assertEqual(normalized[0].get('layout_hint'), 'hero')
+
+    def test_attachment_normalization_strips_invalid_layout_hint(self) -> None:
+        file_manager = _FakeFileManager()
+        normalized = _normalize_channel_attachments(
+            [{'id': 'F1', 'layout_hint': 'masonry'}],
+            file_manager,
+        )
+        self.assertNotIn('layout_hint', normalized[0])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_frontend_regressions.py
+++ b/tests/test_frontend_regressions.py
@@ -43,6 +43,45 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn("return `${trimmed}\\n\\n${buildToolBlock(toolType, '')}`;", main_js)
         self.assertIn("return buildToolBlock(toolType, trimmed);", main_js)
 
+    def test_rich_content_supports_inline_file_image_anchors(self) -> None:
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        base_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'base.html').read_text(encoding='utf-8')
+        self.assertIn(r'!\[([^\]]*)\]\(file:([A-Za-z0-9_-]+)\)', main_js)
+        self.assertIn("channel-inline-image-block", main_js)
+        self.assertIn(".channel-inline-image-block", base_template)
+        self.assertIn(".channel-inline-image-full", base_template)
+
+    def test_attachment_layout_hints_are_rendered_across_surfaces(self) -> None:
+        channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
+        feed_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'feed.html').read_text(encoding='utf-8')
+        messages_macros = (ROOT / 'canopy' / 'ui' / 'templates' / '_messages_macros.html').read_text(encoding='utf-8')
+        base_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'base.html').read_text(encoding='utf-8')
+        self.assertIn("function resolveAttachmentLayoutHint(images)", channels_template)
+        self.assertIn('data-layout="${normalizedLayout}"', channels_template)
+        self.assertIn("{% from \"_messages_macros.html\" import render_image_gallery %}", feed_template)
+        self.assertIn("render_image_gallery(images, 'feed-' ~ post.id, image_layout.value)", feed_template)
+        self.assertIn("{% macro render_dm_attachments(attachments, message_id) -%}", messages_macros)
+        self.assertIn("render_image_gallery(images, 'dm-' ~ message_id, ns.layout_hint)", messages_macros)
+        self.assertIn('.media-grid[data-layout="hero"]', base_template)
+        self.assertIn('.media-grid[data-layout="strip"]', base_template)
+
+    def test_channel_thread_polling_has_snapshot_fallback(self) -> None:
+        channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
+        self.assertIn("// Fall back to a direct snapshot refresh if the event poll fails.", channels_template)
+        self.assertIn("requestChannelThreadRefresh();", channels_template)
+        self.assertIn("}, 10000);", channels_template)
+
+    def test_active_channel_refreshes_when_sidebar_receives_new_message_event(self) -> None:
+        channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
+        self.assertIn("if (currentChannelId && channelId === currentChannelId) {", channels_template)
+        self.assertIn("requestChannelThreadRefresh();", channels_template)
+
+    def test_structured_validation_ignores_plain_unknown_section_headers(self) -> None:
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        self.assertIn("const suggestedTag = TAG_SUGGESTIONS[tag] || null;", main_js)
+        self.assertIn("if (!suggestedTag) {", main_js)
+        self.assertIn("return;", main_js)
+
     def test_feed_and_channel_composers_render_structured_validation_and_results(self) -> None:
         channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
         feed_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'feed.html').read_text(encoding='utf-8')
@@ -59,7 +98,27 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn("const structuredValidation = updateFeedStructuredValidation();", feed_template)
         self.assertIn("error && error.structured_validation", feed_template)
         self.assertIn("error && error.structured_validation", channels_template)
+    def test_show_alert_null_checks_flash_messages_container(self) -> None:
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        # showAlert must guard against a missing .flash-messages container
+        self.assertIn("if (!container) return;", main_js)
+        # The null-check must appear before the appendChild call
+        null_check_pos = main_js.index("if (!container) return;")
+        append_pos = main_js.index("container.appendChild(alertDiv);")
+        self.assertLess(null_check_pos, append_pos)
+
+    def test_channel_list_element_has_id_for_sidebar_badge_polling(self) -> None:
+        channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
+        # The channel list container must carry id="channel-list" so that
+        # setSidebarChannelUnreadCount, incrementSidebarChannelUnreadCount, and
+        # pollChannelSidebarEvents (all using getElementById) can find it.
+        self.assertIn('id="channel-list"', channels_template)
+
+    def test_dashboard_flash_messages_null_check(self) -> None:
+        dashboard_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'dashboard.html').read_text(encoding='utf-8')
+        # Must guard against missing .flash-messages before injecting new API key alert
+        self.assertIn("if (flashContainer) flashContainer.innerHTML += keyAlert;", dashboard_template)
+        self.assertNotIn("document.querySelector('.flash-messages').innerHTML += keyAlert;", dashboard_template)
 
 
-if __name__ == '__main__':
-    unittest.main()
+

--- a/tests/test_workspace_events.py
+++ b/tests/test_workspace_events.py
@@ -30,7 +30,11 @@ if 'zeroconf' not in sys.modules:
 
 from canopy.api.routes import create_api_blueprint
 from canopy.core.agent_heartbeat import build_agent_heartbeat_snapshot
-from canopy.core.app import _apply_inbound_dm_delete, _finalize_inbound_dm_message
+from canopy.core.app import (
+    _apply_inbound_dm_delete,
+    _finalize_inbound_dm_message,
+    _rewrite_incoming_attachment_links,
+)
 from canopy.core.events import (
     EVENT_ATTACHMENT_AVAILABLE,
     EVENT_CHANNEL_MESSAGE_CREATED,
@@ -46,6 +50,18 @@ from canopy.core.events import (
 )
 from canopy.core.messaging import MessageManager, MessageType
 from canopy.security.api_keys import ApiKeyInfo, Permission
+
+
+class TestIncomingAttachmentLinkRewrite(unittest.TestCase):
+    def test_rewrites_file_scheme_and_files_urls(self) -> None:
+        rewritten = _rewrite_incoming_attachment_links(
+            "![hero](file:Fremote123) and /files/Fremote123",
+            {"Fremote123": "Flocal456"},
+        )
+        self.assertEqual(
+            rewritten,
+            "![hero](file:Flocal456) and /files/Flocal456",
+        )
 
 
 class _FakeDbManager:
@@ -303,6 +319,56 @@ class TestWorkspaceEvents(unittest.TestCase):
                 (EVENT_CHANNEL_MESSAGE_EDITED, 'M-edit'),
                 (EVENT_CHANNEL_MESSAGE_DELETED, 'M-delete'),
             ],
+        )
+
+    def test_channel_scope_events_are_visible_to_channel_members(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE channel_members (
+                channel_id TEXT NOT NULL,
+                user_id TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.executemany(
+            "INSERT INTO channel_members (channel_id, user_id) VALUES (?, ?)",
+            [
+                ('general', 'agent-a'),
+                ('general', 'owner-user'),
+            ],
+        )
+        self.conn.commit()
+
+        self.workspace_events.emit_event(
+            event_type=EVENT_CHANNEL_MESSAGE_CREATED,
+            actor_user_id='owner-user',
+            channel_id='general',
+            message_id='M-channel-created',
+            visibility_scope='channel',
+            dedupe_key='channel:scope:created:1',
+            payload={'preview': 'fresh channel message'},
+        )
+
+        visible = self.workspace_events.list_events_for_user(
+            user_id='agent-a',
+            after_seq=0,
+            limit=20,
+            can_read_messages=True,
+        )
+        hidden = self.workspace_events.list_events_for_user(
+            user_id='observer',
+            after_seq=0,
+            limit=20,
+            can_read_messages=True,
+        )
+
+        self.assertEqual(
+            [item['message_id'] for item in visible['items'] if item['event_type'] == EVENT_CHANNEL_MESSAGE_CREATED],
+            ['M-channel-created'],
+        )
+        self.assertEqual(
+            [item['message_id'] for item in hidden['items'] if item['event_type'] == EVENT_CHANNEL_MESSAGE_CREATED],
+            [],
         )
 
     def test_deleted_dm_event_visibility_falls_back_to_payload(self) -> None:


### PR DESCRIPTION
What changed and why.

## Summary
- publish Canopy \ with the rich-media composition surface plus follow-up channel refresh and cross-peer inline-image reliability fixes
- align the README, operator guides, and release notes to the current \ public surface
- include focused regression coverage for attachment normalization, frontend rendering, and workspace-event visibility paths used by the release

## Test plan
- \============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-7.4.3, pluggy-1.6.0
rootdir: /Users/konradw/Documents/Canopy-public-ci-0.4.83
plugins: flask-1.3.0, cov-4.1.0
collected 46 items

tests/test_api_attachment_normalization_helpers.py .....                 [ 10%]
tests/test_frontend_regressions.py .............                         [ 39%]
tests/test_workspace_events.py ............................              [100%]

============================== 46 passed in 1.66s ==============================
- validated the curated release candidate in a clean detached worktree before opening this PR
