### PR TITLE
feat: sidebar unread badges, notification deep-link, bell dedup (0.4.90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.4.90] - 2026-03-16
+
+### Added
+- **Sidebar unread badges** - Left-rail navigation items for Messages, Channels, and Social Feed now show aggregate unread counts as compact pill badges that update via periodic polling and on window focus. Zero-state badges are hidden; counts cap visually at `99+`.
+- **Durable feed-view acknowledgement** - Opening the Social Feed records a per-user acknowledgement timestamp so the feed unread badge reflects genuinely new activity since the last visit. Own-authored posts are excluded from the unread count.
+- **Notification deep-link to exact messages** - Bell notification clicks for channel messages now navigate to the exact target message via a server-side focused context window, even when the message is older than the recent page. DM bell clicks include a `#message-<id>` anchor for exact-message scrolling.
+- **Container-aware focus scrolling** - Channel message focus now uses measured offsets within `#messages-container` instead of `scrollIntoView()`, and retries shortly after render to absorb layout shifts from async hydration.
+
+### Fixed
+- **Bell duplicate counting for mention-bearing messages** - The notification bell now deduplicates by semantic activity key so a `channel_message` event and a `mention` event for the same source message increment the unread badge only once, with the higher-priority event winning the display slot.
+
 ## [0.4.89] - 2026-03-15
 
 ### Added

--- a/canopy/__init__.py
+++ b/canopy/__init__.py
@@ -11,7 +11,7 @@ License: Apache 2.0
 Development: AI-assisted implementation (Claude, Codex, GitHub Copilot, Cursor IDE, Ollama)
 """
 
-__version__ = "0.4.89"
+__version__ = "0.4.90"
 __protocol_version__ = 1
 __author__ = "Canopy Contributors"
 __license__ = "Apache-2.0"

--- a/canopy/core/channels.py
+++ b/canopy/core/channels.py
@@ -4424,11 +4424,112 @@ class ChannelManager:
 
         return purged
 
-    def get_channel_messages(self, channel_id: str, user_id: str, 
+    def _row_to_channel_message(self, row: Any, row_type: str = "message") -> Optional[Message]:
+        """Best-effort row parser used across channel message query paths."""
+        try:
+            try:
+                msg_type = MessageType(row['message_type'])
+            except (ValueError, KeyError):
+                msg_type = MessageType.TEXT
+
+            created_at_raw = row['created_at'] or ''
+            try:
+                created_at = datetime.fromisoformat(created_at_raw.replace('Z', '+00:00'))
+            except (ValueError, AttributeError):
+                try:
+                    created_at = datetime.strptime(created_at_raw, '%Y-%m-%d %H:%M:%S')
+                except Exception:
+                    created_at = datetime.now()
+
+            edited_at = None
+            if row['edited_at']:
+                try:
+                    edited_at = datetime.fromisoformat(row['edited_at'].replace('Z', '+00:00'))
+                except (ValueError, AttributeError):
+                    pass
+
+            expires_at = self._parse_datetime(row['expires_at']) if 'expires_at' in row.keys() else None
+            content_text = row['content'] or ''
+            try:
+                crypto_state = (row['crypto_state'] or '').strip().lower()
+            except Exception:
+                crypto_state = ''
+            if not content_text and crypto_state == 'pending_decrypt':
+                content_text = '[Encrypted message pending key]'
+            elif not content_text and crypto_state == 'decrypt_failed':
+                content_text = '[Encrypted message could not be decrypted]'
+
+            return Message(
+                id=row['id'],
+                channel_id=row['channel_id'],
+                user_id=row['user_id'],
+                content=content_text,
+                message_type=msg_type,
+                created_at=created_at,
+                thread_id=row['thread_id'],
+                parent_message_id=row['parent_message_id'],
+                reactions=json.loads(row['reactions']) if row['reactions'] else None,
+                attachments=json.loads(row['attachments']) if row['attachments'] else None,
+                security=json.loads(row['security']) if row['security'] else None,
+                edited_at=edited_at,
+                expires_at=expires_at,
+                origin_peer=row['origin_peer'] if 'origin_peer' in row.keys() else None,
+                crypto_state=row['crypto_state'] if 'crypto_state' in row.keys() else None,
+            )
+        except Exception as row_err:
+            row_id = '?'
+            try:
+                row_id = row['id'] if 'id' in row.keys() else '?'
+            except Exception:
+                row_id = '?'
+            logger.warning(f"Skipping corrupt {row_type} row {row_id}: {row_err}")
+            return None
+
+    def _hydrate_missing_parent_messages(
+        self,
+        conn: Any,
+        channel_id: str,
+        messages: List[Message],
+    ) -> List[Message]:
+        """Append missing parent/ancestor messages so replies render with context."""
+        msg_ids = {m.id for m in messages}
+        missing_parent_ids = {
+            m.parent_message_id
+            for m in messages
+            if m.parent_message_id and m.parent_message_id not in msg_ids
+        }
+        while missing_parent_ids:
+            placeholders = ",".join("?" * len(missing_parent_ids))
+            parent_rows = conn.execute(
+                f"""
+                SELECT m.*, u.username as author_username
+                FROM channel_messages m
+                LEFT JOIN users u ON m.user_id = u.id
+                WHERE m.channel_id = ? AND m.id IN ({placeholders})
+                  AND (m.expires_at IS NULL OR m.expires_at > CURRENT_TIMESTAMP)
+                """,
+                [channel_id] + list(missing_parent_ids),
+            ).fetchall()
+            if not parent_rows:
+                break
+
+            next_missing_parent_ids = set()
+            for row in parent_rows:
+                message = self._row_to_channel_message(row, "parent")
+                if not message or message.id in msg_ids:
+                    continue
+                messages.append(message)
+                msg_ids.add(message.id)
+                if message.parent_message_id and message.parent_message_id not in msg_ids:
+                    next_missing_parent_ids.add(message.parent_message_id)
+            missing_parent_ids = next_missing_parent_ids
+        return messages
+
+    def get_channel_messages(self, channel_id: str, user_id: str,
                            limit: int = 50, before_message_id: Optional[str] = None) -> List[Message]:
         """Get messages from a channel."""
         logger.debug(f"Getting messages for channel {channel_id}, user {user_id}, limit {limit}")
-        
+
         try:
             access = self.get_channel_access_decision(
                 channel_id=channel_id,
@@ -4443,9 +4544,6 @@ class ChannelManager:
                 return []
 
             with self.db.get_connection() as conn:
-                # Build query — sort root messages by activity time
-                # (resurfaced parents appear at the bottom/newest position).
-                # Replies sort with their parent via COALESCE on the parent row.
                 sort_expr = """
                     CASE
                         WHEN m.parent_message_id IS NOT NULL THEN
@@ -4477,11 +4575,8 @@ class ChannelManager:
                       AND (m.expires_at IS NULL OR m.expires_at > CURRENT_TIMESTAMP)
                 """
                 params: List[Any] = [channel_id]
-                
+
                 if before_message_id:
-                    # Pagination must use the same sort tuple as ORDER BY to
-                    # avoid gaps/duplicates when old threads are resurfaced by
-                    # new replies.
                     query += f"""
                         AND (
                             {sort_expr} < (
@@ -4508,124 +4603,116 @@ class ChannelManager:
                         before_message_id,
                         before_message_id,
                     ])
-                
+
                 query += " ORDER BY sort_time DESC, m.created_at DESC LIMIT ?"
                 params.append(limit)
-                
-                cursor = conn.execute(query, params)
-                rows = cursor.fetchall()
-                
-                def _row_to_message(row: Any, row_type: str = "message") -> Optional[Message]:
-                    """Best-effort row parser used for primary query rows and recursively fetched parents."""
-                    try:
-                        try:
-                            msg_type = MessageType(row['message_type'])
-                        except (ValueError, KeyError):
-                            msg_type = MessageType.TEXT
 
-                        created_at_raw = row['created_at'] or ''
-                        try:
-                            created_at = datetime.fromisoformat(created_at_raw.replace('Z', '+00:00'))
-                        except (ValueError, AttributeError):
-                            try:
-                                created_at = datetime.strptime(created_at_raw, '%Y-%m-%d %H:%M:%S')
-                            except Exception:
-                                created_at = datetime.now()
-
-                        edited_at = None
-                        if row['edited_at']:
-                            try:
-                                edited_at = datetime.fromisoformat(row['edited_at'].replace('Z', '+00:00'))
-                            except (ValueError, AttributeError):
-                                pass
-
-                        expires_at = self._parse_datetime(row['expires_at']) if 'expires_at' in row.keys() else None
-                        content_text = row['content'] or ''
-                        try:
-                            crypto_state = (row['crypto_state'] or '').strip().lower()
-                        except Exception:
-                            crypto_state = ''
-                        if not content_text and crypto_state == 'pending_decrypt':
-                            content_text = '[Encrypted message pending key]'
-                        elif not content_text and crypto_state == 'decrypt_failed':
-                            content_text = '[Encrypted message could not be decrypted]'
-
-                        return Message(
-                            id=row['id'],
-                            channel_id=row['channel_id'],
-                            user_id=row['user_id'],
-                            content=content_text,
-                            message_type=msg_type,
-                            created_at=created_at,
-                            thread_id=row['thread_id'],
-                            parent_message_id=row['parent_message_id'],
-                            reactions=json.loads(row['reactions']) if row['reactions'] else None,
-                            attachments=json.loads(row['attachments']) if row['attachments'] else None,
-                            security=json.loads(row['security']) if row['security'] else None,
-                            edited_at=edited_at,
-                            expires_at=expires_at,
-                            origin_peer=row['origin_peer'] if 'origin_peer' in row.keys() else None,
-                            crypto_state=row['crypto_state'] if 'crypto_state' in row.keys() else None,
-                        )
-                    except Exception as row_err:
-                        row_id = '?'
-                        try:
-                            row_id = row['id'] if 'id' in row.keys() else '?'
-                        except Exception:
-                            row_id = '?'
-                        logger.warning(f"Skipping corrupt {row_type} row {row_id}: {row_err}")
-                        return None
-
-                # Convert to Message objects (skip corrupt rows gracefully)
+                rows = conn.execute(query, params).fetchall()
                 messages: List[Message] = []
                 for row in rows:
-                    message = _row_to_message(row, "message")
+                    message = self._row_to_channel_message(row, "message")
                     if message:
                         messages.append(message)
-                
-                # Reverse to get chronological order
+
                 messages.reverse()
-
-                # Include any missing parent/ancestor messages so replies render under the correct post.
-                # This walks parent chains recursively; one-level hydration can orphan deep reply chains.
-                msg_ids = {m.id for m in messages}
-                missing_parent_ids = {
-                    m.parent_message_id
-                    for m in messages
-                    if m.parent_message_id and m.parent_message_id not in msg_ids
-                }
-                while missing_parent_ids:
-                    placeholders = ",".join("?" * len(missing_parent_ids))
-                    parent_rows = conn.execute(
-                        f"""
-                        SELECT m.*, u.username as author_username
-                        FROM channel_messages m
-                        LEFT JOIN users u ON m.user_id = u.id
-                        WHERE m.channel_id = ? AND m.id IN ({placeholders})
-                          AND (m.expires_at IS NULL OR m.expires_at > CURRENT_TIMESTAMP)
-                        """,
-                        [channel_id] + list(missing_parent_ids),
-                    ).fetchall()
-                    if not parent_rows:
-                        break
-
-                    next_missing_parent_ids = set()
-                    for row in parent_rows:
-                        message = _row_to_message(row, "parent")
-                        if not message or message.id in msg_ids:
-                            continue
-                        messages.append(message)
-                        msg_ids.add(message.id)
-                        if message.parent_message_id and message.parent_message_id not in msg_ids:
-                            next_missing_parent_ids.add(message.parent_message_id)
-                    # Keep original page ordering stable for pagination cursors and only append ancestors.
-                    missing_parent_ids = next_missing_parent_ids
+                messages = self._hydrate_missing_parent_messages(conn, channel_id, messages)
 
                 logger.debug(f"Retrieved {len(messages)} messages from channel {channel_id}")
                 return messages
-                
+
         except Exception as e:
             logger.error(f"Failed to get channel messages: {e}", exc_info=True)
+            return []
+
+    def get_channel_message_context(
+        self,
+        channel_id: str,
+        message_id: str,
+        user_id: str,
+        radius: int = 12,
+    ) -> List[Message]:
+        """Return a focused message window around a specific message id."""
+        if not channel_id or not message_id or not user_id:
+            return []
+        try:
+            access = self.get_channel_access_decision(
+                channel_id=channel_id,
+                user_id=user_id,
+                require_membership=True,
+            )
+            if not access.get('allowed'):
+                return []
+
+            radius = max(1, min(int(radius or 12), 50))
+            with self.db.get_connection() as conn:
+                target_row = conn.execute(
+                    """
+                    SELECT m.*, u.username as author_username
+                    FROM channel_messages m
+                    LEFT JOIN users u ON m.user_id = u.id
+                    WHERE m.channel_id = ? AND m.id = ?
+                      AND (m.expires_at IS NULL OR m.expires_at > CURRENT_TIMESTAMP)
+                    LIMIT 1
+                    """,
+                    (channel_id, message_id),
+                ).fetchone()
+                if not target_row:
+                    return []
+
+                pivot_created_at = target_row['created_at']
+                before_rows = conn.execute(
+                    """
+                    SELECT m.*, u.username as author_username
+                    FROM channel_messages m
+                    LEFT JOIN users u ON m.user_id = u.id
+                    WHERE m.channel_id = ?
+                      AND (m.expires_at IS NULL OR m.expires_at > CURRENT_TIMESTAMP)
+                      AND m.created_at < ?
+                    ORDER BY m.created_at DESC
+                    LIMIT ?
+                    """,
+                    (channel_id, pivot_created_at, radius),
+                ).fetchall()
+                after_rows = conn.execute(
+                    """
+                    SELECT m.*, u.username as author_username
+                    FROM channel_messages m
+                    LEFT JOIN users u ON m.user_id = u.id
+                    WHERE m.channel_id = ?
+                      AND (m.expires_at IS NULL OR m.expires_at > CURRENT_TIMESTAMP)
+                      AND m.created_at > ?
+                    ORDER BY m.created_at ASC
+                    LIMIT ?
+                    """,
+                    (channel_id, pivot_created_at, radius),
+                ).fetchall()
+
+                rows: List[Any] = list(reversed(before_rows)) + [target_row] + list(after_rows)
+                messages: List[Message] = []
+                seen_ids: set[str] = set()
+                for row in rows:
+                    message = self._row_to_channel_message(row, "context")
+                    if not message or message.id in seen_ids:
+                        continue
+                    seen_ids.add(message.id)
+                    messages.append(message)
+
+                messages = self._hydrate_missing_parent_messages(conn, channel_id, messages)
+                messages.sort(
+                    key=lambda m: (
+                        (m.created_at.isoformat() if hasattr(m.created_at, 'isoformat') else str(m.created_at)),
+                        m.id,
+                    )
+                )
+                return messages
+        except Exception as e:
+            logger.error(
+                "Failed to get channel message context channel=%s message=%s: %s",
+                channel_id,
+                message_id,
+                e,
+                exc_info=True,
+            )
             return []
 
     def get_channel_message(
@@ -4653,42 +4740,7 @@ class ChannelManager:
                 ).fetchone()
                 if not row:
                     return None
-                try:
-                    msg_type = MessageType(row['message_type'])
-                except (ValueError, KeyError):
-                    msg_type = MessageType.TEXT
-                created_at_raw = row['created_at'] or ''
-                try:
-                    created_at = datetime.fromisoformat(created_at_raw.replace('Z', '+00:00'))
-                except (ValueError, AttributeError):
-                    try:
-                        created_at = datetime.strptime(created_at_raw, '%Y-%m-%d %H:%M:%S')
-                    except Exception:
-                        created_at = datetime.now()
-                edited_at = None
-                if row.get('edited_at'):
-                    try:
-                        edited_at = datetime.fromisoformat(str(row['edited_at']).replace('Z', '+00:00'))
-                    except (ValueError, AttributeError):
-                        pass
-                expires_at = self._parse_datetime(row['expires_at']) if row.get('expires_at') else None
-                return Message(
-                    id=row['id'],
-                    channel_id=row['channel_id'],
-                    user_id=row['user_id'],
-                    content=row['content'] or '',
-                    message_type=msg_type,
-                    created_at=created_at,
-                    thread_id=row.get('thread_id'),
-                    parent_message_id=row.get('parent_message_id'),
-                    reactions=json.loads(row['reactions']) if row.get('reactions') else None,
-                    attachments=json.loads(row['attachments']) if row.get('attachments') else None,
-                    security=json.loads(row['security']) if row.get('security') else None,
-                    edited_at=edited_at,
-                    expires_at=expires_at,
-                    origin_peer=row.get('origin_peer'),
-                    crypto_state=row.get('crypto_state'),
-                )
+                return self._row_to_channel_message(row, "single")
         except Exception as e:
             logger.error(f"Failed to get channel message {message_id}: {e}", exc_info=True)
             return None

--- a/canopy/core/database.py
+++ b/canopy/core/database.py
@@ -244,6 +244,7 @@ class DatabaseManager:
                 CREATE TABLE IF NOT EXISTS user_feed_preferences (
                     user_id TEXT PRIMARY KEY,
                     algorithm_json TEXT NOT NULL DEFAULT '{}',
+                    last_viewed_at TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     FOREIGN KEY (user_id) REFERENCES users (id)
                 );
@@ -263,7 +264,10 @@ class DatabaseManager:
                     status TEXT DEFAULT 'pending',
                     priority TEXT DEFAULT 'normal',
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    seen_at TIMESTAMP,
                     handled_at TIMESTAMP,
+                    completed_at TIMESTAMP,
+                    completion_ref_json TEXT,
                     expires_at TIMESTAMP,
                     triggered_by_inbox_id TEXT,
                     depth INTEGER DEFAULT 0,
@@ -323,6 +327,35 @@ class DatabaseManager:
                 );
                     CREATE INDEX IF NOT EXISTS idx_agent_presence_checkin
                     ON agent_presence(last_checkin_at);
+
+                CREATE TABLE IF NOT EXISTS agent_runtime_state (
+                    user_id TEXT PRIMARY KEY,
+                    last_event_fetch_at TIMESTAMP,
+                    last_event_cursor_seen INTEGER,
+                    last_inbox_fetch_at TIMESTAMP,
+                    updated_at TIMESTAMP NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_agent_runtime_event_fetch
+                    ON agent_runtime_state(last_event_fetch_at);
+                CREATE INDEX IF NOT EXISTS idx_agent_runtime_inbox_fetch
+                    ON agent_runtime_state(last_inbox_fetch_at);
+
+                CREATE TABLE IF NOT EXISTS agent_event_subscription_state (
+                    user_id TEXT PRIMARY KEY,
+                    custom_enabled INTEGER NOT NULL DEFAULT 0,
+                    updated_at TIMESTAMP NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_agent_event_subscription_state_enabled
+                    ON agent_event_subscription_state(custom_enabled, updated_at);
+
+                CREATE TABLE IF NOT EXISTS agent_event_subscriptions (
+                    user_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    updated_at TIMESTAMP NOT NULL,
+                    PRIMARY KEY (user_id, event_type)
+                );
+                CREATE INDEX IF NOT EXISTS idx_agent_event_subscriptions_user
+                    ON agent_event_subscriptions(user_id, updated_at);
 
                 -- Local workspace event journal (additive read/delivery model)
                 CREATE TABLE IF NOT EXISTS workspace_events (
@@ -631,6 +664,13 @@ class DatabaseManager:
             if 'status' in feed_columns:
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_feed_posts_status ON feed_posts(status)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_post_permissions_user ON post_permissions(user_id)")
+
+            cursor = conn.execute("PRAGMA table_info(user_feed_preferences)")
+            user_feed_pref_columns = [row[1] for row in cursor.fetchall()]
+            if 'last_viewed_at' not in user_feed_pref_columns:
+                logger.info("Migration: Adding last_viewed_at column to user_feed_preferences")
+                conn.execute("ALTER TABLE user_feed_preferences ADD COLUMN last_viewed_at TIMESTAMP")
+
             # channel_messages is created by ChannelManager — only add index if table exists
             cm_exists = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='channel_messages'"
@@ -703,6 +743,79 @@ class DatabaseManager:
                     CREATE INDEX IF NOT EXISTS idx_agent_presence_checkin
                         ON agent_presence(last_checkin_at);
                 """)
+
+            ars_exists = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_runtime_state'"
+            ).fetchone()
+            if not ars_exists:
+                logger.info("Migration: Creating agent_runtime_state table")
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS agent_runtime_state (
+                        user_id TEXT PRIMARY KEY,
+                        last_event_fetch_at TIMESTAMP,
+                        last_event_cursor_seen INTEGER,
+                        last_inbox_fetch_at TIMESTAMP,
+                        updated_at TIMESTAMP NOT NULL
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_agent_runtime_event_fetch
+                        ON agent_runtime_state(last_event_fetch_at);
+                    CREATE INDEX IF NOT EXISTS idx_agent_runtime_inbox_fetch
+                        ON agent_runtime_state(last_inbox_fetch_at);
+                """)
+
+            aess_exists = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_event_subscription_state'"
+            ).fetchone()
+            if not aess_exists:
+                logger.info("Migration: Creating agent_event_subscription_state table")
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS agent_event_subscription_state (
+                        user_id TEXT PRIMARY KEY,
+                        custom_enabled INTEGER NOT NULL DEFAULT 0,
+                        updated_at TIMESTAMP NOT NULL
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_agent_event_subscription_state_enabled
+                        ON agent_event_subscription_state(custom_enabled, updated_at);
+                """)
+
+            aes_exists = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_event_subscriptions'"
+            ).fetchone()
+            if not aes_exists:
+                logger.info("Migration: Creating agent_event_subscriptions table")
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS agent_event_subscriptions (
+                        user_id TEXT NOT NULL,
+                        event_type TEXT NOT NULL,
+                        updated_at TIMESTAMP NOT NULL,
+                        PRIMARY KEY (user_id, event_type)
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_agent_event_subscriptions_user
+                        ON agent_event_subscriptions(user_id, updated_at);
+                """)
+
+            cursor = conn.execute("PRAGMA table_info(agent_inbox)")
+            inbox_columns = {row[1] for row in cursor.fetchall()}
+            if "seen_at" not in inbox_columns:
+                logger.info("Migration: Adding seen_at column to agent_inbox")
+                conn.execute("ALTER TABLE agent_inbox ADD COLUMN seen_at TIMESTAMP")
+            if "completed_at" not in inbox_columns:
+                logger.info("Migration: Adding completed_at column to agent_inbox")
+                conn.execute("ALTER TABLE agent_inbox ADD COLUMN completed_at TIMESTAMP")
+            if "completion_ref_json" not in inbox_columns:
+                logger.info("Migration: Adding completion_ref_json column to agent_inbox")
+                conn.execute("ALTER TABLE agent_inbox ADD COLUMN completion_ref_json TEXT")
+
+            logger.info("Migration: Normalizing legacy handled inbox rows")
+            conn.execute(
+                """
+                UPDATE agent_inbox
+                SET status = 'completed',
+                    seen_at = COALESCE(seen_at, handled_at, created_at),
+                    completed_at = COALESCE(completed_at, handled_at)
+                WHERE status = 'handled'
+                """
+            )
 
             # Migration: content_contexts table for best-effort extracted text context
             conn.executescript("""
@@ -1331,6 +1444,9 @@ class DatabaseManager:
                 _exec_optional("DELETE FROM channel_member_sync_deliveries WHERE target_user_id = ?", (user_id,))
                 _exec_optional("DELETE FROM likes WHERE user_id = ?", (user_id,))
                 _exec_optional("DELETE FROM agent_presence WHERE user_id = ?", (user_id,))
+                _exec_optional("DELETE FROM agent_runtime_state WHERE user_id = ?", (user_id,))
+                _exec_optional("DELETE FROM agent_event_subscription_state WHERE user_id = ?", (user_id,))
+                _exec_optional("DELETE FROM agent_event_subscriptions WHERE user_id = ?", (user_id,))
 
                 # Channel messages (table in channels.py, same DB): likes then parent refs then messages
                 try:

--- a/canopy/core/feed.py
+++ b/canopy/core/feed.py
@@ -1001,6 +1001,79 @@ class FeedManager:
             logger.error(f"Failed to save feed algorithm for {user_id}: {e}")
             return False
 
+    def get_feed_last_viewed_at(self, user_id: str) -> Optional[datetime]:
+        """Return the last time the user acknowledged the feed view."""
+        try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    "SELECT last_viewed_at FROM user_feed_preferences WHERE user_id = ?",
+                    (user_id,),
+                ).fetchone()
+                if not row:
+                    return None
+                return self._parse_datetime(row['last_viewed_at'])
+        except Exception as e:
+            logger.warning(f"Failed to load feed last_viewed_at for {user_id}: {e}")
+            return None
+
+    def mark_feed_viewed(self, user_id: str, viewed_at: Optional[datetime] = None) -> bool:
+        """Record that the user has intentionally viewed the feed."""
+        if not user_id:
+            return False
+        viewed_dt = viewed_at or datetime.now(timezone.utc)
+        viewed_db = self._format_db_timestamp(viewed_dt)
+        try:
+            with self.db.get_connection() as conn:
+                conn.execute("""
+                    INSERT INTO user_feed_preferences (user_id, algorithm_json, last_viewed_at, updated_at)
+                    VALUES (?, '{}', ?, CURRENT_TIMESTAMP)
+                    ON CONFLICT(user_id) DO UPDATE SET
+                        last_viewed_at = excluded.last_viewed_at,
+                        updated_at = CURRENT_TIMESTAMP
+                """, (user_id, viewed_db))
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Failed to mark feed viewed for {user_id}: {e}")
+            return False
+
+    def count_unread_posts(self, user_id: str, *, exclude_own_posts: bool = True) -> int:
+        """Count feed posts with new activity since the user's last acknowledged feed view."""
+        if not user_id:
+            return 0
+
+        last_viewed_at = self.get_feed_last_viewed_at(user_id)
+        params: List[Any] = [user_id, user_id]
+        own_clause = ""
+        if exclude_own_posts:
+            own_clause = " AND p.author_id != ?"
+            params.append(user_id)
+        since_clause = ""
+        if last_viewed_at:
+            since_clause = " AND COALESCE(p.last_activity_at, p.created_at) > ?"
+            params.append(self._format_db_timestamp(last_viewed_at))
+
+        try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(f"""
+                    SELECT COUNT(DISTINCT p.id) AS unread_count
+                    FROM feed_posts p
+                    LEFT JOIN post_permissions pp ON p.id = pp.post_id
+                    WHERE (
+                        p.visibility = 'public' OR
+                        p.visibility = 'network' OR
+                        (p.visibility = 'custom' AND pp.user_id = ?) OR
+                        p.author_id = ?
+                    )
+                      AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP)
+                      {own_clause}
+                      {since_clause}
+                """, params).fetchone()
+                return max(0, int((row['unread_count'] if row else 0) or 0))
+        except Exception as e:
+            logger.error(f"Failed to count unread feed posts for {user_id}: {e}")
+            return 0
+
     def get_available_tags(self, limit: int = 50) -> List[Dict[str, Any]]:
         """Get popular tags across all posts for the tag picker UI."""
         try:

--- a/canopy/ui/routes.py
+++ b/canopy/ui/routes.py
@@ -433,10 +433,11 @@ def create_ui_blueprint() -> Blueprint:
         if not _is_authenticated():
             return {}
         try:
-            db_manager, _, trust_manager, message_manager, channel_manager, _, _, _, profile_manager, _, p2p_manager = _get_app_components_any(current_app)
+            db_manager, _, trust_manager, message_manager, channel_manager, _, feed_manager, _, profile_manager, _, p2p_manager = _get_app_components_any(current_app)
             workspace_event_manager = current_app.config.get('WORKSPACE_EVENT_MANAGER')
             connected_peers = p2p_manager.get_connected_peers() if p2p_manager else []
             local_peer_id = p2p_manager.get_peer_id() if p2p_manager else None
+            current_user_id = session.get('user_id')
             peer_snapshot = _build_sidebar_peer_snapshot(
                 list(connected_peers or []),
                 trust_manager,
@@ -462,6 +463,15 @@ def create_ui_blueprint() -> Blueprint:
                 'sidebar_dm_event_cursor': int((workspace_event_manager.get_latest_seq() if workspace_event_manager else 0) or 0),
                 'sidebar_local_peer_id': local_peer_id,
             }
+            attention_snapshot = _build_sidebar_attention_summary(
+                db_manager,
+                channel_manager,
+                feed_manager,
+                p2p_manager,
+                current_user_id,
+            )
+            out['sidebar_attention_summary'] = attention_snapshot['summary']
+            out['sidebar_attention_rev'] = attention_snapshot['rev']
             # Admin link and badge (instance owner only)
             owner_id = db_manager.get_instance_owner_user_id()
             if owner_id and session.get('user_id') == owner_id:
@@ -1571,6 +1581,39 @@ def create_ui_blueprint() -> Blueprint:
             'dm_rev': _stable_ui_revision(contacts),
         }
 
+    def _count_sidebar_message_unread(
+        db_manager: Any,
+        user_id: str,
+    ) -> int:
+        """Count unread direct and group messages for the global sidebar summary."""
+        if not db_manager or not user_id:
+            return 0
+        try:
+            with db_manager.get_connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT COUNT(DISTINCT m.id) AS unread_count
+                    FROM messages m
+                    WHERE m.read_at IS NULL
+                      AND COALESCE(m.sender_id, '') != ?
+                      AND (
+                          m.recipient_id = ?
+                          OR EXISTS (
+                              SELECT 1
+                              FROM json_each(
+                                  CASE WHEN json_valid(m.metadata) THEN m.metadata ELSE '{}' END,
+                                  '$.group_members'
+                              ) gm
+                              WHERE CAST(gm.value AS TEXT) = ?
+                          )
+                      )
+                    """,
+                    (user_id, user_id, user_id),
+                ).fetchone()
+                return max(0, int((row['unread_count'] if row else 0) or 0))
+        except Exception:
+            return 0
+
     def _build_channel_sidebar_snapshot(
         channel_manager: Any,
         p2p_manager: Any,
@@ -1610,6 +1653,44 @@ def create_ui_blueprint() -> Blueprint:
         return {
             'channels': payload,
             'rev': _stable_ui_revision(payload),
+        }
+
+    def _build_sidebar_attention_summary(
+        db_manager: Any,
+        channel_manager: Any,
+        feed_manager: Any,
+        p2p_manager: Any,
+        user_id: str,
+    ) -> dict[str, Any]:
+        """Build aggregate unread counts for sidebar navigation badges."""
+        messages_unread = _count_sidebar_message_unread(db_manager, user_id)
+
+        channels_unread = 0
+        try:
+            channel_snapshot = _build_channel_sidebar_snapshot(channel_manager, p2p_manager, user_id)
+            channels_unread = sum(
+                max(0, int((entry.get('unread_count') or 0)))
+                for entry in (channel_snapshot.get('channels') or [])
+            )
+        except Exception:
+            channels_unread = 0
+
+        feed_unread = 0
+        try:
+            if feed_manager and hasattr(feed_manager, 'count_unread_posts'):
+                feed_unread = max(0, int(feed_manager.count_unread_posts(user_id) or 0))
+        except Exception:
+            feed_unread = 0
+
+        summary = {
+            'messages': messages_unread,
+            'channels': channels_unread,
+            'feed': feed_unread,
+            'total': messages_unread + channels_unread + feed_unread,
+        }
+        return {
+            'summary': summary,
+            'rev': _stable_ui_revision(summary),
         }
 
     def _build_sidebar_dm_contacts(
@@ -3122,6 +3203,11 @@ def create_ui_blueprint() -> Blueprint:
         try:
             db_manager, _, _, _, _, file_manager, feed_manager, interaction_manager, profile_manager, config, p2p_manager = _get_app_components_any(current_app)
             user_id = get_current_user()
+            if feed_manager and hasattr(feed_manager, 'mark_feed_viewed'):
+                try:
+                    feed_manager.mark_feed_viewed(user_id)
+                except Exception:
+                    pass
             
             # Get query parameters
             algorithm = request.args.get('algorithm', 'chronological')
@@ -4531,6 +4617,37 @@ def create_ui_blueprint() -> Blueprint:
         except Exception as e:
             logger.error(f"Sidebar DM snapshot error: {e}", exc_info=True)
             return jsonify({'success': False, 'error': 'Failed to load DM sidebar snapshot'}), 500
+
+    @ui.route('/ajax/sidebar_attention_summary', methods=['GET'])
+    @require_login
+    def ajax_sidebar_attention_summary():
+        """Return aggregate unread counts for sidebar navigation badges."""
+        try:
+            db_manager, _, _, _, channel_manager, _, feed_manager, _, _, _, p2p_manager = _get_app_components_any(current_app)
+            client_rev = str(request.args.get('rev') or '').strip()
+            snapshot = _build_sidebar_attention_summary(
+                db_manager,
+                channel_manager,
+                feed_manager,
+                p2p_manager,
+                get_current_user(),
+            )
+            changed = snapshot['rev'] != client_rev
+            return jsonify({
+                'success': True,
+                'changed': changed,
+                'rev': snapshot['rev'],
+                'summary': snapshot['summary'] if changed else {},
+            })
+        except Exception as e:
+            logger.error(f"Sidebar attention summary error: {e}", exc_info=True)
+            return jsonify({
+                'success': False,
+                'changed': False,
+                'rev': '',
+                'summary': {'messages': 0, 'channels': 0, 'feed': 0, 'total': 0},
+                'error': 'Failed to load sidebar attention summary',
+            }), 500
 
     @ui.route('/ajax/p2p/diagnostics', methods=['GET'])
     @require_login
@@ -9852,6 +9969,7 @@ def create_ui_blueprint() -> Blueprint:
 
             limit = int(request.args.get('limit', 50))
             before_message_id = request.args.get('before')
+            focus_message_id = str(request.args.get('focus_message') or '').strip()
             
             logger.debug(f"Get channel messages request: user_id={user_id}, channel_id={channel_id}, limit={limit}")
 
@@ -9895,6 +10013,34 @@ def create_ui_blueprint() -> Blueprint:
             messages = channel_manager.get_channel_messages(
                 channel_id, user_id, limit, before_message_id
             )
+            focus_context_mode = 'recent'
+            focus_message_found = not focus_message_id
+            if focus_message_id:
+                focus_message_found = any(
+                    str(getattr(message, 'id', '') or '') == focus_message_id
+                    for message in messages
+                )
+                if (
+                    not focus_message_found
+                    and hasattr(channel_manager, 'get_channel_message_context')
+                ):
+                    try:
+                        focused_messages = channel_manager.get_channel_message_context(
+                            channel_id=channel_id,
+                            message_id=focus_message_id,
+                            user_id=user_id,
+                        )
+                    except Exception:
+                        focused_messages = []
+                    if focused_messages:
+                        messages = focused_messages
+                        focus_context_mode = 'context'
+                        focus_message_found = any(
+                            str(getattr(message, 'id', '') or '') == focus_message_id
+                            for message in messages
+                        )
+                    else:
+                        focus_context_mode = 'missing'
             
             logger.debug(f"Retrieved {len(messages)} messages for channel {channel_id}")
             
@@ -10392,12 +10538,18 @@ def create_ui_blueprint() -> Blueprint:
                     logger.warning(f"Skipping message {getattr(message, 'id', '?')} in response: {msg_err}")
                     continue
             
-            return jsonify({
+            payload = {
                 'messages': messages_data,
                 'channel_id': channel_id,
                 'count': len(messages_data),
                 'workspace_event_cursor': workspace_event_cursor,
-            })
+                'focus_message_id': focus_message_id or None,
+                'focus_message_found': focus_message_found,
+                'focus_context_mode': focus_context_mode if focus_message_id else None,
+            }
+            if focus_message_id and not focus_message_found:
+                payload['warning'] = 'Target message is no longer available in this channel.'
+            return jsonify(payload)
             
         except Exception as e:
             logger.error(f"Get channel messages error: {e}", exc_info=True)

--- a/canopy/ui/static/js/canopy-main.js
+++ b/canopy/ui/static/js/canopy-main.js
@@ -343,6 +343,8 @@
         const canopyInitialRecentDmContacts = window.CANOPY_VARS ? (window.CANOPY_VARS.recentDmContacts || []) : [];
         const canopyInitialDmRev = window.CANOPY_VARS ? (window.CANOPY_VARS.dmRev || '') : '';
         const canopyInitialDmEventCursor = window.CANOPY_VARS ? Number(window.CANOPY_VARS.dmEventCursor || 0) : 0;
+        const canopyInitialAttentionSummary = window.CANOPY_VARS ? (window.CANOPY_VARS.attentionSummary || { messages: 0, channels: 0, feed: 0, total: 0 }) : { messages: 0, channels: 0, feed: 0, total: 0 };
+        const canopyInitialAttentionRev = window.CANOPY_VARS ? (window.CANOPY_VARS.attentionRev || '') : '';
         const canopyLocalPeerId = window.CANOPY_VARS ? String(window.CANOPY_VARS.localPeerId || '').trim() : '';
         const SIDEBAR_VISIBLE_PEER_LIMIT = 12;
         window.canopyPeerProfiles = canopyPeerProfiles || {};
@@ -833,6 +835,9 @@
                 canopySidebarDmState.contacts = [];
             }
             canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
+            if (window.requestCanopySidebarAttentionRefresh) {
+                window.requestCanopySidebarAttentionRefresh({ force: true }).catch(() => {});
+            }
         };
 
         function requestCanopySidebarDmRefresh(options) {
@@ -946,6 +951,129 @@
         document.addEventListener('DOMContentLoaded', function() {
             canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
             startCanopySidebarDmPolling();
+        });
+
+        function formatSidebarUnreadCount(count) {
+            const normalized = Math.max(0, Number(count) || 0);
+            return normalized > 99 ? '99+' : String(normalized);
+        }
+
+        function setSidebarNavUnreadBadge(kind, count) {
+            const badge = document.getElementById(`sidebar-nav-${kind}-badge`);
+            if (!badge) return;
+            const normalized = Math.max(0, Number(count) || 0);
+            if (normalized <= 0) {
+                badge.hidden = true;
+                badge.textContent = '0';
+                badge.removeAttribute('aria-label');
+                return;
+            }
+            badge.hidden = false;
+            badge.textContent = formatSidebarUnreadCount(normalized);
+            badge.setAttribute('aria-label', `${normalized} unread ${kind}`);
+        }
+
+        function renderSidebarAttentionSummary(summary) {
+            const safeSummary = summary && typeof summary === 'object' ? summary : {};
+            setSidebarNavUnreadBadge('messages', safeSummary.messages || 0);
+            setSidebarNavUnreadBadge('channels', safeSummary.channels || 0);
+            setSidebarNavUnreadBadge('feed', safeSummary.feed || 0);
+        }
+
+        const canopySidebarAttentionState = {
+            currentRev: canopyInitialAttentionRev || '',
+            summary: {
+                messages: Math.max(0, Number(canopyInitialAttentionSummary.messages || 0)),
+                channels: Math.max(0, Number(canopyInitialAttentionSummary.channels || 0)),
+                feed: Math.max(0, Number(canopyInitialAttentionSummary.feed || 0)),
+                total: Math.max(0, Number(canopyInitialAttentionSummary.total || 0)),
+            },
+            inFlight: false,
+            queued: false,
+            pollHandle: null,
+        };
+
+        function requestCanopySidebarAttentionRefresh(options) {
+            const opts = options || {};
+            if (canopySidebarAttentionState.inFlight) {
+                canopySidebarAttentionState.queued = true;
+                return Promise.resolve({ queued: true });
+            }
+
+            canopySidebarAttentionState.inFlight = true;
+            const routes = (window.CANOPY_VARS && window.CANOPY_VARS.urls) || {};
+            const endpoint = routes.sidebarAttentionSummary || '/ajax/sidebar_attention_summary';
+            const query = new URLSearchParams();
+            if (!opts.force && canopySidebarAttentionState.currentRev) {
+                query.set('rev', String(canopySidebarAttentionState.currentRev || ''));
+            }
+
+            return fetch(`${endpoint}${query.toString() ? `?${query.toString()}` : ''}`, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            })
+                .then((res) => {
+                    if (!res.ok) {
+                        throw new Error(`Sidebar attention summary failed (${res.status})`);
+                    }
+                    return res.json();
+                })
+                .then((data) => {
+                    if (!data || data.success === false) return data || null;
+                    if (data.rev) {
+                        canopySidebarAttentionState.currentRev = String(data.rev || '');
+                    }
+                    if (data.changed === false) {
+                        return data;
+                    }
+                    const summary = data.summary && typeof data.summary === 'object' ? data.summary : {};
+                    canopySidebarAttentionState.summary = {
+                        messages: Math.max(0, Number(summary.messages || 0)),
+                        channels: Math.max(0, Number(summary.channels || 0)),
+                        feed: Math.max(0, Number(summary.feed || 0)),
+                        total: Math.max(0, Number(summary.total || 0)),
+                    };
+                    renderSidebarAttentionSummary(canopySidebarAttentionState.summary);
+                    return data;
+                })
+                .catch(() => null)
+                .finally(() => {
+                    canopySidebarAttentionState.inFlight = false;
+                    if (canopySidebarAttentionState.queued) {
+                        canopySidebarAttentionState.queued = false;
+                        window.setTimeout(() => {
+                            requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
+                        }, 0);
+                    }
+                });
+        }
+
+        function startCanopySidebarAttentionPolling() {
+            const hasAnyBadge = document.getElementById('sidebar-nav-messages-badge')
+                || document.getElementById('sidebar-nav-channels-badge')
+                || document.getElementById('sidebar-nav-feed-badge');
+            if (!hasAnyBadge) return;
+            renderSidebarAttentionSummary(canopySidebarAttentionState.summary);
+            if (canopySidebarAttentionState.pollHandle) {
+                window.clearInterval(canopySidebarAttentionState.pollHandle);
+            }
+            requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
+            canopySidebarAttentionState.pollHandle = window.setInterval(() => {
+                requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
+            }, 12000);
+            document.addEventListener('visibilitychange', function() {
+                if (document.visibilityState === 'visible') {
+                    requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
+                }
+            });
+            window.addEventListener('focus', function() {
+                requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
+            });
+        }
+
+        window.requestCanopySidebarAttentionRefresh = requestCanopySidebarAttentionRefresh;
+
+        document.addEventListener('DOMContentLoaded', function() {
+            startCanopySidebarAttentionPolling();
         });
 
         window.renderAvatarStack = function(container, options) {
@@ -4241,7 +4369,7 @@
 	            let notificationCount = 0;
 	            let events = [];
 	            const seenEventIds = new Set();
-            const mentionRefs = new Set();
+            const unreadSemanticKeys = new Set();
 	            let initialized = false;
 	            const localUserId = (window.CANOPY_VARS && window.CANOPY_VARS.localUserId) || null;
 	            const routes = {
@@ -4369,6 +4497,47 @@
                 return null;
             }
 
+            function activitySemanticKey(evt) {
+                if (!evt) return null;
+                const ref = evt.ref || {};
+                const kind = String(evt.kind || '').trim();
+                if (ref.message_id) {
+                    if (kind === 'direct_message') return `dm:${ref.message_id}`;
+                    return `msg:${ref.message_id}`;
+                }
+                if (ref.post_id) return `post:${ref.post_id}`;
+                if (kind === 'channel_added' && ref.channel_id && ref.user_id) {
+                    return `channel_added:${ref.channel_id}:${ref.user_id}`;
+                }
+                if (kind === 'interaction' && ref.item_type && ref.item_id) {
+                    return `interaction:${ref.item_type}:${ref.item_id}:${ref.action || ''}:${ref.user_id || ''}`;
+                }
+                return evt.id || `${evt.peer_id || ''}:${kind}:${evt.timestamp || ''}`;
+            }
+
+            function activityPriority(evt) {
+                const kind = String(evt && evt.kind || '').trim();
+                if (kind === 'mention') return 50;
+                if (kind === 'direct_message') return 45;
+                if (kind === 'channel_added') return 40;
+                if (kind === 'interaction') return 30;
+                if (kind === 'channel_message') return 20;
+                if (kind === 'feed_post') return 10;
+                return 0;
+            }
+
+            function mergeActivityEvent(existingEvt, incomingEvt) {
+                if (!existingEvt) return incomingEvt;
+                if (!incomingEvt) return existingEvt;
+                const existingPriority = activityPriority(existingEvt);
+                const incomingPriority = activityPriority(incomingEvt);
+                if (incomingPriority > existingPriority) return incomingEvt;
+                if (incomingPriority < existingPriority) return existingEvt;
+                const existingTs = Number(existingEvt.timestamp || 0);
+                const incomingTs = Number(incomingEvt.timestamp || 0);
+                return incomingTs >= existingTs ? incomingEvt : existingEvt;
+            }
+
 	            function navigateToActivity(evt) {
 	                if (!evt) return;
 	                const kind = evt.kind || '';
@@ -4376,10 +4545,13 @@
 
 	                try {
 	                    if (kind === 'mention') {
+	                        if (ref.message_id) {
+                                window.location.href = `/channels/locate?message_id=${encodeURIComponent(ref.message_id)}`;
+                                return;
+                            }
 	                        if (ref.channel_id) {
 	                            const url = new URL(routes.channels, window.location.origin);
 	                            url.searchParams.set('focus_channel', ref.channel_id);
-	                            if (ref.message_id) url.searchParams.set('focus_message', ref.message_id);
 	                            window.location.href = url.toString();
 	                            return;
 	                        }
@@ -4396,17 +4568,23 @@
 	                        window.location.href = url.toString();
 	                        return;
 	                    }
-	                    if (kind === 'channel_message' && ref.channel_id) {
-	                        const url = new URL(routes.channels, window.location.origin);
-	                        url.searchParams.set('focus_channel', ref.channel_id);
-	                        if (ref.message_id) url.searchParams.set('focus_message', ref.message_id);
-	                        window.location.href = url.toString();
-	                        return;
+	                    if (kind === 'channel_message') {
+                            if (ref.message_id) {
+                                window.location.href = `/channels/locate?message_id=${encodeURIComponent(ref.message_id)}`;
+                                return;
+                            }
+	                        if (ref.channel_id) {
+	                            const url = new URL(routes.channels, window.location.origin);
+	                            url.searchParams.set('focus_channel', ref.channel_id);
+	                            window.location.href = url.toString();
+	                            return;
+	                        }
 	                    }
 	                    if (kind === 'direct_message') {
 	                        const otherUserId = otherUserIdFromDirectMessage(ref);
 	                        const url = new URL(routes.messages, window.location.origin);
 	                        if (otherUserId) url.searchParams.set('with', otherUserId);
+                            if (ref.message_id) url.hash = `message-${ref.message_id}`;
 	                        window.location.href = url.toString();
 	                        return;
 	                    }
@@ -4580,18 +4758,24 @@
 	            }
 
             function recordEvent(evt) {
-                const refKey = eventRefKey(evt);
-                if (evt.kind === 'mention' && refKey) {
-                    mentionRefs.add(refKey);
-                    events = events.filter(e => eventRefKey(e) !== refKey || e.kind === 'mention');
-                } else if (refKey && mentionRefs.has(refKey)) {
-                    return;
-                }
+                const semanticKey = activitySemanticKey(evt);
+                if (!semanticKey) return;
                 const uid = getUserRefId(evt);
                 if (uid) scheduleUserInfoFetch([uid]);
-                notificationCount += 1;
-                events.unshift(evt);
+
+                const existingIndex = events.findIndex((existingEvt) => activitySemanticKey(existingEvt) === semanticKey);
+                if (existingIndex >= 0) {
+                    const merged = mergeActivityEvent(events[existingIndex], evt);
+                    events.splice(existingIndex, 1);
+                    events.unshift(merged);
+                } else {
+                    events.unshift(evt);
+                }
                 events = events.slice(0, 12);
+                if (!unreadSemanticKeys.has(semanticKey)) {
+                    unreadSemanticKeys.add(semanticKey);
+                    notificationCount += 1;
+                }
                 setBadge(notificationCount);
                 renderMenu();
                 markPeerActive(evt.peer_id);
@@ -4646,13 +4830,14 @@
             bellBtn.addEventListener('click', () => {
                 // Opening the bell acknowledges current count, but keeps the history in the menu.
                 notificationCount = 0;
+                unreadSemanticKeys.clear();
                 setBadge(0);
             });
 
             if (clearBtn) {
                 clearBtn.addEventListener('click', () => {
                     events = [];
-                    mentionRefs.clear();
+                    unreadSemanticKeys.clear();
                     notificationCount = 0;
                     setBadge(0);
                     renderMenu();

--- a/canopy/ui/templates/base.html
+++ b/canopy/ui/templates/base.html
@@ -295,6 +295,52 @@
             text-align: center;
         }
 
+        .sidebar .nav-link.nav-link-unread {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.75rem;
+        }
+
+        .sidebar .nav-link.nav-link-unread i {
+            margin-right: 0;
+            flex-shrink: 0;
+        }
+
+        .sidebar-nav-label {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            min-width: 0;
+        }
+
+        .sidebar-nav-text {
+            min-width: 0;
+        }
+
+        .sidebar-nav-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 1.5rem;
+            height: 1.5rem;
+            padding: 0 0.45rem;
+            border-radius: 999px;
+            background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+            color: #fff;
+            font-size: 0.72rem;
+            font-weight: 700;
+            line-height: 1;
+            letter-spacing: 0.01em;
+            box-shadow: 0 8px 18px rgba(239, 68, 68, 0.28);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            flex-shrink: 0;
+        }
+
+        .sidebar-nav-badge[hidden] {
+            display: none !important;
+        }
+
         .sidebar-peers {
             margin: 8px 12px 8px;
             padding: 10px;
@@ -1157,15 +1203,29 @@
             position: relative;
         }
         
-        .sidebar.collapsed .nav-link span {
+        .sidebar.collapsed .nav-link .sidebar-nav-text {
             opacity: 0;
             visibility: hidden;
             transition: all 0.2s ease;
         }
         
         .sidebar.collapsed .nav-link i {
-            margin-right: 0;
             font-size: 1.2rem;
+        }
+
+        .sidebar.collapsed .nav-link.nav-link-unread {
+            justify-content: center;
+        }
+
+        .sidebar.collapsed .sidebar-nav-badge {
+            position: absolute;
+            top: 7px;
+            right: 7px;
+            min-width: 1.3rem;
+            height: 1.3rem;
+            padding: 0 0.3rem;
+            font-size: 0.68rem;
+            box-shadow: 0 6px 16px rgba(239, 68, 68, 0.25);
         }
         
         .sidebar.collapsed .sidebar-divider,
@@ -5281,17 +5341,41 @@
             <div class="sidebar-container expanded" id="sidebar-container">
                 <div class="sidebar" id="main-sidebar">
                     <nav class="nav flex-column py-3">
-                        <a class="nav-link {% if request.endpoint == 'ui.messages' %}active{% endif %}" 
+                        <a class="nav-link nav-link-unread {% if request.endpoint == 'ui.messages' %}active{% endif %}" 
                            href="{{ url_for('ui.messages') }}" data-title="Messages">
-                            <i class="bi bi-chat-left-text"></i> <span>Messages</span>
+                            <span class="sidebar-nav-label">
+                                <i class="bi bi-chat-left-text"></i>
+                                <span class="sidebar-nav-text">Messages</span>
+                            </span>
+                            <span class="sidebar-nav-badge"
+                                  id="sidebar-nav-messages-badge"
+                                  {% if not (sidebar_attention_summary is defined and sidebar_attention_summary.messages > 0) %}hidden{% endif %}>
+                                {{ sidebar_attention_summary.messages if sidebar_attention_summary is defined else 0 }}
+                            </span>
                         </a>
-                        <a class="nav-link {% if request.endpoint == 'ui.channels' %}active{% endif %}"
+                        <a class="nav-link nav-link-unread {% if request.endpoint == 'ui.channels' %}active{% endif %}"
                            href="{{ url_for('ui.channels') }}" data-title="Channels">
-                            <i class="bi bi-hash"></i> <span>Channels</span>
+                            <span class="sidebar-nav-label">
+                                <i class="bi bi-hash"></i>
+                                <span class="sidebar-nav-text">Channels</span>
+                            </span>
+                            <span class="sidebar-nav-badge"
+                                  id="sidebar-nav-channels-badge"
+                                  {% if not (sidebar_attention_summary is defined and sidebar_attention_summary.channels > 0) %}hidden{% endif %}>
+                                {{ sidebar_attention_summary.channels if sidebar_attention_summary is defined else 0 }}
+                            </span>
                         </a>
-                        <a class="nav-link {% if request.endpoint == 'ui.feed' %}active{% endif %}"
+                        <a class="nav-link nav-link-unread {% if request.endpoint == 'ui.feed' %}active{% endif %}"
                            href="{{ url_for('ui.feed') }}" data-title="Social Feed">
-                            <i class="bi bi-newspaper"></i> <span>Social Feed</span>
+                            <span class="sidebar-nav-label">
+                                <i class="bi bi-newspaper"></i>
+                                <span class="sidebar-nav-text">Social Feed</span>
+                            </span>
+                            <span class="sidebar-nav-badge"
+                                  id="sidebar-nav-feed-badge"
+                                  {% if not (sidebar_attention_summary is defined and sidebar_attention_summary.feed > 0) %}hidden{% endif %}>
+                                {{ sidebar_attention_summary.feed if sidebar_attention_summary is defined else 0 }}
+                            </span>
                         </a>
                         <a class="nav-link {% if request.endpoint == 'ui.tasks_page' %}active{% endif %}"
                            href="{{ url_for('ui.tasks_page') }}" data-title="Tasks">
@@ -5584,6 +5668,8 @@
             recentDmContacts: {{ sidebar_recent_dm_contacts|tojson if sidebar_recent_dm_contacts is defined else '[]' }},
             dmRev: {{ sidebar_dm_rev|tojson if sidebar_dm_rev is defined else '""' }},
             dmEventCursor: {{ sidebar_dm_event_cursor|tojson if sidebar_dm_event_cursor is defined else '0' }},
+            attentionSummary: {{ sidebar_attention_summary|tojson if sidebar_attention_summary is defined else {'messages': 0, 'channels': 0, 'feed': 0, 'total': 0}|tojson }},
+            attentionRev: {{ sidebar_attention_rev|tojson if sidebar_attention_rev is defined else '""' }},
             userId: {{ (user_id or 'local_user')|tojson }},
             profileTheme: {{ (profile.theme_preference if profile else 'dark')|tojson }},
             localUserId: {{ session.get('user_id')|tojson }},
@@ -5592,7 +5678,8 @@
             urls: {
                 feed: {{ url_for('ui.feed')|tojson }},
                 channels: {{ url_for('ui.channels')|tojson }},
-                messages: {{ url_for('ui.messages')|tojson }}
+                messages: {{ url_for('ui.messages')|tojson }},
+                sidebarAttentionSummary: {{ url_for('ui.ajax_sidebar_attention_summary')|tojson }}
             }
         };
     </script>

--- a/canopy/ui/templates/channels.html
+++ b/canopy/ui/templates/channels.html
@@ -4762,7 +4762,7 @@ function sortChannelListByPins() {
 }
 
 // Channel management
-function selectChannel(channelId, channelName) {
+function selectChannel(channelId, channelName, options = {}) {
     if (typeof window.canopyPersistActiveMedia === 'function') {
         try {
             window.canopyPersistActiveMedia();
@@ -4827,7 +4827,11 @@ function selectChannel(channelId, channelName) {
     applyChannelNotificationsFromSelection(channelId);
     
     // Load messages for this channel
-    loadChannelMessages(channelId, { forceScroll: true });
+    const focusMessageId = options && options.focusMessageId ? String(options.focusMessageId) : '';
+    const forceScroll = Object.prototype.hasOwnProperty.call(options || {}, 'forceScroll')
+        ? !!options.forceScroll
+        : !focusMessageId;
+    loadChannelMessages(channelId, { forceScroll, focusMessageId });
 }
 
 function updateCurrentChannelIdUI(channelId) {
@@ -5439,7 +5443,15 @@ function loadChannelMessages(channelId, options = {}) {
     pendingChannelMessages = null;
     channelLoadInFlight = true;
 
-    return apiCall(`/ajax/channel_messages/${channelId}`)
+    const focusMessageId = (options && options.focusMessageId)
+        ? String(options.focusMessageId)
+        : (initialFocusMessageId ? String(initialFocusMessageId) : '');
+    const query = new URLSearchParams();
+    if (focusMessageId) {
+        query.set('focus_message', focusMessageId);
+    }
+
+    return apiCall(`/ajax/channel_messages/${channelId}${query.toString() ? `?${query.toString()}` : ''}`)
         .then(data => {
             if (loadToken !== activeChannelLoadToken || String(currentChannelId) !== requestedChannelId) {
                 return;
@@ -5478,12 +5490,55 @@ function loadChannelMessages(channelId, options = {}) {
         });
 }
 
-function focusMessageById(messageId) {
+function clearInitialChannelFocusFromUrl() {
+    try {
+        const url = new URL(window.location.href);
+        let changed = false;
+        if (url.searchParams.has('focus_message')) {
+            url.searchParams.delete('focus_message');
+            changed = true;
+        }
+        if (url.searchParams.has('focus_channel')) {
+            url.searchParams.delete('focus_channel');
+            changed = true;
+        }
+        if (url.searchParams.has('channel')) {
+            url.searchParams.delete('channel');
+            changed = true;
+        }
+        if (changed) {
+            window.history.replaceState({}, document.title, `${url.pathname}${url.search}${url.hash}`);
+        }
+    } catch (_) {}
+}
+
+function scrollMessageIntoContainer(msgEl, options = {}) {
+    const container = document.getElementById('messages-container');
+    if (!msgEl || !container) return false;
+
+    const containerRect = container.getBoundingClientRect();
+    const msgRect = msgEl.getBoundingClientRect();
+    const currentTop = container.scrollTop;
+    const align = options.align || 'center';
+    let offset = container.clientHeight * 0.3;
+    if (align === 'nearest') {
+        offset = Math.min(24, container.clientHeight * 0.08);
+    } else if (align === 'start') {
+        offset = 20;
+    }
+    const targetTop = Math.max(0, currentTop + (msgRect.top - containerRect.top) - offset);
+    container.scrollTo({ top: targetTop, behavior: options.behavior || 'smooth' });
+    return true;
+}
+
+function focusMessageById(messageId, options = {}) {
     if (!messageId) return false;
     const msgEl = document.querySelector(`.message-item[data-message-id="${messageId}"]`);
     if (!msgEl) return false;
     msgEl.classList.add('focus-flash');
-    msgEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    scrollMessageIntoContainer(msgEl, { align: 'center', behavior: options.behavior || 'smooth' });
+    setTimeout(() => scrollMessageIntoContainer(msgEl, { align: 'center', behavior: 'smooth' }), 220);
+    setTimeout(() => scrollMessageIntoContainer(msgEl, { align: 'center', behavior: 'smooth' }), 850);
     setTimeout(() => msgEl.classList.remove('focus-flash'), 3200);
     return true;
 }
@@ -5635,6 +5690,9 @@ function displayMessages(messages, options = {}) {
             applyUserAvatarStacks(userInfo, messagesContainer);
             if (initialFocusMessageId) {
 		            const focused = focusMessageById(initialFocusMessageId);
+                    if (focused) {
+                        clearInitialChannelFocusFromUrl();
+                    }
 		            initialFocusMessageId = null;
 		            if (!focused && container) {
 		                container.scrollTop = container.scrollHeight;
@@ -12321,7 +12379,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (pendingEl) {
                     const nameEl = pendingEl.querySelector('.channel-name');
                     const channelName = nameEl ? nameEl.textContent : 'Unknown';
-                    selectChannel(pendingChannelId, channelName);
+                    selectChannel(pendingChannelId, channelName, { focusMessageId: initialFocusMessageId || '' });
                     didSelectFocus = true;
                 }
                 localStorage.removeItem('pendingChannelId');
@@ -12331,7 +12389,7 @@ document.addEventListener('DOMContentLoaded', function() {
 	                if (focusEl) {
 	                    const nameEl = focusEl.querySelector('.channel-name');
 	                    const channelName = nameEl ? nameEl.textContent : 'Unknown';
-	                    selectChannel(focusChannelId, channelName);
+	                    selectChannel(focusChannelId, channelName, { focusMessageId: initialFocusMessageId || '', forceScroll: false });
 	                    return true;
 	                }
 	                return false;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canopy"
-version = "0.4.89"
+version = "0.4.90"
 description = "Local-first peer-to-peer collaboration for humans and AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_channel_message_route_regressions.py
+++ b/tests/test_channel_message_route_regressions.py
@@ -105,6 +105,9 @@ class TestChannelMessageRouteRegressions(unittest.TestCase):
         self.channel_manager.get_channel_access_decision.return_value = {'allowed': True}
         self.channel_manager.purge_expired_channel_messages.return_value = []
         self.channel_manager.get_channel_messages.return_value = []
+        self.interaction_manager = MagicMock()
+        self.interaction_manager.get_user_liked_ids.return_value = set()
+        self.interaction_manager.get_post_interactions.return_value = {'total_likes': 0}
         self.file_manager = MagicMock()
         self.file_manager.get_file.return_value = types.SimpleNamespace(uploaded_by='owner')
         self.file_manager.is_file_referenced.return_value = False
@@ -124,7 +127,7 @@ class TestChannelMessageRouteRegressions(unittest.TestCase):
             self.channel_manager,
             self.file_manager,
             MagicMock(),
-            MagicMock(),
+            self.interaction_manager,
             MagicMock(),
             MagicMock(),
             self.p2p_manager,
@@ -324,6 +327,42 @@ class TestChannelMessageRouteRegressions(unittest.TestCase):
                 'reason': 'community_note_rated',
             },
             dedupe_suffix='community_note_rated:CN-rate:1',
+        )
+
+    def test_channel_messages_focus_message_uses_context_window_when_recent_page_misses_target(self) -> None:
+        target = MagicMock()
+        target.id = 'M-target'
+        target.channel_id = 'general'
+        target.user_id = 'owner'
+        target.content = 'Older target message'
+        target.created_at = datetime.now(timezone.utc)
+        target.expires_at = None
+        target.to_dict.return_value = {
+            'id': 'M-target',
+            'channel_id': 'general',
+            'user_id': 'owner',
+            'content': 'Older target message',
+            'created_at': target.created_at.isoformat(),
+            'attachments': [],
+            'security': {},
+            'reactions': {},
+        }
+        self.channel_manager.get_channel_messages.return_value = []
+        self.channel_manager.get_channel_message_context.return_value = [target]
+
+        response = self.client.get('/ajax/channel_messages/general?focus_message=M-target')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('focus_message_id'), 'M-target')
+        self.assertTrue(payload.get('focus_message_found'))
+        self.assertEqual(payload.get('focus_context_mode'), 'context')
+        self.assertEqual(payload.get('count'), 1)
+        self.assertEqual((payload.get('messages') or [])[0].get('id'), 'M-target')
+        self.channel_manager.get_channel_message_context.assert_called_once_with(
+            channel_id='general',
+            message_id='M-target',
+            user_id='owner',
         )
 
 

--- a/tests/test_feed_unread_state.py
+++ b/tests/test_feed_unread_state.py
@@ -1,0 +1,139 @@
+"""Tests for feed unread-count persistence."""
+
+import sqlite3
+import unittest
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from canopy.core.feed import FeedManager
+
+
+class _FakeDb:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    @contextmanager
+    def get_connection(self, *args, **kwargs):
+        yield self._conn
+
+
+class TestFeedUnreadState(unittest.TestCase):
+    def setUp(self) -> None:
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.row_factory = sqlite3.Row
+        self.conn.executescript(
+            """
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                username TEXT
+            );
+            CREATE TABLE feed_posts (
+                id TEXT PRIMARY KEY,
+                author_id TEXT NOT NULL,
+                content TEXT NOT NULL,
+                content_type TEXT DEFAULT 'text',
+                metadata TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                expires_at TIMESTAMP,
+                visibility TEXT DEFAULT 'network',
+                likes INTEGER DEFAULT 0,
+                comments INTEGER DEFAULT 0,
+                shares INTEGER DEFAULT 0,
+                last_activity_at TIMESTAMP
+            );
+            CREATE TABLE post_permissions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                post_id TEXT NOT NULL,
+                user_id TEXT NOT NULL
+            );
+            CREATE TABLE user_feed_preferences (
+                user_id TEXT PRIMARY KEY,
+                algorithm_json TEXT NOT NULL DEFAULT '{}',
+                last_viewed_at TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        self.conn.executemany(
+            "INSERT INTO users (id, username) VALUES (?, ?)",
+            [('viewer', 'viewer'), ('author-a', 'author-a'), ('author-b', 'author-b')],
+        )
+
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        last_viewed = now - timedelta(hours=12)
+        old_activity = now - timedelta(days=2)
+        recent_one = now - timedelta(hours=2)
+        recent_two = now - timedelta(minutes=30)
+
+        self.conn.execute(
+            "INSERT INTO user_feed_preferences (user_id, algorithm_json, last_viewed_at, updated_at) VALUES (?, ?, ?, ?)",
+            ('viewer', '{}', last_viewed.strftime('%Y-%m-%d %H:%M:%S'), last_viewed.strftime('%Y-%m-%d %H:%M:%S')),
+        )
+        self.conn.executemany(
+            """
+            INSERT INTO feed_posts (
+                id, author_id, content, created_at, last_activity_at, expires_at, visibility
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    'post-public-new',
+                    'author-a',
+                    'Public new',
+                    recent_one.strftime('%Y-%m-%d %H:%M:%S'),
+                    recent_one.strftime('%Y-%m-%d %H:%M:%S'),
+                    (now + timedelta(days=7)).strftime('%Y-%m-%d %H:%M:%S'),
+                    'public',
+                ),
+                (
+                    'post-custom-new',
+                    'author-b',
+                    'Custom new',
+                    recent_two.strftime('%Y-%m-%d %H:%M:%S'),
+                    recent_two.strftime('%Y-%m-%d %H:%M:%S'),
+                    (now + timedelta(days=7)).strftime('%Y-%m-%d %H:%M:%S'),
+                    'custom',
+                ),
+                (
+                    'post-old',
+                    'author-a',
+                    'Old activity',
+                    old_activity.strftime('%Y-%m-%d %H:%M:%S'),
+                    old_activity.strftime('%Y-%m-%d %H:%M:%S'),
+                    (now + timedelta(days=7)).strftime('%Y-%m-%d %H:%M:%S'),
+                    'public',
+                ),
+                (
+                    'post-own',
+                    'viewer',
+                    'Own post',
+                    recent_two.strftime('%Y-%m-%d %H:%M:%S'),
+                    recent_two.strftime('%Y-%m-%d %H:%M:%S'),
+                    (now + timedelta(days=7)).strftime('%Y-%m-%d %H:%M:%S'),
+                    'public',
+                ),
+            ],
+        )
+        self.conn.execute(
+            "INSERT INTO post_permissions (post_id, user_id) VALUES (?, ?)",
+            ('post-custom-new', 'viewer'),
+        )
+        self.conn.commit()
+
+        self.feed_manager = FeedManager(_FakeDb(self.conn), MagicMock())
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    def test_count_unread_posts_respects_last_viewed_time_and_permissions(self) -> None:
+        self.assertEqual(self.feed_manager.count_unread_posts('viewer'), 2)
+
+    def test_mark_feed_viewed_clears_unread_count(self) -> None:
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        self.assertTrue(self.feed_manager.mark_feed_viewed('viewer', now))
+        self.assertEqual(self.feed_manager.count_unread_posts('viewer'), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_frontend_regressions.py
+++ b/tests/test_frontend_regressions.py
@@ -76,6 +76,21 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn("if (currentChannelId && channelId === currentChannelId) {", channels_template)
         self.assertIn("requestChannelThreadRefresh();", channels_template)
 
+    def test_notification_bell_collapses_semantic_duplicates_and_routes_exact_messages(self) -> None:
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        self.assertIn("const unreadSemanticKeys = new Set();", main_js)
+        self.assertIn("function activitySemanticKey(evt) {", main_js)
+        self.assertIn("function mergeActivityEvent(existingEvt, incomingEvt) {", main_js)
+        self.assertIn("window.location.href = `/channels/locate?message_id=${encodeURIComponent(ref.message_id)}`;", main_js)
+        self.assertIn("if (ref.message_id) url.hash = `message-${ref.message_id}`;", main_js)
+
+    def test_channel_focus_uses_context_window_and_container_scroll(self) -> None:
+        channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
+        self.assertIn("function clearInitialChannelFocusFromUrl()", channels_template)
+        self.assertIn("function scrollMessageIntoContainer(msgEl, options = {})", channels_template)
+        self.assertIn("query.set('focus_message', focusMessageId);", channels_template)
+        self.assertIn("selectChannel(focusChannelId, channelName, { focusMessageId: initialFocusMessageId || '', forceScroll: false });", channels_template)
+
     def test_stream_owner_controls_drive_real_lifecycle_endpoints(self) -> None:
         channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
         self.assertIn("function _setStreamLifecycle(streamId, action, slotId)", channels_template)
@@ -132,11 +147,22 @@ class TestFrontendRegressions(unittest.TestCase):
         # pollChannelSidebarEvents (all using getElementById) can find it.
         self.assertIn('id="channel-list"', channels_template)
 
+    def test_sidebar_navigation_renders_unread_badges_and_attention_refresh(self) -> None:
+        base_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'base.html').read_text(encoding='utf-8')
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        self.assertIn('id="sidebar-nav-messages-badge"', base_template)
+        self.assertIn('id="sidebar-nav-channels-badge"', base_template)
+        self.assertIn('id="sidebar-nav-feed-badge"', base_template)
+        self.assertIn('attentionSummary:', base_template)
+        self.assertIn('sidebarAttentionSummary:', base_template)
+        self.assertIn('function setSidebarNavUnreadBadge(kind, count)', main_js)
+        self.assertIn('function requestCanopySidebarAttentionRefresh(options)', main_js)
+        self.assertIn('function startCanopySidebarAttentionPolling()', main_js)
+        self.assertIn("requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});", main_js)
+
     def test_dashboard_flash_messages_null_check(self) -> None:
         dashboard_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'dashboard.html').read_text(encoding='utf-8')
         # Must guard against missing .flash-messages before injecting new API key alert
         self.assertIn("if (flashContainer) flashContainer.innerHTML += keyAlert;", dashboard_template)
         self.assertNotIn("document.querySelector('.flash-messages').innerHTML += keyAlert;", dashboard_template)
-
-
 

--- a/tests/test_sidebar_attention_summary.py
+++ b/tests/test_sidebar_attention_summary.py
@@ -1,0 +1,241 @@
+"""Regression coverage for sidebar unread summary badges."""
+
+import os
+import sqlite3
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.ui.routes import create_ui_blueprint
+
+
+class _FakeDbManager:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def get_connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def get_instance_owner_user_id(self):
+        return None
+
+
+class _FakeFeedManager:
+    def __init__(self, unread_count: int = 0) -> None:
+        self.unread_count = unread_count
+        self.marked_users: list[str] = []
+
+    def count_unread_posts(self, user_id: str) -> int:
+        return int(self.unread_count)
+
+    def mark_feed_viewed(self, user_id: str) -> bool:
+        self.marked_users.append(str(user_id))
+        return True
+
+    def purge_expired_posts(self):
+        return []
+
+    def get_user_feed(self, user_id: str, limit: int = 50, algorithm: str = 'chronological'):
+        return []
+
+
+class TestSidebarAttentionSummary(unittest.TestCase):
+    def setUp(self) -> None:
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.row_factory = sqlite3.Row
+        self.conn.executescript(
+            """
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                username TEXT,
+                display_name TEXT,
+                avatar_file_id TEXT,
+                account_type TEXT,
+                origin_peer TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                sender_id TEXT NOT NULL,
+                recipient_id TEXT,
+                content TEXT,
+                message_type TEXT,
+                status TEXT,
+                created_at TEXT,
+                delivered_at TEXT,
+                read_at TEXT,
+                edited_at TEXT,
+                metadata TEXT
+            );
+            """
+        )
+        self.conn.executemany(
+            "INSERT INTO users (id, username, display_name, avatar_file_id, account_type, origin_peer, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ('owner', 'owner', 'Owner', None, 'human', None, '2026-03-16T09:00:00+00:00'),
+                ('peer-a', 'peer_a', 'Peer A', None, 'agent', None, '2026-03-16T09:01:00+00:00'),
+                ('peer-b', 'peer_b', 'Peer B', None, 'human', None, '2026-03-16T09:02:00+00:00'),
+            ],
+        )
+        self.conn.executemany(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    'dm-unread', 'peer-a', 'owner', 'Unread direct', 'text', 'delivered',
+                    '2026-03-16T10:00:00+00:00', '2026-03-16T10:00:01+00:00', None, None, None,
+                ),
+                (
+                    'group-unread', 'peer-b', 'group:alpha', 'Unread group', 'text', 'delivered',
+                    '2026-03-16T10:05:00+00:00', '2026-03-16T10:05:01+00:00', None, None,
+                    '{"group_id":"group:alpha","group_members":["owner","peer-b"]}',
+                ),
+                (
+                    'dm-read', 'peer-a', 'owner', 'Already read', 'text', 'delivered',
+                    '2026-03-16T10:10:00+00:00', '2026-03-16T10:10:01+00:00', '2026-03-16T10:11:00+00:00', None, None,
+                ),
+                (
+                    'dm-outbound', 'owner', 'peer-a', 'Sent by owner', 'text', 'delivered',
+                    '2026-03-16T10:12:00+00:00', '2026-03-16T10:12:01+00:00', None, None, None,
+                ),
+            ],
+        )
+        self.conn.commit()
+
+        self.db_manager = _FakeDbManager(self.conn)
+        self.feed_manager = _FakeFeedManager(unread_count=4)
+        self.channel_manager = MagicMock()
+        self.channel_manager.get_user_channels.return_value = [
+            SimpleNamespace(
+                id='chan-1',
+                name='general',
+                description='',
+                channel_type='public',
+                privacy_mode='open',
+                origin_peer='',
+                user_role='member',
+                member_count=3,
+                unread_count=2,
+                notifications_enabled=True,
+                crypto_mode='',
+                lifecycle_status='active',
+                lifecycle_ttl_days=180,
+                lifecycle_preserved=False,
+                archived_at=None,
+                archive_reason=None,
+                days_until_archive=None,
+                owner_peer_state=None,
+            ),
+            SimpleNamespace(
+                id='chan-2',
+                name='ops',
+                description='',
+                channel_type='private',
+                privacy_mode='open',
+                origin_peer='',
+                user_role='member',
+                member_count=2,
+                unread_count=3,
+                notifications_enabled=True,
+                crypto_mode='',
+                lifecycle_status='active',
+                lifecycle_ttl_days=180,
+                lifecycle_preserved=False,
+                archived_at=None,
+                archive_reason=None,
+                days_until_archive=None,
+                owner_peer_state=None,
+            ),
+        ]
+
+        self.interaction_manager = MagicMock()
+        self.interaction_manager.get_user_liked_ids.return_value = set()
+
+        components = (
+            self.db_manager,
+            MagicMock(),
+            MagicMock(),
+            None,
+            self.channel_manager,
+            MagicMock(),
+            self.feed_manager,
+            self.interaction_manager,
+            MagicMock(),
+            MagicMock(),
+            None,
+        )
+
+        self.get_components_patcher = patch('canopy.ui.routes.get_app_components', return_value=components)
+        self.get_components_patcher.start()
+        self.addCleanup(self.get_components_patcher.stop)
+
+        self.render_template_patcher = patch('canopy.ui.routes.render_template', return_value='ok')
+        self.render_template_patcher.start()
+        self.addCleanup(self.render_template_patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.register_blueprint(create_ui_blueprint())
+        self.client = app.test_client()
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'owner'
+            sess['username'] = 'owner'
+            sess['display_name'] = 'Owner'
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    def test_sidebar_attention_summary_reports_messages_channels_and_feed(self) -> None:
+        response = self.client.get('/ajax/sidebar_attention_summary')
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        self.assertTrue(payload.get('changed'))
+        self.assertEqual(payload.get('summary'), {
+            'messages': 2,
+            'channels': 5,
+            'feed': 4,
+            'total': 11,
+        })
+
+        rev = payload.get('rev')
+        repeat = self.client.get(f'/ajax/sidebar_attention_summary?rev={rev}')
+        self.assertEqual(repeat.status_code, 200)
+        repeat_payload = repeat.get_json() or {}
+        self.assertTrue(repeat_payload.get('success'))
+        self.assertFalse(repeat_payload.get('changed'))
+        self.assertEqual(repeat_payload.get('summary'), {})
+
+    def test_feed_route_marks_feed_viewed_on_page_open(self) -> None:
+        response = self.client.get('/feed')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.feed_manager.marked_users, ['owner'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add left-rail sidebar unread badges for Messages, Channels, and Social Feed with periodic polling refresh
- Add durable per-user feed-view acknowledgement so feed unread count reflects real new activity
- Fix notification bell deep-links to navigate to exact target messages via server-side focused context window
- Add semantic dedupe for bell events so mention+channel_message for the same source only count once
- Add container-aware focus scrolling in channels for reliable message targeting

## Test plan
- pytest tests/test_sidebar_attention_summary.py tests/test_feed_unread_state.py tests/test_frontend_regressions.py tests/test_channel_message_route_regressions.py -q
- python3 scripts/check_jinja_templates.py