### PR TITLE
Canopy v0.4.105 — search stability, sidebar polish, bell UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.4.105] - 2026-03-18
+
+### Fixed
+- **DM search stability** — The DM workspace now uses an explicit `isDmSearchActive()` helper that consistently suspends all live-refresh paths (event polling, snapshot resync, visibility-change refresh, manual Refresh button) while a search query is active. The Refresh button reloads the current search page instead of silently reverting to the live thread.
+- **Channel search stability** — Background thread refresh no longer overwrites channel search results. A new `rerunActiveChannelSearch()` path keeps search results coherent after local actions (delete, edit, stream create, note publish/rate, skill endorse) without reverting to the live thread. Search results scroll to the newest matches on initial search; reruns after local actions preserve scroll position.
+
+### Improved
+- **Left-rail card labels** — Card mode labels are hidden when collapsed (the chevron already indicates the state) and tightened to prevent overlap with count badges on narrow sidebars.
+
+## [0.4.103] - 2026-03-18
+
+### Improved
+- **Bell seen vs clear separation** — Opening the bell now clears the red badge without removing entries from the dropdown. A new `seenThrough` localStorage watermark tracks which items the user has already glanced at, while the existing `dismissedThrough` cursor still controls list removal via the Clear button. Badge count reflects only items newer than the seen cursor. Both cursors stay coherent (Clear advances both).
+
+## [0.4.102] - 2026-03-18
+
+### Improved
+- **Left-rail card states** — Recent DMs and Connected cards now support three persistent viewing states: collapsed, top 5 (peek), and expanded (bounded scroll). State persists per user in localStorage. Header toggle collapses/expands; footer toggle switches between peek and full list. DM unread total now reflects all contacts, not just the visible slice.
+- **Mini-player placement** — The sidebar mini-player can now be moved between a top and bottom slot. Placement persists per user in localStorage. Defaults to the top utility slot.
+
+## [0.4.101] - 2026-03-18
+
+### Fixed
+- **Channel read clears attention immediately** — Opening a channel now triggers an immediate sidebar and bell attention refresh when unread state is cleared, instead of waiting for the next poll cycle. `mark_channel_read()` returns whether it actually cleared unread state, the AJAX response exposes `marked_read`, and the channel view calls `requestCanopySidebarAttentionRefresh({ force: true })` on a positive transition.
+
 ## [0.4.100] - 2026-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.100-blue" alt="Version 0.4.100">
+  <img src="https://img.shields.io/badge/version-0.4.105-blue" alt="Version 0.4.105">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 License">
   <img src="https://img.shields.io/badge/encryption-ChaCha20--Poly1305-blueviolet" alt="ChaCha20-Poly1305">
@@ -79,13 +79,13 @@ Most chat products treat AI as bolt-on automation hanging off webhooks or extern
 
 Recent user-facing changes reflected in the app and docs:
 
+- **Search stability and UX** in `0.4.104`-`0.4.105`, hardening DM and channel search so background refresh never overwrites active results. Channel search scrolls to the newest matches. Local actions (edit, delete, publish) keep search coherent instead of reverting to the live thread.
+- **Sidebar polish** in `0.4.101`-`0.4.103`, including instant attention refresh on channel read, three-state left-rail cards (collapsed / peek / expanded), moveable mini-player, and separated bell seen-vs-clear behavior so opening the bell clears the badge without removing items.
 - **First-run guidance and smart landing** in `0.4.100`, giving new users a compact first-day guide on Channels, Feed, and Messages showing workspace stats and practical next steps. Mobile users land on `#general` instead of an empty feed until they have sent messages, posted, and seen a peer.
 - **Event-driven attention center** in `0.4.97`-`0.4.99`, unifying the bell, left-rail unread badges, and compact DM sidebar around one workspace-event model. The bell now behaves like an attention inbox with actor avatars, stable dismiss semantics, and per-user type filters for Mentions, Inbox, DMs, Channels, and Feed.
 - **Curated channels with durable enforcement** in `0.4.91`-`0.4.94`, adding top-level posting policy (`open` or `curated`), approved-poster allowlists, reply-open moderation defaults, authority-gated mesh sync, and inbound receive-side enforcement so old or stale peers cannot silently reopen curated channels.
-- **Responsive channel workspace polish** in `0.4.95`-`0.4.96`, including channel-header compaction for narrow and landscape layouts plus YouTube click-to-play facades that avoid immediate iframe flood and third-party throttling.
 - **Inline map, chart, and rich media embeds** in `0.4.84`-`0.4.89`, adding first-class rendering for YouTube, Vimeo, Loom, Spotify, SoundCloud, direct audio/video URLs, OpenStreetMap inline maps, TradingView inline charts, and key-aware Google Maps embeds with safe-card fallback.
 - **Streaming runtime hardening** in `0.4.84`-`0.4.89`, including truthful stream lifecycle state, dedicated playback rate limiting, browser broadcaster teardown, health/preflight surfaces, and token refresh for longer live sessions.
-- **Agent event-feed maturity** in `0.4.77`-`0.4.80`, adding `GET /api/v1/agents/me/events`, durable event subscriptions, quiet-feed support, and cleaner heartbeat/admin diagnostics for real agent runtimes.
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 

--- a/canopy/__init__.py
+++ b/canopy/__init__.py
@@ -11,7 +11,7 @@ License: Apache 2.0
 Development: AI-assisted implementation (Claude, Codex, GitHub Copilot, Cursor IDE, Ollama)
 """
 
-__version__ = "0.4.100"
+__version__ = "0.4.105"
 __protocol_version__ = 1
 __author__ = "Canopy Contributors"
 __license__ = "Apache-2.0"

--- a/canopy/core/channels.py
+++ b/canopy/core/channels.py
@@ -4802,7 +4802,7 @@ class ChannelManager:
         role = decision.get('role')
         return str(role) if role else None
 
-    def mark_channel_read(self, channel_id: str, user_id: str) -> None:
+    def mark_channel_read(self, channel_id: str, user_id: str) -> bool:
         """Update last_read_at for a user in a channel to now, clearing its unread count."""
         try:
             with self.db.get_connection() as conn:
@@ -4824,7 +4824,7 @@ class ChannelManager:
                     (channel_id, user_id),
                 ).fetchone()
                 if not unread_exists:
-                    return
+                    return False
                 conn.execute(
                     """UPDATE channel_members SET last_read_at = CURRENT_TIMESTAMP
                        WHERE channel_id = ? AND user_id = ?""",
@@ -4839,8 +4839,10 @@ class ChannelManager:
                 payload={"reason": "channel_read"},
                 dedupe_suffix=f"channel_read:{user_id}",
             )
+            return True
         except Exception as e:
             logger.warning(f"Failed to mark channel {channel_id} as read for {user_id}: {e}")
+            return False
 
     def is_channel_admin(self, channel_id: str, user_id: str) -> bool:
         """Check if a user is an admin (or creator) of a channel."""

--- a/canopy/ui/routes.py
+++ b/canopy/ui/routes.py
@@ -10511,8 +10511,8 @@ def create_ui_blueprint() -> Blueprint:
                         'reason': access.get('reason'),
                     }), 403
                 return jsonify({'error': 'You are not a member of this channel'}), 403
-            # Mark channel as read now that the user is viewing it
-            channel_manager.mark_channel_read(channel_id, user_id)
+            # Mark channel as read now that the user is viewing it.
+            marked_read = channel_manager.mark_channel_read(channel_id, user_id) is True
             try:
                 workspace_event_cursor = int((workspace_event_manager.get_latest_seq() if workspace_event_manager else 0) or 0)
             except Exception:
@@ -11139,6 +11139,7 @@ def create_ui_blueprint() -> Blueprint:
                 'messages': messages_data,
                 'channel_id': channel_id,
                 'count': len(messages_data),
+                'marked_read': marked_read,
                 'workspace_event_cursor': workspace_event_cursor,
                 'focus_message_id': focus_message_id or None,
                 'focus_message_found': focus_message_found,

--- a/canopy/ui/static/js/canopy-main.js
+++ b/canopy/ui/static/js/canopy-main.js
@@ -349,10 +349,136 @@
         const canopyInitialAttentionActivityRev = window.CANOPY_VARS ? (window.CANOPY_VARS.attentionActivityRev || '') : '';
         const canopyInitialAttentionEventCursor = window.CANOPY_VARS ? Number(window.CANOPY_VARS.attentionEventCursor || 0) : 0;
         const canopyLocalPeerId = window.CANOPY_VARS ? String(window.CANOPY_VARS.localPeerId || '').trim() : '';
-        const SIDEBAR_VISIBLE_PEER_LIMIT = 12;
+        const SIDEBAR_CARD_PEEK_LIMIT = 5;
+        const canopySidebarRailStoragePrefix = (() => {
+            const userId = window.CANOPY_VARS ? String(window.CANOPY_VARS.userId || 'local_user').trim() : 'local_user';
+            return `canopy.sidebar.rail.${userId || 'local_user'}`;
+        })();
         window.canopyPeerProfiles = canopyPeerProfiles || {};
         window.canopyPeerTrust = canopyPeerTrust || {};
         window.canopyInitialConnectedPeers = canopyInitialConnectedPeers || [];
+
+        function normalizeSidebarCardState(state) {
+            const raw = String(state || '').trim().toLowerCase();
+            if (raw === 'collapsed' || raw === 'expanded') return raw;
+            return 'peek';
+        }
+
+        function loadSidebarRailPreference(key, fallback) {
+            try {
+                if (!window.localStorage) return fallback;
+                const raw = window.localStorage.getItem(`${canopySidebarRailStoragePrefix}.${key}`);
+                return raw == null ? fallback : raw;
+            } catch (_) {
+                return fallback;
+            }
+        }
+
+        function saveSidebarRailPreference(key, value) {
+            try {
+                if (window.localStorage) {
+                    window.localStorage.setItem(`${canopySidebarRailStoragePrefix}.${key}`, String(value));
+                }
+            } catch (_) {}
+        }
+
+        const canopySidebarRailState = {
+            cards: {
+                dm: normalizeSidebarCardState(loadSidebarRailPreference('dmCardState', 'peek')),
+                peers: normalizeSidebarCardState(loadSidebarRailPreference('peerCardState', 'peek')),
+            },
+            miniPosition: String(loadSidebarRailPreference('miniPosition', 'top') || 'top').trim().toLowerCase() === 'bottom' ? 'bottom' : 'top',
+        };
+
+        function getSidebarCardState(kind) {
+            return canopySidebarRailState.cards[kind] || 'peek';
+        }
+
+        function setSidebarCardState(kind, nextState) {
+            const normalized = normalizeSidebarCardState(nextState);
+            canopySidebarRailState.cards[kind] = normalized;
+            saveSidebarRailPreference(kind === 'dm' ? 'dmCardState' : 'peerCardState', normalized);
+            if (kind === 'dm') {
+                canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
+            } else if (kind === 'peers') {
+                renderSidebarPeers();
+            }
+        }
+
+        function toggleSidebarCardCollapsed(kind) {
+            const current = getSidebarCardState(kind);
+            setSidebarCardState(kind, current === 'collapsed' ? 'peek' : 'collapsed');
+        }
+
+        function toggleSidebarCardExpansion(kind, totalCount) {
+            const current = getSidebarCardState(kind);
+            const normalizedTotal = Math.max(0, Number(totalCount) || 0);
+            if (normalizedTotal <= SIDEBAR_CARD_PEEK_LIMIT) {
+                if (current === 'collapsed') {
+                    setSidebarCardState(kind, 'peek');
+                }
+                return;
+            }
+            setSidebarCardState(kind, current === 'expanded' ? 'peek' : 'expanded');
+        }
+
+        function visibleSidebarCardItems(kind, items) {
+            const normalized = Array.isArray(items) ? items.filter(Boolean) : [];
+            const state = getSidebarCardState(kind);
+            if (state === 'collapsed') return [];
+            if (state === 'expanded') return normalized;
+            return normalized.slice(0, SIDEBAR_CARD_PEEK_LIMIT);
+        }
+
+        function updateSidebarCardChrome(kind, totalCount) {
+            const state = getSidebarCardState(kind);
+            const safeTotal = Math.max(0, Number(totalCount) || 0);
+            const prefix = kind === 'dm' ? 'sidebar-dm' : 'sidebar-peers';
+            const card = document.getElementById(`${prefix}-card`);
+            const modeLabel = document.getElementById(`${prefix}-mode-label`);
+            const toggleBtn = document.getElementById(`${prefix}-toggle`);
+            const footer = document.getElementById(`${prefix}-footer`);
+            const summary = document.getElementById(`${prefix}-summary`);
+            const expandBtn = document.getElementById(`${prefix}-expand-btn`);
+            const hasOverflow = safeTotal > SIDEBAR_CARD_PEEK_LIMIT;
+            if (card) {
+                card.setAttribute('data-view-state', state);
+            }
+            if (modeLabel) {
+                modeLabel.textContent = state === 'collapsed' ? '' : (state === 'expanded' ? 'All' : 'Top 5');
+                modeLabel.hidden = state === 'collapsed';
+            }
+            if (toggleBtn) {
+                const icon = toggleBtn.querySelector('i');
+                if (icon) {
+                    icon.className = `bi bi-chevron-${state === 'collapsed' ? 'down' : 'up'}`;
+                }
+                toggleBtn.setAttribute('aria-label', `${state === 'collapsed' ? 'Expand' : 'Collapse'} ${kind === 'dm' ? 'recent direct messages' : 'connected peers'}`);
+            }
+            if (summary) {
+                if (safeTotal <= 0) {
+                    summary.textContent = kind === 'dm' ? 'No recent conversations' : 'No active peers';
+                } else if (state === 'expanded' && hasOverflow) {
+                    summary.textContent = `Showing all ${safeTotal}`;
+                } else if (hasOverflow) {
+                    summary.textContent = `Showing top ${SIDEBAR_CARD_PEEK_LIMIT} of ${safeTotal}`;
+                } else {
+                    summary.textContent = `Showing all ${safeTotal}`;
+                }
+            }
+            if (footer) {
+                footer.hidden = state === 'collapsed' || safeTotal <= 0;
+            }
+            if (expandBtn) {
+                expandBtn.hidden = state === 'collapsed' || !hasOverflow;
+                expandBtn.innerHTML = state === 'expanded'
+                    ? '<i class="bi bi-arrows-collapse"></i><span>Show less</span>'
+                    : `<i class="bi bi-arrows-angle-expand"></i><span>View ${safeTotal - SIDEBAR_CARD_PEEK_LIMIT} more</span>`;
+                expandBtn.setAttribute('aria-label', state === 'expanded'
+                    ? `Show fewer ${kind === 'dm' ? 'direct messages' : 'connected peers'}`
+                    : `Show more ${kind === 'dm' ? 'direct messages' : 'connected peers'}`);
+            }
+        }
 
         function canopyInitial(label) {
             const text = (label || '?').trim();
@@ -523,8 +649,6 @@
 
         function renderSidebarPeers() {
             const listEl = document.getElementById('sidebar-peer-list');
-            const moreWrap = document.getElementById('sidebar-peer-more');
-            const moreBtn = document.getElementById('sidebar-peer-more-btn');
             if (!listEl) return;
             const activePeers = Array.from(canopySidebarPeerState.peers.values())
                 .filter(record => record && record.active)
@@ -541,24 +665,16 @@
                 empty.textContent = 'No active peers';
                 listEl.appendChild(empty);
                 setSidebarPeerCount(0);
-                if (moreWrap) moreWrap.style.display = 'none';
+                updateSidebarCardChrome('peers', 0);
                 return;
             }
 
-            const visiblePeers = activePeers.slice(0, SIDEBAR_VISIBLE_PEER_LIMIT);
+            const visiblePeers = visibleSidebarCardItems('peers', activePeers);
             visiblePeers.forEach(record => {
                 listEl.appendChild(createSidebarPeerElement(record));
             });
             setSidebarPeerCount(activePeers.length);
-            const overflowCount = Math.max(0, activePeers.length - visiblePeers.length);
-            if (moreWrap && moreBtn) {
-                if (overflowCount > 0) {
-                    moreWrap.style.display = '';
-                    moreBtn.textContent = `View ${overflowCount} more peer${overflowCount === 1 ? '' : 's'}`;
-                } else {
-                    moreWrap.style.display = 'none';
-                }
-            }
+            updateSidebarCardChrome('peers', activePeers.length);
             renderSidebarPeerModalList();
         }
 
@@ -635,10 +751,27 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             seedSidebarPeerState();
+            canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
             renderSidebarPeers();
-            const moreBtn = document.getElementById('sidebar-peer-more-btn');
-            if (moreBtn) {
-                moreBtn.addEventListener('click', openSidebarPeersModal);
+            const dmToggleBtn = document.getElementById('sidebar-dm-toggle');
+            if (dmToggleBtn) {
+                dmToggleBtn.addEventListener('click', () => toggleSidebarCardCollapsed('dm'));
+            }
+            const dmExpandBtn = document.getElementById('sidebar-dm-expand-btn');
+            if (dmExpandBtn) {
+                dmExpandBtn.addEventListener('click', () => toggleSidebarCardExpansion('dm', canopySidebarDmState.contacts.length));
+            }
+            const peersToggleBtn = document.getElementById('sidebar-peers-toggle');
+            if (peersToggleBtn) {
+                peersToggleBtn.addEventListener('click', () => toggleSidebarCardCollapsed('peers'));
+            }
+            const peersExpandBtn = document.getElementById('sidebar-peers-expand-btn');
+            if (peersExpandBtn) {
+                peersExpandBtn.addEventListener('click', () => toggleSidebarCardExpansion('peers', getActiveSidebarPeers().length));
+            }
+            const peersOpenModalBtn = document.getElementById('sidebar-peers-open-modal');
+            if (peersOpenModalBtn) {
+                peersOpenModalBtn.addEventListener('click', openSidebarPeersModal);
             }
             const peerSearch = document.getElementById('sidebar-peers-search');
             if (peerSearch) {
@@ -724,7 +857,8 @@
             const totalEl = document.getElementById('sidebar-dm-unread-total');
             if (!listEl) return;
 
-            const normalized = Array.isArray(contacts) ? contacts.filter(Boolean).slice(0, 5) : [];
+            const normalized = Array.isArray(contacts) ? contacts.filter(Boolean) : [];
+            const visibleContacts = visibleSidebarCardItems('dm', normalized);
             const totalUnread = normalized.reduce((sum, contact) => sum + Math.max(0, Number(contact && contact.unread_count) || 0), 0);
             if (totalEl) totalEl.textContent = String(totalUnread);
 
@@ -734,10 +868,11 @@
                 empty.className = 'sidebar-peer-empty';
                 empty.textContent = 'No recent direct messages';
                 listEl.appendChild(empty);
+                updateSidebarCardChrome('dm', 0);
                 return;
             }
 
-            normalized.forEach(contact => {
+            visibleContacts.forEach(contact => {
                 const link = document.createElement('a');
                 link.className = 'sidebar-dm-contact';
                 if (Number(contact.unread_count) > 0) {
@@ -807,6 +942,8 @@
 
                 listEl.appendChild(link);
             });
+
+            updateSidebarCardChrome('dm', normalized.length);
         }
 
         window.syncCanopySidebarDmContacts = function(payload) {
@@ -928,6 +1065,10 @@
             const userId = window.CANOPY_VARS ? String(window.CANOPY_VARS.userId || 'local_user').trim() : 'local_user';
             return `canopy.attention.dismissedThrough.${userId || 'local_user'}`;
         })();
+        const canopyAttentionSeenStorageKey = (() => {
+            const userId = window.CANOPY_VARS ? String(window.CANOPY_VARS.userId || 'local_user').trim() : 'local_user';
+            return `canopy.attention.seenThrough.${userId || 'local_user'}`;
+        })();
 
         const CANOPY_ATTENTION_FILTER_DEFS = [
             { key: 'mention', label: 'Mentions', icon: 'bi-at' },
@@ -997,6 +1138,26 @@
             return normalized;
         }
 
+        function loadCanopyAttentionSeenCursor() {
+            try {
+                const raw = window.localStorage ? window.localStorage.getItem(canopyAttentionSeenStorageKey) : null;
+                return Math.max(0, Number(raw || 0) || 0);
+            } catch (_) {
+                return 0;
+            }
+        }
+
+        function saveCanopyAttentionSeenCursor(value) {
+            const normalized = Math.max(0, Number(value || 0) || 0);
+            canopySidebarAttentionState.seenThroughCursor = normalized;
+            try {
+                if (window.localStorage) {
+                    window.localStorage.setItem(canopyAttentionSeenStorageKey, String(normalized));
+                }
+            } catch (_) {}
+            return normalized;
+        }
+
         function filterCanopyAttentionItems(items) {
             const dismissedThrough = Math.max(0, Number(canopySidebarAttentionState.dismissedThroughCursor || 0) || 0);
             const normalized = Array.isArray(items) ? items.filter(Boolean) : [];
@@ -1012,7 +1173,24 @@
             });
         }
 
+        function countUnseenCanopyAttentionItems(items) {
+            const seenThrough = Math.max(
+                0,
+                Number(canopySidebarAttentionState.seenThroughCursor || 0) || 0,
+                Number(canopySidebarAttentionState.dismissedThroughCursor || 0) || 0
+            );
+            const normalized = Array.isArray(items) ? items.filter(Boolean) : [];
+            return normalized.reduce((sum, item) => {
+                const seq = Math.max(0, Number(item && item.seq || 0) || 0);
+                return sum + (seq > seenThrough ? 1 : 0);
+            }, 0);
+        }
+
         canopySidebarAttentionState.dismissedThroughCursor = loadCanopyAttentionDismissCursor();
+        canopySidebarAttentionState.seenThroughCursor = Math.max(
+            canopySidebarAttentionState.dismissedThroughCursor,
+            loadCanopyAttentionSeenCursor()
+        );
         canopySidebarAttentionState.filters = loadCanopyAttentionFilters();
 
         const SIDEBAR_ATTENTION_EVENT_TYPES = [
@@ -4523,11 +4701,11 @@
             window.renderCanopyAttentionBell = function(items) {
                 const normalized = Array.isArray(items) ? items.filter(Boolean).slice(0, 12) : [];
                 if (!listEl) {
-                    setBadge(normalized.length);
+                    setBadge(countUnseenCanopyAttentionItems(normalized));
                     return;
                 }
                 listEl.innerHTML = '';
-                setBadge(normalized.length);
+                setBadge(countUnseenCanopyAttentionItems(normalized));
                 if (!normalized.length) {
                     if (emptyWrap) emptyWrap.style.display = 'block';
                     return;
@@ -4610,6 +4788,7 @@
                 clearBtn.addEventListener('click', () => {
                     canopySidebarAttentionState.items = [];
                     saveCanopyAttentionDismissCursor(canopySidebarAttentionState.currentEventCursor);
+                    saveCanopyAttentionSeenCursor(canopySidebarAttentionState.currentEventCursor);
                     if (window.renderCanopyAttentionBell) {
                         window.renderCanopyAttentionBell([]);
                     }
@@ -4628,6 +4807,7 @@
 
             if (bellBtn) {
                 bellBtn.addEventListener('click', () => {
+                    saveCanopyAttentionSeenCursor(canopySidebarAttentionState.currentEventCursor);
                     if (window.renderCanopyAttentionBell) {
                         window.renderCanopyAttentionBell(filterCanopyAttentionItems(canopySidebarAttentionState.items));
                     }
@@ -4676,10 +4856,13 @@
             const playBtn = document.getElementById('sidebar-media-mini-play');
             const jumpBtn = document.getElementById('sidebar-media-mini-jump');
             const pipBtn = document.getElementById('sidebar-media-mini-pip');
+            const pinBtn = document.getElementById('sidebar-media-mini-pin');
             const closeBtn = document.getElementById('sidebar-media-mini-close');
             const timeEl = document.getElementById('sidebar-media-mini-time');
             const mainScroller = document.querySelector('.main-content');
             const miniVideoHost = document.getElementById('sidebar-media-mini-video');
+            const topSlot = document.getElementById('sidebar-media-mini-slot-top');
+            const bottomSlot = document.getElementById('sidebar-media-mini-slot-bottom');
 
             const state = {
                 current: null,
@@ -4691,6 +4874,29 @@
                 returnUrl: null,
                 dockedSubtitle: null
             };
+
+            function updateMiniPlacementControl() {
+                if (!pinBtn) return;
+                const atBottom = canopySidebarRailState.miniPosition === 'bottom';
+                pinBtn.innerHTML = atBottom
+                    ? '<i class="bi bi-arrow-up-square"></i>'
+                    : '<i class="bi bi-arrow-down-square"></i>';
+                pinBtn.title = atBottom ? 'Move mini player to top' : 'Move mini player lower';
+                pinBtn.setAttribute('aria-label', atBottom ? 'Move mini player to top' : 'Move mini player lower');
+            }
+
+            function setCanopySidebarMiniPosition(nextPosition) {
+                const normalized = String(nextPosition || '').trim().toLowerCase() === 'bottom' ? 'bottom' : 'top';
+                const targetSlot = normalized === 'bottom' ? bottomSlot : topSlot;
+                if (mini && targetSlot && mini.parentElement !== targetSlot) {
+                    targetSlot.appendChild(mini);
+                }
+                canopySidebarRailState.miniPosition = normalized;
+                saveSidebarRailPreference('miniPosition', normalized);
+                updateMiniPlacementControl();
+            }
+
+            setCanopySidebarMiniPosition(canopySidebarRailState.miniPosition);
 
             function mediaTypeFor(el) {
                 if (!el || !el.tagName) return '';
@@ -5439,6 +5645,12 @@
                         miniVideoHost.innerHTML = '';
                     }
                     hideMini();
+                });
+            }
+
+            if (pinBtn) {
+                pinBtn.addEventListener('click', () => {
+                    setCanopySidebarMiniPosition(canopySidebarRailState.miniPosition === 'bottom' ? 'top' : 'bottom');
                 });
             }
 

--- a/canopy/ui/templates/base.html
+++ b/canopy/ui/templates/base.html
@@ -341,6 +341,10 @@
             display: none !important;
         }
 
+        .sidebar-utility-slot:empty {
+            display: none;
+        }
+
         .sidebar-peers {
             margin: 8px 12px 8px;
             padding: 10px;
@@ -362,16 +366,146 @@
             backdrop-filter: blur(12px) saturate(135%);
         }
 
+        .sidebar-panel-heading {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            min-width: 0;
+            overflow: hidden;
+        }
+
+        .sidebar-panel-title {
+            min-width: 0;
+        }
+
+        .sidebar-panel-mode {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 1.3rem;
+            padding: 0.12rem 0.48rem;
+            border-radius: 999px;
+            background: rgba(15, 23, 42, 0.7);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            color: var(--canopy-text-secondary);
+            font-size: 0.6rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            white-space: nowrap;
+        }
+
+        .sidebar-panel-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            flex-shrink: 0;
+        }
+
+        .sidebar-panel-icon-btn,
+        .sidebar-media-mini-pin {
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--canopy-text-secondary);
+            width: 28px;
+            height: 28px;
+            border-radius: 9px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s ease;
+            flex-shrink: 0;
+        }
+
+        .sidebar-panel-icon-btn:hover,
+        .sidebar-media-mini-pin:hover {
+            background: rgba(34, 197, 94, 0.12);
+            border-color: rgba(74, 222, 128, 0.35);
+            color: #dcfce7;
+        }
+
+        .sidebar-panel-icon-btn:focus-visible,
+        .sidebar-media-mini-pin:focus-visible {
+            outline: none;
+            background: rgba(34, 197, 94, 0.12);
+            border-color: rgba(74, 222, 128, 0.42);
+            box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.22);
+            color: #dcfce7;
+        }
+
+        .sidebar-panel-footer {
+            margin-top: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+        }
+
+        .sidebar-panel-footer[hidden] {
+            display: none !important;
+        }
+
+        .sidebar-panel-summary {
+            font-size: 0.65rem;
+            color: var(--canopy-text-muted);
+            letter-spacing: 0.02em;
+        }
+
+        .sidebar-panel-expand-btn {
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--canopy-text-secondary);
+            padding: 0.35rem 0.6rem;
+            border-radius: 10px;
+            font-size: 0.68rem;
+            line-height: 1;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            transition: all 0.2s ease;
+        }
+
+        .sidebar-panel-expand-btn:hover {
+            background: rgba(34, 197, 94, 0.12);
+            border-color: rgba(74, 222, 128, 0.35);
+            color: #dcfce7;
+        }
+
+        .sidebar-panel-expand-btn:focus-visible {
+            outline: none;
+            background: rgba(34, 197, 94, 0.12);
+            border-color: rgba(74, 222, 128, 0.42);
+            box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.22);
+            color: #dcfce7;
+        }
+
         .sidebar-dm-list {
             margin-top: 8px;
             display: flex;
             flex-direction: column;
             gap: 7px;
-            max-height: 232px;
-            overflow-y: auto;
+            max-height: none;
+            overflow-y: visible;
             overflow-x: hidden;
             overscroll-behavior: contain;
             scrollbar-gutter: stable;
+        }
+
+        .sidebar-dm-contacts[data-view-state="collapsed"] .sidebar-dm-list,
+        .sidebar-peers[data-view-state="collapsed"] .sidebar-peer-list {
+            display: none;
+        }
+
+        .sidebar-dm-contacts[data-view-state="collapsed"],
+        .sidebar-peers[data-view-state="collapsed"] {
+            padding-bottom: 10px;
+        }
+
+        .sidebar-dm-contacts[data-view-state="expanded"] .sidebar-dm-list,
+        .sidebar-peers[data-view-state="expanded"] .sidebar-peer-list {
+            max-height: min(38vh, 360px);
+            overflow-y: auto;
+            padding-right: 2px;
         }
 
         .sidebar-dm-contact {
@@ -555,6 +689,13 @@
             align-items: center;
             gap: 8px;
             margin-bottom: 8px;
+        }
+
+        .sidebar-media-mini-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            margin-left: auto;
         }
 
         .sidebar-media-mini-icon {
@@ -746,6 +887,7 @@
             letter-spacing: 0.13em;
             text-transform: uppercase;
             color: var(--canopy-text-muted);
+            gap: 0.65rem;
         }
 
         .sidebar-peers-count {
@@ -761,8 +903,8 @@
             display: flex;
             flex-direction: column;
             gap: 7px;
-            max-height: 272px;
-            overflow-y: auto;
+            max-height: none;
+            overflow-y: visible;
             overflow-x: hidden;
             overscroll-behavior: contain;
             scrollbar-gutter: stable;
@@ -835,29 +977,6 @@
             font-size: 0.72rem;
             color: var(--canopy-text-muted);
             padding: 8px 4px;
-        }
-
-        .sidebar-peer-more {
-            margin-top: 4px;
-        }
-
-        .sidebar-peer-more-btn {
-            width: 100%;
-            border-radius: 10px;
-            border: 1px dashed rgba(255, 255, 255, 0.12);
-            background: rgba(255, 255, 255, 0.035);
-            color: var(--canopy-text-muted);
-            font-size: 0.72rem;
-            font-weight: 600;
-            letter-spacing: 0.03em;
-            padding: 8px 10px;
-            transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease;
-        }
-
-        .sidebar-peer-more-btn:hover {
-            color: var(--canopy-text-primary);
-            border-color: rgba(56, 189, 248, 0.28);
-            background: rgba(56, 189, 248, 0.08);
         }
 
         .peer-modal-search {
@@ -1516,21 +1635,20 @@
             }
 
             .sidebar-dm-list {
-                display: grid;
-                grid-template-columns: repeat(2, minmax(0, 1fr));
+                display: flex;
+                flex-direction: column;
                 gap: 6px;
                 max-height: none;
             }
 
             .sidebar-dm-contact {
-                grid-template-columns: auto 1fr;
-                align-items: start;
+                grid-template-columns: auto minmax(0, 1fr);
+                align-items: center;
                 gap: 7px;
                 padding: 7px;
             }
 
-            .sidebar-dm-time,
-            .sidebar-dm-preview {
+            .sidebar-dm-time {
                 display: none;
             }
 
@@ -1546,12 +1664,17 @@
             }
 
             .sidebar-dm-name {
-                font-size: 0.72rem;
+                font-size: 0.74rem;
                 line-height: 1.2;
-                white-space: normal;
-                display: -webkit-box;
-                -webkit-line-clamp: 2;
-                -webkit-box-orient: vertical;
+            }
+
+            .sidebar-dm-preview {
+                font-size: 0.64rem;
+            }
+
+            .sidebar-dm-contacts[data-view-state="expanded"] .sidebar-dm-list,
+            .sidebar-peers[data-view-state="expanded"] .sidebar-peer-list {
+                max-height: min(42vh, 300px);
             }
 
             .navbar {
@@ -5659,13 +5782,59 @@
                         {% endif %}
                     </nav>
 
+                    <div class="sidebar-utility-slot" id="sidebar-media-mini-slot-top">
+                        <div id="sidebar-media-mini" class="sidebar-media-mini" aria-live="polite" aria-label="Media mini player">
+                            <div class="sidebar-media-mini-top">
+                                <div class="sidebar-media-mini-icon" id="sidebar-media-mini-icon">
+                                    <i class="bi bi-music-note-beamed"></i>
+                                </div>
+                                <div class="sidebar-media-mini-meta">
+                                    <div class="sidebar-media-mini-title" id="sidebar-media-mini-title">Now Playing</div>
+                                    <div class="sidebar-media-mini-subtitle" id="sidebar-media-mini-subtitle">Media is docked while off-screen</div>
+                                </div>
+                                <div class="sidebar-media-mini-actions">
+                                    <button type="button" class="sidebar-media-mini-pin" id="sidebar-media-mini-pin" aria-label="Move mini player">
+                                        <i class="bi bi-arrow-up-right-square"></i>
+                                    </button>
+                                    <button type="button" class="sidebar-media-mini-close" id="sidebar-media-mini-close" aria-label="Dismiss mini player">
+                                        <i class="bi bi-x-lg"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="sidebar-media-mini-progress" id="sidebar-media-mini-progress">
+                                <span id="sidebar-media-mini-progress-bar"></span>
+                            </div>
+                            <div id="sidebar-media-mini-video" class="sidebar-media-mini-video" aria-label="Mini video player"></div>
+                            <div class="sidebar-media-mini-controls">
+                                <button type="button" class="sidebar-media-mini-btn" id="sidebar-media-mini-play">
+                                    <i class="bi bi-pause-fill me-1"></i><span>Pause</span>
+                                </button>
+                                <button type="button" class="sidebar-media-mini-btn" id="sidebar-media-mini-jump">
+                                    <i class="bi bi-arrow-up-right-square me-1"></i><span>Return</span>
+                                </button>
+                                <button type="button" class="sidebar-media-mini-btn" id="sidebar-media-mini-pip" style="display:none;">
+                                    <i class="bi bi-pip me-1"></i><span>PiP</span>
+                                </button>
+                                <span class="sidebar-media-mini-time" id="sidebar-media-mini-time">--:--</span>
+                            </div>
+                        </div>
+                    </div>
+
                     {% if sidebar_recent_dm_contacts is defined %}
-                    <div class="sidebar-dm-contacts">
+                    <div class="sidebar-dm-contacts" id="sidebar-dm-card" data-view-state="peek">
                         <div class="sidebar-peers-header">
-                            <span>Recent DMs</span>
-                            <span class="sidebar-peers-count" id="sidebar-dm-unread-total">
-                                {{ sidebar_recent_dm_contacts|sum(attribute='unread_count') }}
-                            </span>
+                            <div class="sidebar-panel-heading">
+                                <span class="sidebar-panel-title">Recent DMs</span>
+                                <span class="sidebar-panel-mode" id="sidebar-dm-mode-label">Top 5</span>
+                                <span class="sidebar-peers-count" id="sidebar-dm-unread-total">
+                                    {{ sidebar_recent_dm_contacts|sum(attribute='unread_count') }}
+                                </span>
+                            </div>
+                            <div class="sidebar-panel-actions">
+                                <button type="button" class="sidebar-panel-icon-btn" id="sidebar-dm-toggle" aria-label="Collapse recent direct messages">
+                                    <i class="bi bi-chevron-up"></i>
+                                </button>
+                            </div>
                         </div>
                         <div class="sidebar-dm-list" id="sidebar-dm-list">
                             {% if sidebar_recent_dm_contacts %}
@@ -5704,45 +5873,31 @@
                                 <div class="sidebar-peer-empty">No recent direct messages</div>
                             {% endif %}
                         </div>
+                        <div class="sidebar-panel-footer" id="sidebar-dm-footer">
+                            <span class="sidebar-panel-summary" id="sidebar-dm-summary">Showing up to five conversations</span>
+                            <button type="button" class="sidebar-panel-expand-btn" id="sidebar-dm-expand-btn" hidden>
+                                <i class="bi bi-arrows-angle-expand"></i><span>View more</span>
+                            </button>
+                        </div>
                     </div>
                     {% endif %}
 
-                    <div id="sidebar-media-mini" class="sidebar-media-mini" aria-live="polite" aria-label="Media mini player">
-                        <div class="sidebar-media-mini-top">
-                            <div class="sidebar-media-mini-icon" id="sidebar-media-mini-icon">
-                                <i class="bi bi-music-note-beamed"></i>
-                            </div>
-                            <div class="sidebar-media-mini-meta">
-                                <div class="sidebar-media-mini-title" id="sidebar-media-mini-title">Now Playing</div>
-                                <div class="sidebar-media-mini-subtitle" id="sidebar-media-mini-subtitle">Media is docked while off-screen</div>
-                            </div>
-                            <button type="button" class="sidebar-media-mini-close" id="sidebar-media-mini-close" aria-label="Dismiss mini player">
-                                <i class="bi bi-x-lg"></i>
-                            </button>
-                        </div>
-                        <div class="sidebar-media-mini-progress" id="sidebar-media-mini-progress">
-                            <span id="sidebar-media-mini-progress-bar"></span>
-                        </div>
-                        <div id="sidebar-media-mini-video" class="sidebar-media-mini-video" aria-label="Mini video player"></div>
-                        <div class="sidebar-media-mini-controls">
-                            <button type="button" class="sidebar-media-mini-btn" id="sidebar-media-mini-play">
-                                <i class="bi bi-pause-fill me-1"></i><span>Pause</span>
-                            </button>
-                            <button type="button" class="sidebar-media-mini-btn" id="sidebar-media-mini-jump">
-                                <i class="bi bi-arrow-up-right-square me-1"></i><span>Return</span>
-                            </button>
-                            <button type="button" class="sidebar-media-mini-btn" id="sidebar-media-mini-pip" style="display:none;">
-                                <i class="bi bi-pip me-1"></i><span>PiP</span>
-                            </button>
-                            <span class="sidebar-media-mini-time" id="sidebar-media-mini-time">--:--</span>
-                        </div>
-                    </div>
-
                     {% if sidebar_connected_peers is defined %}
-                    <div class="sidebar-peers">
+                    <div class="sidebar-peers" id="sidebar-peers-card" data-view-state="peek">
                         <div class="sidebar-peers-header">
-                            <span>Connected</span>
-                            <span class="sidebar-peers-count" id="sidebar-peer-count">{{ sidebar_connected_peers|length }}</span>
+                            <div class="sidebar-panel-heading">
+                                <span class="sidebar-panel-title">Connected</span>
+                                <span class="sidebar-panel-mode" id="sidebar-peers-mode-label">Top 5</span>
+                                <span class="sidebar-peers-count" id="sidebar-peer-count">{{ sidebar_connected_peers|length }}</span>
+                            </div>
+                            <div class="sidebar-panel-actions">
+                                <button type="button" class="sidebar-panel-icon-btn" id="sidebar-peers-open-modal" aria-label="Search connected peers">
+                                    <i class="bi bi-search"></i>
+                                </button>
+                                <button type="button" class="sidebar-panel-icon-btn" id="sidebar-peers-toggle" aria-label="Collapse connected peers">
+                                    <i class="bi bi-chevron-up"></i>
+                                </button>
+                            </div>
                         </div>
                         <div class="sidebar-peer-list" id="sidebar-peer-list">
                             {% if sidebar_connected_peers %}
@@ -5789,13 +5944,16 @@
                                 <div class="sidebar-peer-empty">No active peers</div>
                             {% endif %}
                         </div>
-                        <div class="sidebar-peer-more" id="sidebar-peer-more" style="display:none;">
-                            <button type="button" class="sidebar-peer-more-btn" id="sidebar-peer-more-btn">
-                                View more peers
+                        <div class="sidebar-panel-footer" id="sidebar-peers-footer">
+                            <span class="sidebar-panel-summary" id="sidebar-peers-summary">Showing up to five peers</span>
+                            <button type="button" class="sidebar-panel-expand-btn" id="sidebar-peers-expand-btn" hidden>
+                                <i class="bi bi-arrows-angle-expand"></i><span>View more</span>
                             </button>
                         </div>
                     </div>
                     {% endif %}
+
+                    <div class="sidebar-utility-slot" id="sidebar-media-mini-slot-bottom"></div>
 
                     <div class="sidebar-footer">
                         <hr class="my-2 sidebar-divider" style="border-color: rgba(255,255,255,0.2);">

--- a/canopy/ui/templates/channels.html
+++ b/canopy/ui/templates/channels.html
@@ -4733,6 +4733,7 @@ let channelSendInFlight = false;
 let replyToMessageId = null;   // threading: parent message we're replying to
 let replyToAuthor = '';
 let isSearchActive = false;
+let currentChannelSearchQuery = '';
 let initialFocusMessageId = null;
 let channelRefreshInFlight = false;
 let pendingChannelMessages = null;
@@ -6020,6 +6021,9 @@ function loadChannelMessages(channelId, options = {}) {
                 const hint = data.warning ? ` <small class="d-block mt-2 text-muted">${escapeHtml(String(data.warning).slice(0, 120))}</small>` : '';
                 messagesContainer.innerHTML = '<div class="text-center text-muted p-4">No messages yet' + hint + '</div>';
             }
+            if (data && data.marked_read && typeof window.requestCanopySidebarAttentionRefresh === 'function') {
+                window.requestCanopySidebarAttentionRefresh({ force: true }).catch(() => {});
+            }
         })
         .catch(error => {
             if (loadToken !== activeChannelLoadToken || String(currentChannelId) !== requestedChannelId) {
@@ -6248,6 +6252,8 @@ function displayMessages(messages, options = {}) {
 		            if (!focused && container) {
 		                container.scrollTop = container.scrollHeight;
 		            }
+		        } else if (container && options.scrollToTop) {
+		            container.scrollTop = 0;
 		        } else if (container) {
 		            if (options.forceScroll || wasNearBottom) {
 		                container.scrollTop = container.scrollHeight;
@@ -8790,7 +8796,6 @@ function requestChannelThreadRefresh(options = {}) {
         return;
     }
     if (isSearchActive) {
-        loadChannelMessages(currentChannelId, { forceScroll });
         return;
     }
     if (channelLoadInFlight || channelRefreshInFlight) {
@@ -9203,7 +9208,9 @@ function submitCommunityNote() {
             const modal = bootstrap.Modal.getInstance(modalEl);
             if (modal) modal.hide();
         }
-        requestChannelThreadRefresh({ forceScroll: false });
+        if (!rerunActiveChannelSearch({ scrollToTop: false })) {
+            requestChannelThreadRefresh({ forceScroll: false });
+        }
     }).catch((error) => {
         showAlert(error.error || 'Failed to publish note', 'danger');
     });
@@ -9215,7 +9222,9 @@ function rateCommunityNote(noteId, helpful) {
         body: JSON.stringify({ helpful: !!helpful })
     }).then(() => {
         showAlert('Note rating saved', 'success');
-        requestChannelThreadRefresh({ forceScroll: false });
+        if (!rerunActiveChannelSearch({ scrollToTop: false })) {
+            requestChannelThreadRefresh({ forceScroll: false });
+        }
     }).catch((error) => {
         showAlert(error.error || 'Failed to rate note', 'danger');
     });
@@ -9227,7 +9236,9 @@ function endorseSkill(skillId) {
         body: JSON.stringify({ weight: 1.0 })
     }).then(() => {
         showAlert('Skill endorsed', 'success');
-        requestChannelThreadRefresh({ forceScroll: false });
+        if (!rerunActiveChannelSearch({ scrollToTop: false })) {
+            requestChannelThreadRefresh({ forceScroll: false });
+        }
     }).catch((error) => {
         showAlert(error.error || 'Failed to endorse skill', 'danger');
     });
@@ -9773,7 +9784,9 @@ async function submitStreamCreateModal() {
             if (modal) modal.hide();
         }
         showAlert(`Stream "${title}" created`, 'success');
-        requestChannelThreadRefresh({ forceScroll: true });
+        if (!rerunActiveChannelSearch({ scrollToTop: false })) {
+            requestChannelThreadRefresh({ forceScroll: true });
+        }
     } catch (err) {
         const msg = err && err.message ? err.message : 'Failed to create stream';
         showAlert(msg, 'danger');
@@ -11091,12 +11104,16 @@ function sendMessage(event) {
             apiCall(`/ajax/channel_messages/${currentChannelId}`)
                 .then(freshData => {
                     if (freshData && freshData.messages) {
-                        if (!appendNewMessages(freshData.messages)) {
+                        if (isSearchActive) {
+                            rerunActiveChannelSearch({ scrollToTop: false });
+                        } else if (!appendNewMessages(freshData.messages)) {
                             displayMessages(freshData.messages, { forceScroll: true });
                         }
                     }
                 }).catch(() => {
-                    requestChannelThreadRefresh({ forceScroll: true });
+                    if (!rerunActiveChannelSearch({ scrollToTop: false })) {
+                        requestChannelThreadRefresh({ forceScroll: true });
+                    }
                 });
         } else {
             console.error('Send message failed:', data.error);
@@ -11779,7 +11796,9 @@ function saveInlineChannelMessageEdit(messageId) {
         }
         cancelInlineChannelMessageEdit(messageId, true);
         showAlert('Message updated successfully', 'success');
-        requestChannelThreadRefresh({ forceScroll: false });
+        if (!rerunActiveChannelSearch({ scrollToTop: false })) {
+            requestChannelThreadRefresh({ forceScroll: false });
+        }
     })
     .catch(error => {
         showAlert(error.error || error.message || 'Failed to update message', 'danger');
@@ -12369,6 +12388,9 @@ function deleteChannelById(channelId, modal) {
 // Utility functions
 function refreshMessages() {
     if (!currentChannelId) return;
+    if (rerunActiveChannelSearch({ scrollToTop: false })) {
+        return;
+    }
     if (isChannelMediaPlaying()) {
         // Incremental refresh to preserve audio/video playback
         apiCall(`/ajax/channel_messages/${currentChannelId}`)
@@ -12872,7 +12894,9 @@ function deleteChannelMessage(messageId) {
                 msgEl.style.opacity = '0';
                 setTimeout(() => msgEl.remove(), 300);
             }
-            requestChannelThreadRefresh({ forceScroll: false });
+            if (!rerunActiveChannelSearch({ scrollToTop: false })) {
+                requestChannelThreadRefresh({ forceScroll: false });
+            }
         } else {
             showAlert(data.error || 'Failed to delete message', 'danger');
         }
@@ -12883,19 +12907,31 @@ function deleteChannelMessage(messageId) {
 }
 
 // --- Channel Search ---
-function searchChannelMessages() {
-    const query = document.getElementById('search-input').value.trim();
-    if (!query || !currentChannelId) return;
+function searchChannelMessages(options = {}) {
+    const opts = options || {};
+    const query = String(Object.prototype.hasOwnProperty.call(opts, 'query') ? opts.query : (document.getElementById('search-input').value || '')).trim();
+    if (!query || !currentChannelId) return Promise.resolve(null);
 
     isSearchActive = true;
+    currentChannelSearchQuery = query;
     document.getElementById('search-clear-btn').style.display = '';
 
-    apiCall(`/ajax/channel_search/${currentChannelId}?q=${encodeURIComponent(query)}`)
+    if (!Object.prototype.hasOwnProperty.call(opts, 'query')) {
+        const searchInput = document.getElementById('search-input');
+        if (searchInput) {
+            searchInput.value = query;
+        }
+    }
+
+    return apiCall(`/ajax/channel_search/${currentChannelId}?q=${encodeURIComponent(query)}`)
         .then(data => {
             const container = document.getElementById('messages-list');
+            const scrollContainer = document.getElementById('messages-container');
             if (data.messages && data.messages.length > 0) {
-                // displayMessages writes into messages-list; prepend banner after
-                displayMessages(data.messages, { ignoreSignature: true, forceScroll: true });
+                displayMessages(data.messages, {
+                    ignoreSignature: true,
+                    forceScroll: opts.scrollToBottom !== false,
+                });
                 const banner = document.createElement('div');
                 banner.className = 'alert alert-info py-1 px-2 mb-2';
                 banner.style.fontSize = '0.85rem';
@@ -12903,6 +12939,9 @@ function searchChannelMessages() {
                     ${data.count} result${data.count !== 1 ? 's' : ''} for "<strong>${escapeHtml(query)}</strong>"
                     <button class="btn btn-sm btn-link p-0 ms-2" onclick="clearSearch()">Clear</button>`;
                 container.prepend(banner);
+                if (scrollContainer && opts.scrollToBottom !== false) {
+                    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+                }
             } else {
                 container.innerHTML = `<div class="text-center text-muted p-4">
                     <i class="bi bi-search fs-3"></i>
@@ -12910,14 +12949,32 @@ function searchChannelMessages() {
                     <button class="btn btn-sm btn-outline-secondary" onclick="clearSearch()">Clear search</button>
                 </div>`;
             }
+            return data;
         })
         .catch(err => {
             console.error('Search error:', err);
+            return null;
         });
+}
+
+function rerunActiveChannelSearch(options = {}) {
+    if (!isSearchActive || !currentChannelId) {
+        return false;
+    }
+    const query = String(currentChannelSearchQuery || '').trim();
+    if (!query) {
+        return false;
+    }
+    searchChannelMessages({
+        query,
+        scrollToBottom: false,
+    }).catch(() => {});
+    return true;
 }
 
 function clearSearch() {
     isSearchActive = false;
+    currentChannelSearchQuery = '';
     document.getElementById('search-input').value = '';
     document.getElementById('search-clear-btn').style.display = 'none';
     if (currentChannelId) loadChannelMessages(currentChannelId, { forceScroll: true });

--- a/canopy/ui/templates/messages.html
+++ b/canopy/ui/templates/messages.html
@@ -1528,6 +1528,18 @@
     let dmQueuedSnapshotOptions = null;
     let dmComposerDragDepth = 0;
     const DM_WORKSPACE_EVENT_TYPES = ['dm.message.created', 'dm.message.edited', 'dm.message.deleted', 'attachment.available'];
+    const DM_SEARCH_QUERY = {{ search_query|tojson }};
+
+    function isDmSearchActive() {
+        if (String(DM_SEARCH_QUERY || '').trim()) {
+            return true;
+        }
+        try {
+            return new URL(window.location.href).searchParams.has('search');
+        } catch (error) {
+            return window.location.search.includes('search=');
+        }
+    }
 
     function matchesInitialRecipients() {
         const current = selectedRecipients.map(rec => rec.user_id).filter(Boolean).sort();
@@ -1659,7 +1671,7 @@
 
     function loadDmSnapshot(options) {
         const opts = options || {};
-        if (window.location.search.includes('search=')) {
+        if (isDmSearchActive()) {
             if (opts.hardFallback) window.location.reload();
             return Promise.resolve(null);
         }
@@ -1747,7 +1759,7 @@
     }
 
     function pollDmEvents() {
-        if (dmEventPollInFlight || window.location.search.includes('search=')) {
+        if (dmEventPollInFlight || isDmSearchActive()) {
             return;
         }
         dmEventPollInFlight = true;
@@ -1790,7 +1802,7 @@
 
     function startDmPolling() {
         stopDmPolling();
-        if (window.location.search.includes('search=')) {
+        if (isDmSearchActive()) {
             return;
         }
         pollDmEvents();
@@ -1809,6 +1821,10 @@
     }
 
     function refreshMessages() {
+        if (isDmSearchActive()) {
+            window.location.reload();
+            return;
+        }
         loadDmSnapshot({ forceBottom: false, allowDeferred: false, hardFallback: true }).catch(() => {});
     }
 
@@ -2915,7 +2931,7 @@
         }
         startDmPolling();
         document.addEventListener('visibilitychange', () => {
-            if (!document.hidden) {
+            if (!document.hidden && !isDmSearchActive()) {
                 pollDmEvents();
                 loadDmSnapshot({
                     allowDeferred: true,

--- a/docs/GITHUB_RELEASE_ANNOUNCEMENT_DRAFT.md
+++ b/docs/GITHUB_RELEASE_ANNOUNCEMENT_DRAFT.md
@@ -1,4 +1,4 @@
-# GitHub Release Announcement Draft (Canopy 0.4.100)
+# GitHub Release Announcement Draft (Canopy 0.4.105)
 
 Use this as the base for the GitHub release page, repo announcement, and launch posts.
 
@@ -8,14 +8,13 @@ Use this as the base for the GitHub release page, repo announcement, and launch 
 
 ## Full announcement (GitHub release notes)
 
-**Canopy 0.4.100 is out.**
+**Canopy 0.4.105 is out.**
 
-This release tightens the parts of Canopy people touch every day and adds proper first-run orientation:
-- new users get a guided landing instead of a blank page,
-- channel moderation now survives real mesh conditions,
-- the bell is now a real attention inbox,
-- rich embeds and live stream cards behave more honestly,
-- mobile and constrained layouts are less brittle.
+This release focuses on making search, sidebar, and notification surfaces feel reliable and responsive under real daily use:
+- search results stay stable across DMs and channels instead of getting overwritten by live refresh,
+- the sidebar gives you real control over card layout and attention flow,
+- the bell separates "I saw this" from "clear this",
+- first-run users get a guided landing instead of a blank page.
 
 ### What is Canopy?
 
@@ -26,22 +25,18 @@ Canopy is a local-first encrypted collaboration system for humans and AI agents:
 - built-in AI-native runtime surfaces through REST, MCP, agent inbox, heartbeat, and workspace events,
 - no mandatory hosted collaboration backend for day-to-day operation.
 
-### Highlights in 0.4.100
+### Highlights since 0.4.100
 
-- **First-run guidance**: new users see a compact first-day guide on Channels, Feed, and Messages showing workspace stats and four practical next steps. Mobile users land on `#general` instead of an empty feed. The guide auto-hides once core actions are completed.
-- **Curated channels that hold**: top-level posting policy can now be restricted to approved posters while replies remain open by default, and the policy stays consistent across peers instead of silently reverting during sync.
-- **Event-driven attention center**: unread badges, compact DM sidebar, and bell all flow from one workspace-event model. The bell now shows actor avatars, remembers dismiss state, and lets each user filter Mentions, Inbox, DMs, Channels, and Feed.
-- **Better embeds and media behavior**: Canopy renders a wider range of shared content including Vimeo, Loom, Spotify, SoundCloud, OpenStreetMap, TradingView, and Google Maps with safer fallback behavior, while YouTube now uses click-to-play loading instead of eager iframe injection.
-- **Truthful live stream cards**: stream cards reflect real lifecycle state, remote viewers stop seeing stale status, playback endpoints no longer fight the general API limiter, and longer sessions can refresh tokens instead of silently expiring.
-- **Responsive workspace polish**: channel header and composer controls now compact more cleanly on narrow and landscape layouts.
+- **Search that stays put** (`0.4.104`-`0.4.105`): DM and channel search are now first-class UI states. Background refresh, event polling, visibility-change handlers, and manual Refresh all suspend while a search is active. Channel search scrolls you to the newest matches. Local actions (edit, delete, publish, endorse) rerun the active search instead of reverting to the live thread.
+- **Sidebar you can shape** (`0.4.101`-`0.4.103`): Recent DMs and Connected cards support three persistent states — collapsed, top 5, and expanded. The mini-player can be pinned top or bottom. Opening a channel instantly clears its attention badge instead of waiting for the next poll. All preferences persist per user in localStorage.
+- **Bell that respects your attention** (`0.4.103`): Opening the bell clears the red badge without removing entries. A separate "seen" watermark tracks what you've glanced at; "Clear" still removes items from the list. Both cursors stay coherent.
+- **First-run guidance** (`0.4.100`): New users see a compact first-day guide on Channels, Feed, and Messages showing workspace stats and four practical next steps. Mobile users land on `#general` instead of an empty feed.
 
 ### Why this release matters
 
-This release is about trust in the product surface.
+The surfaces people touch every minute — search, sidebar layout, the notification bell — are exactly the places where small inconsistencies erode trust in a product. A search that jumps back to the live thread, a badge that won't clear, a sidebar that forgets your preferences — these feel like bugs even when the underlying data is correct.
 
-Canopy already had strong local-first and AI-native foundations. The problem was that some of the most visible workflows still broke down under real use: the first-run experience was disorienting, curated channels could drift, the bell could feel noisy or superficial, embeds could feel partial, and constrained layouts could collapse under pressure.
-
-`0.4.100` fixes enough of that surface area to make Canopy feel more like a serious daily workspace and less like a promising prototype.
+`0.4.105` fixes that layer. Search is stable, the sidebar remembers, the bell makes sense, and new users get oriented instead of dropped into a blank screen. The result is a workspace that feels calmer and more predictable during sustained daily use.
 
 ### Getting started
 
@@ -53,20 +48,19 @@ Canopy already had strong local-first and AI-native foundations. The problem was
 
 ### Notes
 
-Canopy remains early-stage software. Test peer connectivity, curated-channel behavior, stream playback, and attention surfaces on your own instance before broad rollout.
+Canopy remains early-stage software. Test search behavior, sidebar persistence, and attention surfaces on your own instance before broad rollout.
 
 ---
 
 ## Short version (for repo Discussions / announcements)
 
-Canopy 0.4.100 is live.
+Canopy 0.4.105 is live.
 
-This release tightens five important surfaces:
-- new users get a guided first-run landing instead of a blank page,
-- curated channels now survive real sync conditions,
-- the bell is now a real attention inbox with avatars, stable clear, and filters,
-- embeds and live stream cards behave more honestly,
-- mobile and constrained layouts hold together better.
+This release hardens the surfaces you touch every day:
+- DM and channel search stays stable — no more live-refresh stomping your results,
+- sidebar cards remember your preferred layout (collapsed / peek / expanded),
+- the bell separates "seen" from "cleared" so the badge makes sense,
+- first-run users get a guided landing instead of a blank page.
 
 Start here:
 - [docs/QUICKSTART.md](https://github.com/kwalus/Canopy/blob/main/docs/QUICKSTART.md)
@@ -77,11 +71,10 @@ Start here:
 
 ## Social copy (very short)
 
-Canopy 0.4.100 is out: local-first encrypted collaboration for humans and AI agents.
+Canopy 0.4.105 is out: local-first encrypted collaboration for humans and AI agents.
 
-This drop makes the product feel much more solid in real use:
-- guided first-run experience,
-- curated channels that hold,
-- a real event-driven attention bell,
-- better embeds and stream truth,
-- cleaner constrained-layout behavior.
+This drop makes daily use feel much more solid:
+- search that stays put across DMs and channels,
+- sidebar that remembers your layout,
+- bell that knows seen vs cleared,
+- guided first-run experience.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canopy"
-version = "0.4.100"
+version = "0.4.105"
 description = "Local-first peer-to-peer collaboration for humans and AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_channel_message_route_regressions.py
+++ b/tests/test_channel_message_route_regressions.py
@@ -223,6 +223,15 @@ class TestChannelMessageRouteRegressions(unittest.TestCase):
         payload = response.get_json() or {}
         self.assertEqual(payload.get('workspace_event_cursor'), 5)
 
+    def test_channel_messages_reports_when_view_marks_channel_read(self) -> None:
+        self.channel_manager.mark_channel_read.return_value = True
+
+        response = self.client.get('/ajax/channel_messages/general')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('marked_read'))
+
     def test_channel_messages_snapshot_refreshes_remote_stream_attachment_status(self) -> None:
         message = MagicMock()
         message.id = 'M-stream'

--- a/tests/test_channel_sidebar_state_delta.py
+++ b/tests/test_channel_sidebar_state_delta.py
@@ -194,7 +194,7 @@ class TestChannelSidebarStateDelta(unittest.TestCase):
         self.assertIn("function refreshChannelMessagesSnapshot(options = {}) {", body)
         self.assertIn("function requestChannelThreadRefresh(options = {}) {", body)
         self.assertIn("if (isSearchActive) {", body)
-        self.assertIn("loadChannelMessages(currentChannelId, { forceScroll });", body)
+        self.assertIn("refreshChannelMessagesSnapshot({ forceScroll });", body)
         self.assertIn("function setSidebarChannelMemberCount(channelId, memberCount) {", body)
         self.assertIn("function applySidebarChannelStateUpdate(channelId, payload) {", body)
         self.assertIn("reason === 'notifications_updated'", body)

--- a/tests/test_frontend_regressions.py
+++ b/tests/test_frontend_regressions.py
@@ -75,6 +75,8 @@ class TestFrontendRegressions(unittest.TestCase):
         channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
         self.assertIn("if (currentChannelId && channelId === currentChannelId) {", channels_template)
         self.assertIn("requestChannelThreadRefresh();", channels_template)
+        self.assertIn("if (data && data.marked_read && typeof window.requestCanopySidebarAttentionRefresh === 'function') {", channels_template)
+        self.assertIn("window.requestCanopySidebarAttentionRefresh({ force: true }).catch(() => {});", channels_template)
 
     def test_notification_bell_uses_attention_snapshot_and_peer_polling_stays_separate(self) -> None:
         main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
@@ -88,10 +90,14 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn("img.src = avatarUrl;", main_js)
         self.assertIn("iconWrap.textContent = fallbackInitial;", main_js)
         self.assertIn("const canopyAttentionDismissStorageKey = (() => {", main_js)
+        self.assertIn("const canopyAttentionSeenStorageKey = (() => {", main_js)
         self.assertIn("window.localStorage.setItem(canopyAttentionDismissStorageKey, String(normalized));", main_js)
+        self.assertIn("window.localStorage.setItem(canopyAttentionSeenStorageKey, String(normalized));", main_js)
         self.assertIn("function filterCanopyAttentionItems(items) {", main_js)
+        self.assertIn("function countUnseenCanopyAttentionItems(items) {", main_js)
         self.assertIn("window.renderCanopyAttentionBell(filterCanopyAttentionItems(canopySidebarAttentionState.items));", main_js)
         self.assertIn("saveCanopyAttentionDismissCursor(canopySidebarAttentionState.currentEventCursor);", main_js)
+        self.assertIn("saveCanopyAttentionSeenCursor(canopySidebarAttentionState.currentEventCursor);", main_js)
         self.assertIn("const CANOPY_ATTENTION_FILTER_DEFS = [", main_js)
         self.assertIn("const canopyAttentionFilterStorageKey = (() => {", main_js)
         self.assertIn("function renderFilterBar() {", main_js)
@@ -181,6 +187,44 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn('function startCanopyWorkspaceAttentionPolling()', main_js)
         self.assertIn('function pollCanopyWorkspaceAttentionEvents()', main_js)
         self.assertIn("requestCanopySidebarDmRefresh({ force: false }).catch(() => {});", main_js)
+
+    def test_sidebar_cards_support_three_states_and_mini_player_placement(self) -> None:
+        base_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'base.html').read_text(encoding='utf-8')
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        self.assertIn('id="sidebar-dm-card"', base_template)
+        self.assertIn('id="sidebar-dm-toggle"', base_template)
+        self.assertIn('id="sidebar-dm-expand-btn"', base_template)
+        self.assertIn('id="sidebar-peers-card"', base_template)
+        self.assertIn('id="sidebar-peers-toggle"', base_template)
+        self.assertIn('id="sidebar-peers-expand-btn"', base_template)
+        self.assertIn('id="sidebar-peers-open-modal"', base_template)
+        self.assertIn('id="sidebar-media-mini-slot-top"', base_template)
+        self.assertIn('id="sidebar-media-mini-slot-bottom"', base_template)
+        self.assertIn('id="sidebar-media-mini-pin"', base_template)
+        self.assertIn("const SIDEBAR_CARD_PEEK_LIMIT = 5;", main_js)
+        self.assertIn("function toggleSidebarCardCollapsed(kind)", main_js)
+        self.assertIn("function toggleSidebarCardExpansion(kind, totalCount)", main_js)
+        self.assertIn("function updateSidebarCardChrome(kind, totalCount)", main_js)
+        self.assertIn("function setCanopySidebarMiniPosition(nextPosition)", main_js)
+        self.assertIn("setCanopySidebarMiniPosition(canopySidebarRailState.miniPosition);", main_js)
+
+    def test_dm_search_uses_explicit_search_state_to_suspend_live_refresh(self) -> None:
+        messages_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'messages.html').read_text(encoding='utf-8')
+        self.assertIn("const DM_SEARCH_QUERY = ", messages_template)
+        self.assertIn("function isDmSearchActive() {", messages_template)
+        self.assertIn("if (dmEventPollInFlight || isDmSearchActive()) {", messages_template)
+        self.assertIn("if (isDmSearchActive()) {\n            window.location.reload();\n            return;\n        }", messages_template)
+        self.assertIn("if (!document.hidden && !isDmSearchActive()) {", messages_template)
+        self.assertIn("return window.location.search.includes('search=');", messages_template)
+
+    def test_channel_search_preserves_search_view_and_scrolls_to_top(self) -> None:
+        channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
+        self.assertIn("let currentChannelSearchQuery = '';", channels_template)
+        self.assertIn("if (isSearchActive) {\n        return;\n    }", channels_template)
+        self.assertIn("scrollToBottom: false,", channels_template)
+        self.assertIn("forceScroll: opts.scrollToBottom !== false,", channels_template)
+        self.assertIn("function rerunActiveChannelSearch(options = {}) {", channels_template)
+        self.assertNotIn("if (isSearchActive) {\n        loadChannelMessages(currentChannelId, { forceScroll });", channels_template)
 
     def test_curated_channel_creation_and_member_policy_controls_exist(self) -> None:
         channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')

--- a/tests/test_messages_ui_workspace.py
+++ b/tests/test_messages_ui_workspace.py
@@ -92,6 +92,14 @@ class _FakeP2PManager:
         }
 
 
+class _FakeWorkspaceEventManager:
+    def __init__(self, latest_seq: int = 0) -> None:
+        self.latest_seq = latest_seq
+
+    def get_latest_seq(self) -> int:
+        return int(self.latest_seq)
+
+
 class TestMessagesUiWorkspace(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
@@ -171,6 +179,7 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         self.profile_manager = MagicMock()
         self.profile_manager.get_profile.return_value = None
         self.p2p_manager = _FakeP2PManager()
+        self.workspace_event_manager = _FakeWorkspaceEventManager()
 
         components = (
             self.db_manager,
@@ -193,6 +202,7 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         app = Flask(__name__)
         app.config['TESTING'] = True
         app.secret_key = 'test-secret'
+        app.config['WORKSPACE_EVENT_MANAGER'] = self.workspace_event_manager
         app.register_blueprint(create_ui_blueprint())
         self.app = app
         self.client = app.test_client()
@@ -229,7 +239,14 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         self.assertIn('.7z,.rar', body)
         self.assertIn('.html,.css,.sh,.bat,.cfg,.ini,.toml', body)
         self.assertIn('/ajax/messages/thread_snapshot', body)
-        self.assertIn("function refreshMessages() {\n        loadDmSnapshot(", body)
+        self.assertIn('/api/v1/events?', body)
+        self.assertIn('let dmEventCursor = ', body)
+        self.assertIn('function pollDmEvents() {', body)
+        self.assertIn('function queueDmSnapshot(options) {', body)
+        self.assertIn('dmQueuedSnapshotOptions', body)
+        self.assertIn("function refreshMessages() {", body)
+        self.assertIn("if (isDmSearchActive()) {", body)
+        self.assertIn("loadDmSnapshot({ forceBottom: false, allowDeferred: false, hardFallback: true }).catch(() => {});", body)
         self.assertIn('/ajax/mention_suggestions?', body)
         self.assertIn('setupMessageDropzone();', body)
         self.assertIn("composer.addEventListener('drop'", body)
@@ -242,7 +259,10 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         body = response.get_data(as_text=True)
         self.assertIn('Search DMs and group chats', body)
+        self.assertIn('Search results', body)
         self.assertIn('Relay delivered through broker', body)
+        self.assertIn('Clear search', body)
+        self.assertNotIn('id="dm-composer"', body)
 
     def test_message_search_decrypts_before_matching(self) -> None:
         self.conn.execute(
@@ -335,8 +355,25 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         self.assertIn('Hello owner', payload.get('thread_body_html') or '')
         self.assertIn('Need update', payload.get('thread_body_html') or '')
         self.assertIn('E2E over mesh', payload.get('thread_header_html') or '')
+        self.assertEqual(payload.get('workspace_event_cursor'), 0)
         self.assertTrue(payload.get('thread_state_token'))
         self.assertTrue(payload.get('sidebar_state_token'))
+
+    def test_thread_snapshot_cursor_does_not_advance_past_snapshot_state(self) -> None:
+        self.workspace_event_manager.latest_seq = 5
+        original_get_messages = self.message_manager.get_messages
+
+        def _race_get_messages(*args, **kwargs):
+            self.workspace_event_manager.latest_seq = 9
+            return original_get_messages(*args, **kwargs)
+
+        with patch.object(self.message_manager, 'get_messages', side_effect=_race_get_messages):
+            response = self.client.get('/ajax/messages/thread_snapshot?with=peer-a')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        self.assertEqual(payload.get('workspace_event_cursor'), 5)
 
     def test_ajax_send_message_preserves_reply_to_metadata(self) -> None:
         response = self.client.post(

--- a/tests/test_sidebar_recent_dm_contacts.py
+++ b/tests/test_sidebar_recent_dm_contacts.py
@@ -87,6 +87,14 @@ class _FakeP2PManager:
         return []
 
 
+class _FakeWorkspaceEventManager:
+    def __init__(self, latest_seq: int = 0) -> None:
+        self.latest_seq = latest_seq
+
+    def get_latest_seq(self) -> int:
+        return int(self.latest_seq)
+
+
 class TestSidebarRecentDmContacts(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
@@ -166,6 +174,7 @@ class TestSidebarRecentDmContacts(unittest.TestCase):
         self.p2p_manager = _FakeP2PManager()
         self.trust_manager = MagicMock()
         self.trust_manager.get_trust_score.return_value = 90
+        self.workspace_event_manager = _FakeWorkspaceEventManager()
 
         components = (
             self.db_manager,
@@ -191,6 +200,7 @@ class TestSidebarRecentDmContacts(unittest.TestCase):
         app = Flask(__name__)
         app.config['TESTING'] = True
         app.secret_key = 'sidebar-dm-secret'
+        app.config['WORKSPACE_EVENT_MANAGER'] = self.workspace_event_manager
         app.register_blueprint(create_ui_blueprint())
         self.app = app
         self.client = app.test_client()
@@ -215,13 +225,16 @@ class TestSidebarRecentDmContacts(unittest.TestCase):
         self.assertIn('Recent DMs', body)
         self.assertIn('Alice', body)
         self.assertIn('Bob', body)
+        self.assertIn('id="sidebar-dm-card"', body)
+        self.assertIn('id="sidebar-dm-toggle"', body)
+        self.assertIn('id="sidebar-dm-expand-btn"', body)
         self.assertIn('data-dm-user-id="peer-a"', body)
         self.assertIn('data-dm-user-id="peer-b"', body)
         self.assertIn('/messages?with=peer-a#message-DM-a-unread', body)
         self.assertNotIn('data-dm-user-id="group:', body)
 
-    def test_peer_activity_includes_recent_dm_contacts(self) -> None:
-        response = self.client.get('/ajax/peer_activity')
+    def test_sidebar_dm_snapshot_includes_recent_dm_contacts(self) -> None:
+        response = self.client.get('/ajax/sidebar_dm_snapshot')
         self.assertEqual(response.status_code, 200)
         payload = response.get_json() or {}
 
@@ -232,13 +245,13 @@ class TestSidebarRecentDmContacts(unittest.TestCase):
         self.assertEqual(contacts[0].get('target_message_id'), 'DM-a-unread')
         self.assertEqual(contacts[0].get('status_state'), 'online')
 
-    def test_peer_activity_delta_request_omits_recent_dm_contacts_when_unchanged(self) -> None:
-        first = self.client.get('/ajax/peer_activity')
+    def test_sidebar_dm_snapshot_delta_request_omits_contacts_when_unchanged(self) -> None:
+        first = self.client.get('/ajax/sidebar_dm_snapshot')
         self.assertEqual(first.status_code, 200)
         first_payload = first.get_json() or {}
 
         response = self.client.get(
-            f"/ajax/peer_activity?peer_rev={first_payload.get('peer_rev')}&dm_rev={first_payload.get('dm_rev')}"
+            f"/ajax/sidebar_dm_snapshot?dm_rev={first_payload.get('dm_rev')}"
         )
         self.assertEqual(response.status_code, 200)
         payload = response.get_json() or {}
@@ -246,6 +259,23 @@ class TestSidebarRecentDmContacts(unittest.TestCase):
         self.assertTrue(payload.get('success'))
         self.assertFalse(payload.get('dm_changed'))
         self.assertEqual(payload.get('recent_dm_contacts'), [])
+
+    def test_sidebar_dm_snapshot_cursor_does_not_advance_past_snapshot_state(self) -> None:
+        self.workspace_event_manager.latest_seq = 7
+
+        original_get_messages = self.message_manager.get_messages
+
+        def _race_get_messages(*args, **kwargs):
+            self.workspace_event_manager.latest_seq = 11
+            return original_get_messages(*args, **kwargs)
+
+        with patch.object(self.message_manager, 'get_messages', side_effect=_race_get_messages):
+            response = self.client.get('/ajax/sidebar_dm_snapshot')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        self.assertEqual(payload.get('workspace_event_cursor'), 7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Canopy v0.4.105 public release (from v0.4.100).

## Highlights since v0.4.100

- **Search stability** (0.4.104-105): DM and channel search are now first-class UI states. Background refresh, event polling, and visibility-change handlers all suspend while search is active. Channel search scrolls to newest matches. Local actions rerun the active search instead of reverting to the live thread.
- **Sidebar polish** (0.4.101-103): Instant attention refresh on channel read. Three-state left-rail cards (collapsed/peek/expanded). Moveable mini-player. Bell seen-vs-clear separation.
- **First-run guidance** (0.4.100): Compact first-day guide on Channels, Feed, and Messages. Mobile users land on #general instead of empty feed.
- **Channel read attention sync** (0.4.101): Opening a channel immediately clears its attention badge.

## Files

49 curated files: core, UI, templates, JS, docs, and tests. No internal scripts, agent notes, or secrets.
