### PR TITLE
v0.4.106–0.4.109 — privacy defaults, P2P hardening, sidebar perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.4.109] - 2026-03-19
+
+### Hardened
+- **Encryption helper robustness** — `DataEncryptor.encrypt()` and `decrypt()` handle `None` inputs gracefully. Large-payload warnings alert operators before performance-sensitive paths. Debug logging no longer includes raw metadata.
+
+## [0.4.108] - 2026-03-19
+
+### Hardened
+- **Delete signal authorization** — Inbound P2P delete signals for channel messages now verify requester ownership (message author or channel admin). Revocation signals are prioritised in the store-and-forward queue to survive offline-peer overflow.
+
+### Performance
+- **Sidebar rendering efficiency** — DM contacts and peer list use DocumentFragment batching and render-key diffing to skip unnecessary DOM writes. Attention poll interval relaxed from 2.5s to 5s. GPU compositing hints added to animated sidebar elements.
+
+## [0.4.107] - 2026-03-19
+
+### Hardened
+- **Trust boundary enforcement** — Delete-signal compliance and violation handlers verify signal ownership before adjusting trust scores. Manually penalised peers are locked from automated trust recovery. Trust score operations validate against non-existent records.
+- **P2P input validation** — Inbound messages enforce payload size limits (512 KB total, 256 KB content, 512-byte IDs). Feed posts with private or custom visibility are rejected at the P2P layer. Author identity is verified against origin peer on inbound feed posts. Delete signal handlers verify requester ownership across all data types.
+- **API authentication tightening** — All P2P status endpoints require authentication. Session-based API key generation validates CSRF tokens.
+- **Feed visibility defaults** — `can_view()` defaults to untrusted, requiring callers to pass explicit trust context. `get_user_posts()` applies standard visibility filters. Feed statistics include custom-visibility posts the viewer has permission to see.
+
+### Performance
+- **Channel rendering** — O(n) orphan-reply check via Set lookup (previously O(n²)). `displayMessages` returns its Promise for proper search-banner chaining.
+
+## [0.4.106] - 2026-03-18
+
+### Changed
+- **Privacy-first trust baseline** — Unknown peers now start at trust score 0 (pending review) instead of 100 (implicitly trusted). `is_peer_trusted()` requires an explicit trust row before a peer qualifies. The Trust UI now separates connected-but-unreviewed peers into a "Potential peers" queue rather than placing them into trust tiers by default.
+- **Feed defaults to private** — Feed post creation defaults to `private` ("Only Me") across UI, API, and MCP. Agents and users that omit visibility no longer broadcast unintentionally. Helper text in the feed composer clarifies the default and explains trusted sharing.
+- **Trusted feed visibility consistency** — All feed query paths (`get_user_feed`, `search_posts`, `count_unread_posts`, `get_feed_statistics`, `_get_smart_feed`, `get_posts_since`) now include `trusted` visibility so trusted posts are no longer inconsistently omitted.
+- **Targeted feed propagation** — `broadcast_feed_post()` now computes target peers by visibility scope: public/network → all connected, trusted → only peers meeting the trust threshold, private/custom → no P2P broadcast. Catch-up sync includes trusted posts only for explicitly trusted peers.
+- **Feed visibility narrowing revocation** — When a post is edited from a broader to a narrower visibility, peers that are no longer in scope receive a delete signal. Update call sites in UI, API, and MCP now pass `previous_visibility` so revocation logic can run.
+- **Operator copy clarity** — Settings advise using a separate node for public relay. Channel privacy descriptions clarify that Guarded is moderated/mesh-visible (not private) and Private is for sensitive work.
+
 ## [0.4.105] - 2026-03-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.4.105-blue" alt="Version 0.4.105">
+  <img src="https://img.shields.io/badge/version-0.4.109-blue" alt="Version 0.4.109">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 License">
   <img src="https://img.shields.io/badge/encryption-ChaCha20--Poly1305-blueviolet" alt="ChaCha20-Poly1305">
@@ -30,6 +30,8 @@
 
 
 > **Early-stage software.** Canopy is actively developed and evolving quickly. Use it for real workflows, but expect sharp edges and keep backups. See [LICENSE](LICENSE) for terms.
+
+> **No tokens, no coins, no crypto.** Canopy is a free, open-source communication tool. It has no cryptocurrency, no blockchain, no token, and no paid tier. Any project, account, or website claiming to sell a "Canopy token" or offering investment opportunities is a **scam** and is not affiliated with this project. Report imposters to [GitHub Support](https://support.github.com).
 
 ---
 

--- a/canopy/__init__.py
+++ b/canopy/__init__.py
@@ -11,7 +11,7 @@ License: Apache 2.0
 Development: AI-assisted implementation (Claude, Codex, GitHub Copilot, Cursor IDE, Ollama)
 """
 
-__version__ = "0.4.105"
+__version__ = "0.4.109"
 __protocol_version__ = 1
 __author__ = "Canopy Contributors"
 __license__ = "Apache-2.0"

--- a/canopy/api/routes.py
+++ b/canopy/api/routes.py
@@ -1939,6 +1939,7 @@ def create_api_blueprint() -> Blueprint:
     
     # P2P Network endpoints
     @api.route('/p2p/status', methods=['GET'])
+    @require_auth(allow_session=True)
     def get_p2p_status():
         """Get P2P network status."""
         *_, p2p_manager = _get_app_components_any(current_app)
@@ -2862,6 +2863,7 @@ def create_api_blueprint() -> Blueprint:
             else:
                 session_user = session.get('user_id')
                 if session_user:
+                    validate_csrf_request()
                     user_id = session_user
                 else:
                     return jsonify({
@@ -2904,6 +2906,9 @@ def create_api_blueprint() -> Blueprint:
                 return jsonify({'error': 'Failed to generate API key'}), 500
                 
         except Exception as e:
+            from werkzeug.exceptions import HTTPException
+            if isinstance(e, HTTPException):
+                raise
             logger.error(f"Failed to generate API key: {e}")
             return jsonify({'error': 'Internal server error'}), 500
     
@@ -3600,7 +3605,8 @@ def create_api_blueprint() -> Blueprint:
             return jsonify({
                 'peer_id': peer_id,
                 'trust_score': score,
-                'is_trusted': is_trusted
+                'is_trusted': is_trusted,
+                'has_explicit_score': trust_manager.has_explicit_trust_score(peer_id),
             })
             
         except Exception as e:
@@ -3751,7 +3757,7 @@ def create_api_blueprint() -> Blueprint:
             
             content = data.get('content')
             post_type = data.get('post_type', 'text')
-            visibility = data.get('visibility', 'network')
+            visibility = data.get('visibility', 'private')
             permissions = data.get('permissions', [])
             metadata = data.get('metadata')
             expires_at = data.get('expires_at')
@@ -3776,7 +3782,7 @@ def create_api_blueprint() -> Blueprint:
             try:
                 vis = PostVisibility(visibility)
             except ValueError:
-                vis = PostVisibility.NETWORK
+                vis = PostVisibility.PRIVATE
             
             # Auto-detect poll posts when content matches poll format
             if pt == PostType.TEXT and parse_poll(content or ''):
@@ -6409,6 +6415,7 @@ def create_api_blueprint() -> Blueprint:
                                 content=updated.content,
                                 post_type=updated.post_type.value,
                                 visibility=updated.visibility.value,
+                                previous_visibility=post.visibility.value if getattr(post, 'visibility', None) else None,
                                 timestamp=updated.created_at.isoformat() if hasattr(updated.created_at, 'isoformat') else str(updated.created_at),
                                 metadata=updated.metadata,
                                 expires_at=updated.expires_at.isoformat() if getattr(updated, 'expires_at', None) else None,

--- a/canopy/core/app.py
+++ b/canopy/core/app.py
@@ -4062,14 +4062,21 @@ def create_app(config: Optional[Config] = None) -> Flask:
                 # Feed posts newer than what the peer has
                 try:
                     since_feed = feed_latest or '1970-01-01 00:00:00'
+                    visible_feed_modes = ['network', 'public']
+                    try:
+                        if trust_manager and trust_manager.is_peer_trusted(str(from_peer or '').strip()):
+                            visible_feed_modes.append('trusted')
+                    except Exception:
+                        pass
                     with db_manager.get_connection() as conn:
+                        placeholders = ",".join("?" for _ in visible_feed_modes)
                         rows = conn.execute(
                             "SELECT id, author_id, content, content_type, "
                             "visibility, metadata, created_at, expires_at "
                             "FROM feed_posts WHERE created_at > ? AND "
-                            "(visibility = 'network' OR visibility = 'public') "
+                            f"visibility IN ({placeholders}) "
                             "ORDER BY created_at ASC LIMIT 200",
-                            (since_feed,)
+                            (since_feed, *visible_feed_modes)
                         ).fetchall()
                     if rows:
                         feed_posts = []
@@ -4899,6 +4906,36 @@ def create_app(config: Optional[Config] = None) -> Flask:
                                display_name, from_peer):
             """Store an incoming P2P feed post locally. Updates content/metadata when post already exists (edit broadcast)."""
             try:
+                # --- Input validation ---
+
+                # Reject posts with private/custom visibility over P2P
+                vis_str = str(visibility or '').lower()
+                if vis_str in ('private', 'custom'):
+                    logger.warning(f"Rejecting P2P feed post {post_id} with visibility={vis_str} from {from_peer}")
+                    return
+
+                # ID length limits
+                for label, val in [('post_id', post_id), ('author_id', author_id)]:
+                    if val and len(str(val).encode('utf-8')) > 512:
+                        logger.warning(f"Rejecting P2P feed post: {label} too long from {from_peer}")
+                        return
+
+                # Content size limit (256 KB)
+                if content and len(str(content).encode('utf-8')) > 256 * 1024:
+                    logger.warning(f"Rejecting oversized P2P feed post content from {from_peer}")
+                    return
+
+                # Metadata size limit (64 KB)
+                if metadata:
+                    import json as _json
+                    try:
+                        meta_size = len(_json.dumps(metadata).encode('utf-8'))
+                        if meta_size > 64 * 1024:
+                            logger.warning(f"Rejecting oversized P2P feed post metadata from {from_peer}")
+                            return
+                    except Exception:
+                        pass
+
                 # Ensure shadow user exists (reuse channel message logic)
                 feed_origin_peer = ''
                 try:
@@ -4913,6 +4950,18 @@ def create_app(config: Optional[Config] = None) -> Flask:
                     feed_origin_peer,
                     allow_origin_reassign=True,
                 )
+
+                # Author-ID spoofing prevention: verify the claimed author
+                # belongs to the sending peer
+                author_row = db_manager.get_user(author_id)
+                if author_row:
+                    origin = (author_row.get('origin_peer') or '').strip()
+                    if origin and origin != str(from_peer or '').strip():
+                        logger.warning(
+                            f"Rejecting P2P feed post {post_id}: author {author_id} "
+                            f"origin_peer={origin} != from_peer={from_peer}"
+                        )
+                        return
 
                 # Normalise timestamp
                 normalised_ts = None
@@ -6148,6 +6197,14 @@ def create_app(config: Optional[Config] = None) -> Flask:
         p2p_manager.on_direct_message = _on_p2p_direct_message
 
         # --- Delete signal handler ---
+        def _requester_owns_user(owner_user_id: str, from_peer_id: str) -> bool:
+            """Check that owner_user_id's origin_peer matches from_peer_id."""
+            urow = db_manager.get_user(owner_user_id)
+            if not urow:
+                return False
+            origin = (urow.get('origin_peer') or '').strip()
+            return bool(origin) and origin == str(from_peer_id or '').strip()
+
         def _on_delete_signal(signal_id, data_type, data_id, reason,
                               requester_peer, is_ack, ack_status, from_peer):
             """Handle incoming DELETE_SIGNAL from a peer.
@@ -6159,6 +6216,12 @@ def create_app(config: Optional[Config] = None) -> Flask:
                We update our local signal status and adjust trust score.
             """
             try:
+                # ID length limits
+                for label, val in [('signal_id', signal_id), ('data_id', data_id)]:
+                    if val and len(str(val).encode('utf-8')) > 512:
+                        logger.warning(f"Rejecting delete signal: {label} too long from {from_peer}")
+                        return
+
                 if is_ack:
                     # --- Acknowledgment from a peer ---
                     status = ack_status or 'acknowledged'
@@ -6192,26 +6255,48 @@ def create_app(config: Optional[Config] = None) -> Flask:
 
                 elif data_type == 'channel_message':
                     # Delete a specific channel message (explicit type).
-                    # Remove FK references first: likes and parent_message_id.
+                    # Security: only the message's origin peer or the channel's
+                    # origin peer (admin) may request deletion.
                     try:
                         channel_id = None
                         with db_manager.get_connection() as conn:
                             row = conn.execute(
-                                "SELECT channel_id FROM channel_messages WHERE id = ?",
+                                "SELECT channel_id, user_id FROM channel_messages WHERE id = ?",
                                 (data_id,),
                             ).fetchone()
                             if row:
                                 channel_id = row['channel_id'] if hasattr(row, 'keys') else row[0]
-                            conn.execute("DELETE FROM likes WHERE message_id = ?", (data_id,))
-                            conn.execute(
-                                "UPDATE channel_messages SET parent_message_id = NULL WHERE parent_message_id = ?",
-                                (data_id,),
-                            )
-                            cur = conn.execute(
-                                "DELETE FROM channel_messages WHERE id = ?",
-                                (data_id,))
-                            conn.commit()
-                            deleted = cur.rowcount > 0
+                                msg_user_id = row['user_id'] if hasattr(row, 'keys') else row[1]
+                                requester = str(requester_peer or from_peer or '').strip()
+                                msg_authorized = _requester_owns_user(msg_user_id, requester)
+                                ch_row = conn.execute(
+                                    "SELECT origin_peer FROM channels WHERE id = ?",
+                                    (channel_id,),
+                                ).fetchone()
+                                ch_origin = ''
+                                if ch_row:
+                                    ch_origin = (ch_row['origin_peer'] if hasattr(ch_row, 'keys') else ch_row[0]) or ''
+                                ch_admin = bool(ch_origin) and requester == ch_origin
+                                if not msg_authorized and not ch_admin:
+                                    logger.warning(
+                                        "SECURITY: Rejected channel_message delete for %s "
+                                        "(requester=%s, msg_user=%s, ch_origin=%s)",
+                                        data_id, requester, msg_user_id, ch_origin,
+                                    )
+                                    deleted = False
+                                else:
+                                    conn.execute("DELETE FROM likes WHERE message_id = ?", (data_id,))
+                                    conn.execute(
+                                        "UPDATE channel_messages SET parent_message_id = NULL WHERE parent_message_id = ?",
+                                        (data_id,),
+                                    )
+                                    cur = conn.execute(
+                                        "DELETE FROM channel_messages WHERE id = ?",
+                                        (data_id,))
+                                    conn.commit()
+                                    deleted = cur.rowcount > 0
+                            else:
+                                deleted = True  # Already gone, idempotent
                         if deleted and channel_id:
                             try:
                                 channel_manager._emit_channel_user_event(
@@ -6241,15 +6326,21 @@ def create_app(config: Optional[Config] = None) -> Flask:
                             logger.error(f"Failed to delete file {data_id}: {del_err}")
 
                 elif data_type in ('feed_post', 'post'):
-                    # Delete a feed post
+                    # Delete a feed post — verify requester owns the author
                     try:
                         deleted_post = feed_manager.get_post(data_id) if feed_manager else None
-                        with db_manager.get_connection() as conn:
-                            cur = conn.execute(
-                                "DELETE FROM feed_posts WHERE id = ?",
-                                (data_id,))
-                            conn.commit()
-                            deleted = cur.rowcount > 0
+                        if deleted_post and not _requester_owns_user(deleted_post.author_id, from_peer):
+                            logger.warning(
+                                f"SECURITY: Rejected feed post delete for {data_id}: "
+                                f"author={deleted_post.author_id} not owned by {from_peer}"
+                            )
+                        elif deleted_post or not feed_manager:
+                            with db_manager.get_connection() as conn:
+                                cur = conn.execute(
+                                    "DELETE FROM feed_posts WHERE id = ?",
+                                    (data_id,))
+                                conn.commit()
+                                deleted = cur.rowcount > 0
                         if deleted and feed_manager and deleted_post:
                             try:
                                 feed_manager._emit_post_event(

--- a/canopy/core/database.py
+++ b/canopy/core/database.py
@@ -144,11 +144,12 @@ class DatabaseManager:
                 CREATE TABLE IF NOT EXISTS trust_scores (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     peer_id TEXT NOT NULL,
-                    score INTEGER DEFAULT 100,
+                    score INTEGER DEFAULT 0,
                     last_interaction TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     compliance_events INTEGER DEFAULT 0,
                     violation_events INTEGER DEFAULT 0,
                     notes TEXT,
+                    manually_penalized BOOLEAN NOT NULL DEFAULT 0,
                     UNIQUE(peer_id)
                 );
                 
@@ -851,6 +852,13 @@ class DatabaseManager:
             if self._identity_portability_enabled():
                 self._ensure_identity_portability_schema(conn)
 
+            # --- Trust scores: add manually_penalized column ---
+            trust_cursor = conn.execute("PRAGMA table_info(trust_scores)")
+            trust_columns = [row[1] for row in trust_cursor.fetchall()]
+            if 'manually_penalized' not in trust_columns:
+                logger.info("Migration: Adding manually_penalized column to trust_scores")
+                conn.execute("ALTER TABLE trust_scores ADD COLUMN manually_penalized BOOLEAN NOT NULL DEFAULT 0")
+
             conn.commit()
         except Exception as e:
             logger.critical(
@@ -1549,7 +1557,7 @@ class DatabaseManager:
         with self.get_connection() as conn:
             conn.execute("""
                 INSERT INTO trust_scores (peer_id, score, notes) 
-                VALUES (?, 100 + ?, ?)
+                VALUES (?, max(0, min(100, ?)), ?)
                 ON CONFLICT(peer_id) DO UPDATE SET
                     score = max(0, min(100, score + ?)),
                     last_interaction = CURRENT_TIMESTAMP,
@@ -1564,7 +1572,7 @@ class DatabaseManager:
                 "SELECT score FROM trust_scores WHERE peer_id = ?", (peer_id,)
             )
             row = cursor.fetchone()
-            return row['score'] if row else 100  # Default trust score
+            return row['score'] if row else 0  # Unknown peers are pending review
     
     def get_all_trust_scores(self) -> Dict[str, int]:
         """Get all trust scores."""
@@ -1589,7 +1597,7 @@ class DatabaseManager:
             return False
     
     def update_delete_signal_status(self, signal_id: str, status: str) -> bool:
-        """Update delete signal status."""
+        """Update delete signal status. Returns False if signal_id not found."""
         VALID_STATUS_COLUMNS = {
             'pending': 'sent_at',
             'acknowledged': 'acknowledged_at',
@@ -1601,18 +1609,21 @@ class DatabaseManager:
             with self.get_connection() as conn:
                 timestamp_col = VALID_STATUS_COLUMNS.get(status)
                 if timestamp_col:
-                    conn.execute(f"""
+                    cur = conn.execute(f"""
                         UPDATE delete_signals 
                         SET status = ?, {timestamp_col} = CURRENT_TIMESTAMP
                         WHERE id = ?
                     """, (status, signal_id))
                 else:
-                    conn.execute("""
+                    cur = conn.execute("""
                         UPDATE delete_signals 
                         SET status = ?
                         WHERE id = ?
                     """, (status, signal_id))
                 conn.commit()
+                if cur.rowcount == 0:
+                    logger.warning(f"Delete signal {signal_id} not found for status update")
+                    return False
                 return True
         except Exception as e:
             logger.error(f"Failed to update delete signal: {e}")

--- a/canopy/core/feed.py
+++ b/canopy/core/feed.py
@@ -231,8 +231,12 @@ class Post:
             'tags': self.tags_list,
         }
     
-    def can_view(self, viewer_id: str, trust_score: int = 50) -> bool:
-        """Check if a user can view this post based on visibility settings."""
+    def can_view(self, viewer_id: str, trust_score: int = 0) -> bool:
+        """Check if a user can view this post based on visibility settings.
+        
+        Default trust_score is 0 (untrusted) so callers must explicitly
+        pass the viewer's actual trust level to allow trusted-visibility access.
+        """
         if self.visibility == PostVisibility.PUBLIC:
             return True
         elif self.visibility == PostVisibility.NETWORK:
@@ -387,7 +391,7 @@ class FeedManager:
     @log_performance('feed')
     def create_post(self, author_id: str, content: str,
                    post_type: PostType = PostType.TEXT,
-                   visibility: PostVisibility = PostVisibility.NETWORK,
+                   visibility: PostVisibility = PostVisibility.PRIVATE,
                    metadata: Optional[Dict[str, Any]] = None,
                    permissions: Optional[List[str]] = None,
                    source_type: str = 'human',
@@ -579,6 +583,7 @@ class FeedManager:
                     WHERE (
                         p.visibility = 'public' OR
                         p.visibility = 'network' OR
+                        p.visibility = 'trusted' OR
                         (p.visibility = 'custom' AND pp.user_id = ?) OR
                         p.author_id = ?
                     ) AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP)
@@ -632,6 +637,7 @@ class FeedManager:
                     WHERE (
                         p.visibility = 'public' OR
                         p.visibility = 'network' OR
+                        p.visibility = 'trusted' OR
                         (p.visibility = 'custom' AND pp.user_id = ?) OR
                         p.author_id = ?
                     )
@@ -663,6 +669,7 @@ class FeedManager:
             WHERE (
                 p.visibility = 'public' OR
                 p.visibility = 'network' OR
+                p.visibility = 'trusted' OR
                 (p.visibility = 'custom' AND pp.user_id = ?) OR
                 p.author_id = ?
             ) AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP) {max_age_clause}
@@ -687,22 +694,48 @@ class FeedManager:
         scored.sort(key=lambda x: x[0], reverse=True)
         return [post for _, post in scored[:limit]]
     
-    def get_user_posts(self, author_id: str, limit: int = 50) -> List[Post]:
-        """Get all posts by a specific user."""
+    def get_user_posts(self, author_id: str, limit: int = 50,
+                       viewer_id: Optional[str] = None) -> List[Post]:
+        """Get posts by a specific user, filtered by visibility.
+        
+        When viewer_id is provided, applies the standard visibility filter
+        so private/custom posts are only returned to authorised viewers.
+        When viewer_id is None, only public/network/trusted posts are returned.
+        """
         try:
             with self.db.get_connection() as conn:
-                cursor = conn.execute("""
-                    SELECT p.*, u.username as author_username
-                    FROM feed_posts p
-                    LEFT JOIN users u ON p.author_id = u.id
-                    WHERE p.author_id = ?
-                      AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP)
-                    ORDER BY p.created_at DESC
-                    LIMIT ?
-                """, (author_id, limit))
-                
+                if viewer_id:
+                    cursor = conn.execute("""
+                        SELECT p.*, u.username as author_username
+                        FROM feed_posts p
+                        LEFT JOIN users u ON p.author_id = u.id
+                        LEFT JOIN post_permissions pp ON p.id = pp.post_id
+                        WHERE p.author_id = ?
+                          AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP)
+                          AND (
+                              p.visibility = 'public'
+                              OR p.visibility = 'network'
+                              OR p.visibility = 'trusted'
+                              OR p.author_id = ?
+                              OR (p.visibility = 'custom' AND pp.user_id = ?)
+                          )
+                        ORDER BY p.created_at DESC
+                        LIMIT ?
+                    """, (author_id, viewer_id, viewer_id, limit))
+                else:
+                    cursor = conn.execute("""
+                        SELECT p.*, u.username as author_username
+                        FROM feed_posts p
+                        LEFT JOIN users u ON p.author_id = u.id
+                        WHERE p.author_id = ?
+                          AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP)
+                          AND p.visibility IN ('public', 'network', 'trusted')
+                        ORDER BY p.created_at DESC
+                        LIMIT ?
+                    """, (author_id, limit))
+
                 return [self._row_to_post(row, conn) for row in cursor.fetchall()]
-                
+
         except Exception as e:
             logger.error(f"Failed to get posts for user {author_id}: {e}")
             return []
@@ -992,6 +1025,7 @@ class FeedManager:
                     WHERE (
                         p.visibility = 'public' OR
                         p.visibility = 'network' OR
+                        p.visibility = 'trusted' OR
                         (p.visibility = 'custom' AND pp.user_id = ?) OR
                         p.author_id = ?
                     ) AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP)
@@ -1007,18 +1041,25 @@ class FeedManager:
             return []
     
     def get_feed_statistics(self, user_id: str) -> Dict[str, int]:
-        """Get feed statistics for a user."""
+        """Get feed statistics for a user (includes custom-visibility posts)."""
         try:
             with self.db.get_connection() as conn:
                 cursor = conn.execute("""
-                    SELECT 
-                        COUNT(*) as total_posts,
-                        SUM(CASE WHEN author_id = ? THEN 1 ELSE 0 END) as user_posts,
-                        COUNT(DISTINCT author_id) as unique_authors
-                    FROM feed_posts
-                    WHERE (visibility = 'public' OR visibility = 'network' OR author_id = ?)
-                      AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
-                """, (user_id, user_id))
+                    SELECT
+                        COUNT(DISTINCT p.id) as total_posts,
+                        SUM(CASE WHEN p.author_id = ? THEN 1 ELSE 0 END) as user_posts,
+                        COUNT(DISTINCT p.author_id) as unique_authors
+                    FROM feed_posts p
+                    LEFT JOIN post_permissions pp ON p.id = pp.post_id
+                    WHERE (
+                        p.visibility = 'public'
+                        OR p.visibility = 'network'
+                        OR p.visibility = 'trusted'
+                        OR p.author_id = ?
+                        OR (p.visibility = 'custom' AND pp.user_id = ?)
+                    )
+                      AND (p.expires_at IS NULL OR p.expires_at > CURRENT_TIMESTAMP)
+                """, (user_id, user_id, user_id))
                 
                 row = cursor.fetchone()
                 return {
@@ -1129,6 +1170,7 @@ class FeedManager:
                     WHERE (
                         p.visibility = 'public' OR
                         p.visibility = 'network' OR
+                        p.visibility = 'trusted' OR
                         (p.visibility = 'custom' AND pp.user_id = ?) OR
                         p.author_id = ?
                     )

--- a/canopy/core/inbox.py
+++ b/canopy/core/inbox.py
@@ -58,9 +58,8 @@ DEFAULT_AGENT_INBOX_CONFIG: Dict[str, Any] = {
     "allowed_trigger_types": ["mention", "dm", "reply", "channel_added"],
     "thread_reply_notifications": True,
     "auto_subscribe_own_threads": True,
-    # Mesh peers are implicitly trusted; TrustManager default_trust_score=100
-    # so this is belt-and-suspenders, but disabling it avoids false rejections
-    # when a peer hasn't been explicitly added to trust_scores yet.
+    # Agent inbox delivery should not depend on manual trust review unless the
+    # operator explicitly enables trusted-only filtering for that account.
     "trusted_only": False,
     "min_trust_score": 0,
     # Very short cooldowns for agent use — agents need to react quickly.

--- a/canopy/core/messaging.py
+++ b/canopy/core/messaging.py
@@ -398,7 +398,7 @@ class Message:
             logger.debug(f"Message {self.id}: Found {len(self.metadata['attachments'])} attachments")
         else:
             result['attachments'] = []
-            logger.debug(f"Message {self.id}: No attachments found (metadata: {self.metadata})")
+            logger.debug(f"Message {self.id}: No attachments found")
             
         return result
     

--- a/canopy/mcp/server.py
+++ b/canopy/mcp/server.py
@@ -58,6 +58,7 @@ from canopy.core.agent_heartbeat import (
     build_agent_heartbeat_snapshot,
     build_actionable_work_preview,
 )
+from canopy.core.inbox import AGENT_SETTABLE_STATUSES
 from canopy.security.api_keys import Permission
 
 # Set up logging
@@ -226,7 +227,7 @@ class CanopyMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "status": {"type": "string", "description": "Filter by status (pending|handled|skipped|expired)"},
+                            "status": {"type": "string", "description": "Filter by status (pending|seen|completed|handled|skipped|expired)"},
                             "limit": {"type": "integer", "description": "Maximum items to retrieve (default: 50)", "default": 50},
                             "since": {"type": "string", "description": "Optional. ISO timestamp to fetch items after."},
                             "include_handled": {"type": "boolean", "description": "Include handled items (default: false)", "default": False}
@@ -239,7 +240,7 @@ class CanopyMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "status": {"type": "string", "description": "Filter by status (pending|handled|skipped|expired)"}
+                            "status": {"type": "string", "description": "Filter by status (pending|seen|completed|handled|skipped|expired)"}
                         }
                     }
                 ),
@@ -290,12 +291,13 @@ class CanopyMCPServer:
                 ),
                 Tool(
                     name="canopy_ack_inbox",
-                    description="Update agent inbox items (mark handled/skipped/pending)",
+                    description="Update agent inbox items (mark seen/completed/skipped/pending) with optional completion linkage",
                     inputSchema={
                         "type": "object",
                         "properties": {
                             "ids": {"type": "array", "items": {"type": "string"}, "description": "Inbox item IDs"},
-                            "status": {"type": "string", "description": "New status (handled|skipped|pending)", "default": "handled"}
+                            "status": {"type": "string", "description": "New status (seen|completed|skipped|pending); legacy alias 'handled' maps to completed. 'expired' is system-only and will be rejected.", "default": "handled"},
+                            "completion_ref": {"type": "object", "description": "Optional evidence link when completing or skipping work, e.g. {source_type, source_id, message_id, post_id}"}
                         },
                         "required": ["ids"]
                     }
@@ -1883,9 +1885,7 @@ class CanopyMCPServer:
                     window_hours=window_hours,
                     limit=limit,
                 )
-                pending_after = inbox_manager.count_items(
-                    user_id=self.user_id, status='pending'
-                )
+                pending_after = inbox_manager.count_items(user_id=self.user_id)
                 result['pending_after'] = pending_after
                 result['user_id'] = self.user_id
                 result['window_hours'] = window_hours
@@ -1900,6 +1900,12 @@ class CanopyMCPServer:
             if not isinstance(ids, list) or not ids:
                 return [TextContent(type="text", text="Error: ids must be a non-empty list")]
             status = args.get("status", "handled")
+            completion_ref = args.get("completion_ref")
+            if completion_ref is not None and not isinstance(completion_ref, dict):
+                return [TextContent(type="text", text="Error: completion_ref must be an object if provided")]
+            normalized_status = str(status or "").strip().lower()
+            if normalized_status not in AGENT_SETTABLE_STATUSES:
+                return [TextContent(type="text", text=f"Error: invalid status '{normalized_status}'. Must be one of: seen, completed, skipped, pending (or legacy alias handled)")]
 
             from canopy.core.app import create_app
 
@@ -1912,6 +1918,7 @@ class CanopyMCPServer:
                     user_id=self.user_id,
                     ids=ids,
                     status=status,
+                    completion_ref=completion_ref,
                 )
                 payload = {"updated": count}
                 return [TextContent(type="text", text=json.dumps(payload, indent=2))]
@@ -2063,7 +2070,7 @@ class CanopyMCPServer:
 
                 inbox_items = []
                 if inbox_manager:
-                    inbox_items = inbox_manager.list_items(self.user_id, status='pending', limit=limit, since=since_iso, include_handled=False)
+                    inbox_items = inbox_manager.list_items(self.user_id, limit=limit, since=since_iso, include_handled=False)
 
                 task_items = []
                 if task_manager:
@@ -2197,13 +2204,13 @@ class CanopyMCPServer:
                 if inbox_manager:
                     try:
                         stats = inbox_manager.get_stats(self.user_id, window_hours=window_hours)
-                        inbox_count = int((stats.get('status_counts') or {}).get('pending', 0))
+                        status_counts = stats.get('status_counts') or {}
+                        inbox_count = int(status_counts.get('pending', 0) or 0) + int(status_counts.get('seen', 0) or 0)
                     except Exception:
                         inbox_count = 0
                     try:
                         preview_items = inbox_manager.list_items(
                             user_id=self.user_id,
-                            status='pending',
                             limit=5,
                             since=since_iso,
                             include_handled=False,
@@ -3966,11 +3973,14 @@ class CanopyMCPServer:
                 if not content:
                     raise ValueError("content is required")
                 post_type_str = (args.get("post_type") or "text").lower()
-                visibility_str = (args.get("visibility") or "network").lower()
+                visibility_str = (args.get("visibility") or "private").lower()
                 post_type = PostType.TEXT
                 if post_type_str in {"poll"} or parse_poll(content or ""):
                     post_type = PostType.POLL
-                visibility = PostVisibility.NETWORK if visibility_str == "network" else PostVisibility.NETWORK
+                try:
+                    visibility = PostVisibility(visibility_str)
+                except Exception:
+                    visibility = PostVisibility.PRIVATE
                 expires_at = args.get("expires_at")
                 ttl_seconds = args.get("ttl_seconds")
                 ttl_mode = args.get("ttl_mode")
@@ -4103,6 +4113,7 @@ class CanopyMCPServer:
                     except Exception:
                         pass
 
+                previous_post = feed_manager.get_post(post_id)
                 try:
                     metadata["edited_at"] = datetime.now(timezone.utc).isoformat()
                 except Exception:
@@ -4134,6 +4145,7 @@ class CanopyMCPServer:
                                 content=updated.content,
                                 post_type=updated.post_type.value,
                                 visibility=updated.visibility.value,
+                                previous_visibility=previous_post.visibility.value if getattr(previous_post, "visibility", None) else None,
                                 timestamp=updated.created_at.isoformat() if hasattr(updated.created_at, "isoformat") else str(updated.created_at),
                                 metadata=updated.metadata,
                                 expires_at=updated.expires_at.isoformat() if getattr(updated, "expires_at", None) else None,

--- a/canopy/network/manager.py
+++ b/canopy/network/manager.py
@@ -1872,13 +1872,17 @@ class P2PNetworkManager:
             logger.info(f"Broker request from {from_peer} declined (relay_policy=off)")
             return
 
-        # Check trust score — decline relay for low-trust peers
+        # Privacy-first relay posture: unknown peers do not get broker help.
         if self.get_trust_score:
             try:
                 score = self.get_trust_score(from_peer)
-                if score < 20:
+                threshold = max(
+                    1,
+                    int(getattr(getattr(self.config, 'security', None), 'trust_threshold', 50) or 50),
+                )
+                if score < threshold:
                     logger.warning(f"Broker request from {from_peer} declined "
-                                   f"(trust score {score} < 20)")
+                                   f"(trust score {score} < {threshold})")
                     return
             except Exception:
                 pass
@@ -2650,6 +2654,7 @@ class P2PNetworkManager:
     def broadcast_feed_post(self, post_id: str, author_id: str,
                              content: str, post_type: str = 'text',
                              visibility: str = 'network',
+                             previous_visibility: Optional[str] = None,
                              timestamp: Optional[str] = None,
                              metadata: Optional[dict[Any, Any]] = None,
                              expires_at: Optional[str] = None,
@@ -2666,12 +2671,14 @@ class P2PNetworkManager:
 
         if not self.message_router:
             return False
+        visibility_mode = str(visibility or 'private').strip().lower() or 'private'
+        previous_visibility_mode = str(previous_visibility or visibility_mode).strip().lower() or visibility_mode
         meta: Dict[str, Any] = {
             'type': 'feed_post',
             'post_id': post_id,
             'author_id': author_id,
             'post_type': post_type,
-            'visibility': visibility,
+            'visibility': visibility_mode,
             'timestamp': timestamp,
             'metadata': metadata or {},
             'expires_at': expires_at,
@@ -2706,16 +2713,105 @@ class P2PNetworkManager:
         except Exception as e:
             logger.debug(f"Feed attachment embedding failed: {e}")
 
-        future = asyncio.run_coroutine_threadsafe(
-            self.message_router.send_feed_post_broadcast(content, meta),
-            self._event_loop
+        target_peers, revoke_peers = self._get_feed_post_target_delta(
+            previous_visibility_mode,
+            visibility_mode,
         )
+        if visibility_mode == 'trusted' and not target_peers:
+            logger.info(
+                "Feed post %s visibility=trusted has no trusted connected peers; keeping local only",
+                post_id,
+            )
+
+        async def _send_feed_post() -> bool:
+            sent_any = False
+            if visibility_mode in {'public', 'network'}:
+                sent_any = await self.message_router.send_feed_post_broadcast(content, meta)
+            else:
+                for peer_id in target_peers:
+                    payload = {
+                        'content': content,
+                        'metadata': dict(meta),
+                    }
+                    message = self.message_router.create_message(
+                        MessageType.FEED_POST,
+                        peer_id,
+                        payload,
+                        ttl=getattr(self.message_router, '_CONTENT_TTL', 5),
+                    )
+                    self.message_router.sign_message(message)
+                    if await self.message_router._route_to_peer(message):
+                        sent_any = True
+
+            revoked_any = False
+            if revoke_peers:
+                for peer_id in revoke_peers:
+                    signal_id = secrets.token_hex(12)
+                    if await self.message_router.send_delete_signal(
+                        signal_id=signal_id,
+                        data_type='feed_post',
+                        data_id=post_id,
+                        reason=f"visibility_narrowed:{previous_visibility_mode}->{visibility_mode}",
+                        target_peer=peer_id,
+                    ):
+                        revoked_any = True
+                logger.info(
+                    "Feed post %s revoked from %d peer(s) due to visibility change %s -> %s",
+                    post_id,
+                    len(revoke_peers),
+                    previous_visibility_mode,
+                    visibility_mode,
+                )
+            if visibility_mode in {'private', 'custom'}:
+                return revoked_any or not revoke_peers
+            return sent_any or revoked_any
+
+        future = asyncio.run_coroutine_threadsafe(_send_feed_post(), self._event_loop)
 
         try:
             return future.result(timeout=5.0)
         except Exception as e:
             logger.error(f"Error broadcasting feed post: {e}", exc_info=True)
             return False
+
+    def _get_feed_post_target_peers(self, visibility: str) -> list[str]:
+        """Return connected peer targets for a feed post visibility mode."""
+        visibility_mode = str(visibility or 'private').strip().lower() or 'private'
+        if visibility_mode in {'private', 'custom'}:
+            return []
+        peers = list(self.get_connected_peers())
+        if visibility_mode in {'public', 'network'}:
+            return peers
+        if visibility_mode != 'trusted' or not self.get_trust_score:
+            return []
+        threshold = max(
+            1,
+            int(getattr(getattr(self.config, 'security', None), 'trust_threshold', 50) or 50),
+        )
+        trusted_peers: list[str] = []
+        for peer_id in peers:
+            if not peer_id:
+                continue
+            try:
+                if int(self.get_trust_score(peer_id)) >= threshold:
+                    trusted_peers.append(peer_id)
+            except Exception:
+                continue
+        return trusted_peers
+
+    def _get_feed_post_target_delta(
+        self,
+        previous_visibility: str,
+        visibility: str,
+    ) -> tuple[list[str], list[str]]:
+        """Return (target_peers, revoke_peers) for a feed visibility change."""
+        target_peers = self._get_feed_post_target_peers(visibility)
+        previous_targets = self._get_feed_post_target_peers(previous_visibility)
+        if not previous_targets:
+            return target_peers, []
+        target_set = set(target_peers)
+        revoke_peers = [peer_id for peer_id in previous_targets if peer_id not in target_set]
+        return target_peers, revoke_peers
 
     def broadcast_interaction(self, item_id: str, user_id: str,
                                action: str, item_type: str = 'post',

--- a/canopy/network/routing.py
+++ b/canopy/network/routing.py
@@ -130,6 +130,10 @@ def encode_channel_key_material(key_material: bytes) -> str:
 # Prevents a misbehaving or permanently-offline peer from exhausting RAM.
 MAX_PENDING_PER_PEER = 500
 
+MAX_CONTENT_BYTES = 256 * 1024       # 256 KB for text content
+MAX_PAYLOAD_BYTES = 512 * 1024       # 512 KB for total message payload
+MAX_ID_BYTES = 512                   # max length for any user/post/signal ID
+
 
 class MessageType(Enum):
     """Types of P2P messages."""
@@ -776,7 +780,17 @@ class MessageRouter:
             self.pending_messages[target_peer] = []
         queue = self.pending_messages[target_peer]
         if len(queue) >= MAX_PENDING_PER_PEER:
-            dropped = queue.pop(0)
+            # Prioritise delete signals: evict the oldest non-delete-signal
+            # message so revocation/privacy signals survive queue overflow.
+            evict_idx = None
+            for i, m in enumerate(queue):
+                if m.type != MessageType.DELETE_SIGNAL:
+                    evict_idx = i
+                    break
+            if evict_idx is not None:
+                dropped = queue.pop(evict_idx)
+            else:
+                dropped = queue.pop(0)
             logger.warning(
                 f"Pending queue for {target_peer} full ({MAX_PENDING_PER_PEER}); "
                 f"dropped oldest message {dropped.id}"
@@ -813,13 +827,33 @@ class MessageRouter:
         """Deliver message to local application."""
         logger.debug(f"Delivering message {message.id} locally")
         payload = cast(Dict[str, Any], message.payload)
-        
+
         # Decrypt if needed
         if message.encrypted_payload:
             if not self.decrypt_message(message):
                 logger.error(f"Failed to decrypt message {message.id}")
                 return False
-        
+
+        # Payload size guard: drop oversized messages before any handler runs
+        try:
+            import json as _json
+            payload_bytes = len(_json.dumps(payload).encode('utf-8'))
+            if payload_bytes > MAX_PAYLOAD_BYTES:
+                logger.warning(
+                    f"Dropping oversized message {message.id} from {message.from_peer}: "
+                    f"{payload_bytes} bytes exceeds {MAX_PAYLOAD_BYTES} limit"
+                )
+                return False
+            content_val = payload.get('content', '')
+            if isinstance(content_val, str) and len(content_val.encode('utf-8')) > MAX_CONTENT_BYTES:
+                logger.warning(
+                    f"Dropping message {message.id} from {message.from_peer}: "
+                    f"content exceeds {MAX_CONTENT_BYTES} byte limit"
+                )
+                return False
+        except Exception:
+            pass
+
         logger.debug(f"Received {message.type.value} message from {message.from_peer}")
 
         # Emit a lightweight UI-facing activity event for user-level messages.

--- a/canopy/security/encryption.py
+++ b/canopy/security/encryption.py
@@ -93,24 +93,34 @@ class DataEncryptor:
         """Check if encryption is currently enabled."""
         return self._enabled
     
-    def encrypt(self, plaintext: str) -> str:
+    _LARGE_PAYLOAD_WARN_BYTES = 1 * 1024 * 1024  # 1 MiB
+
+    def encrypt(self, plaintext: Optional[str]) -> Optional[str]:
         """
         Encrypt a string for storage.
         
         Args:
-            plaintext: The string to encrypt
+            plaintext: The string to encrypt. Binary data must be
+                       base64-encoded by the caller before passing here.
             
         Returns:
-            Encrypted string with prefix, or original string if encryption disabled
+            Encrypted string with prefix, or original string if encryption
+            disabled. Returns None when plaintext is None.
         """
+        if plaintext is None:
+            return None
         if not self._enabled or not plaintext:
             return plaintext
         
         try:
+            plaintext_bytes = plaintext.encode('utf-8')
+            if len(plaintext_bytes) > self._LARGE_PAYLOAD_WARN_BYTES:
+                logger.warning(
+                    f"Encrypting large payload ({len(plaintext_bytes)} bytes); "
+                    "consider chunking or compressing before encryption"
+                )
             cipher = ChaCha20Poly1305(cast(bytes, self._cipher_key))
             nonce = secrets.token_bytes(12)
-            
-            plaintext_bytes = plaintext.encode('utf-8')
             ciphertext = cipher.encrypt(nonce, plaintext_bytes, None)
             
             # Format: ENC:1:<nonce_hex>:<ciphertext_hex>
@@ -120,7 +130,7 @@ class DataEncryptor:
             logger.error(f"Encryption failed: {e}")
             return plaintext  # Fail open - store unencrypted rather than lose data
     
-    def decrypt(self, stored_value: str) -> str:
+    def decrypt(self, stored_value: Optional[str]) -> Optional[str]:
         """
         Decrypt a stored string.
         
@@ -128,8 +138,11 @@ class DataEncryptor:
             stored_value: The stored string (possibly encrypted)
             
         Returns:
-            Decrypted string, or original string if not encrypted
+            Decrypted string, or original string if not encrypted.
+            Returns None when stored_value is None.
         """
+        if stored_value is None:
+            return None
         if not stored_value or not stored_value.startswith(ENCRYPTED_PREFIX):
             return stored_value  # Not encrypted, return as-is
         
@@ -167,7 +180,7 @@ class DataEncryptor:
                 logger.debug(f"Decryption failed (suppressed repeat, fingerprint={fingerprint}): {e}")
             return "[Decryption failed]"
     
-    def is_encrypted(self, value: str) -> bool:
+    def is_encrypted(self, value: Optional[str]) -> bool:
         """Check if a value is encrypted."""
         return value is not None and value.startswith(ENCRYPTED_PREFIX)
 

--- a/canopy/security/trust.py
+++ b/canopy/security/trust.py
@@ -76,13 +76,31 @@ class TrustManager:
     def __init__(self, db_manager: DatabaseManager):
         """Initialize trust manager with database connection."""
         self.db = db_manager
-        self.default_trust_score = 100
+        # Privacy-first baseline: unknown peers are pending review, not trusted.
+        self.default_trust_score = 0
         self.min_trust_score = 0
         self.max_trust_score = 100
         self.delete_timeout_hours = 24
+
+    def has_explicit_trust_score(self, peer_id: str) -> bool:
+        """Return True when a peer has a persisted trust row."""
+        if not peer_id:
+            return False
+        try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    "SELECT 1 FROM trust_scores WHERE peer_id = ?",
+                    (peer_id,),
+                ).fetchone()
+                return bool(row)
+        except Exception as e:
+            logger.error(f"Failed to check trust row for {peer_id}: {e}")
+            return False
     
     def get_trust_score(self, peer_id: str) -> int:
         """Get current trust score for a peer."""
+        if not peer_id:
+            return self.default_trust_score
         try:
             with self.db.get_connection() as conn:
                 cursor = conn.execute("""
@@ -118,11 +136,17 @@ class TrustManager:
             with self.db.get_connection() as conn:
                 # Get current score or create new entry
                 cursor = conn.execute("""
-                    SELECT score FROM trust_scores WHERE peer_id = ?
+                    SELECT score, manually_penalized FROM trust_scores WHERE peer_id = ?
                 """, (peer_id,))
                 
                 row = cursor.fetchone()
                 current_score = row['score'] if row else self.default_trust_score
+                manually_penalized = bool(row['manually_penalized']) if row and 'manually_penalized' in row.keys() else False
+
+                # Block positive score changes for manually penalized peers
+                if manually_penalized and score_delta > 0:
+                    logger.debug(f"Skipping positive trust delta for manually penalized peer {peer_id}")
+                    return current_score
                 
                 # Calculate new score within bounds
                 new_score = max(
@@ -133,7 +157,7 @@ class TrustManager:
                 # Update or insert trust score
                 if row:
                     conn.execute("""
-                        UPDATE trust_scores 
+                        UPDATE trust_scores
                         SET score = ?, last_interaction = CURRENT_TIMESTAMP,
                             compliance_events = compliance_events + ?,
                             violation_events = violation_events + ?,
@@ -184,18 +208,20 @@ class TrustManager:
                 row = cursor.fetchone()
 
                 note = f"manual: {reason}" if reason else "manual"
+                penalized = 1 if clamped_score < 50 else 0
                 if row:
                     conn.execute("""
                         UPDATE trust_scores
-                        SET score = ?, last_interaction = CURRENT_TIMESTAMP, notes = ?
+                        SET score = ?, last_interaction = CURRENT_TIMESTAMP,
+                            notes = ?, manually_penalized = ?
                         WHERE peer_id = ?
-                    """, (clamped_score, note, peer_id))
+                    """, (clamped_score, note, penalized, peer_id))
                 else:
                     conn.execute("""
                         INSERT INTO trust_scores
-                        (peer_id, score, compliance_events, violation_events, notes)
-                        VALUES (?, ?, 0, 0, ?)
-                    """, (peer_id, clamped_score, note))
+                        (peer_id, score, compliance_events, violation_events, notes, manually_penalized)
+                        VALUES (?, ?, 0, 0, ?, ?)
+                    """, (peer_id, clamped_score, note, penalized))
 
                 conn.commit()
                 logger.info(f"Set trust score for {peer_id}: {clamped_score} ({note})")
@@ -273,14 +299,26 @@ class TrustManager:
             return False
     
     def comply_with_delete_signal(self, signal_id: str, peer_id: str) -> bool:
-        """Mark a delete signal as complied with and update trust score."""
+        """Mark a delete signal as complied with and update trust score.
+        
+        Ownership check: the signal's target_peer_id must match peer_id
+        to prevent a peer claiming compliance credit for someone else's signal.
+        """
         try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    "SELECT target_peer_id FROM delete_signals WHERE id = ?",
+                    (signal_id,)
+                ).fetchone()
+                if not row or row['target_peer_id'] != peer_id:
+                    logger.warning(f"Ownership check failed for comply: signal={signal_id} peer={peer_id}")
+                    return False
+
             success = self.db.update_delete_signal_status(signal_id, "complied")
             if success:
-                # Reward compliance with positive trust score
                 self.update_trust_score(
-                    peer_id, 
-                    TrustEvent.DELETE_COMPLIED, 
+                    peer_id,
+                    TrustEvent.DELETE_COMPLIED,
                     reason=f"Complied with delete signal {signal_id}"
                 )
                 logger.info(f"Marked delete signal {signal_id} as complied")
@@ -288,16 +326,27 @@ class TrustManager:
         except Exception as e:
             logger.error(f"Failed to mark delete signal as complied: {e}")
             return False
-    
+
     def violate_delete_signal(self, signal_id: str, peer_id: str) -> bool:
-        """Mark a delete signal as violated and penalize trust score."""
+        """Mark a delete signal as violated and penalize trust score.
+        
+        Ownership check: the signal's target_peer_id must match peer_id.
+        """
         try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    "SELECT target_peer_id FROM delete_signals WHERE id = ?",
+                    (signal_id,)
+                ).fetchone()
+                if not row or row['target_peer_id'] != peer_id:
+                    logger.warning(f"Ownership check failed for violate: signal={signal_id} peer={peer_id}")
+                    return False
+
             success = self.db.update_delete_signal_status(signal_id, "violated")
             if success:
-                # Penalize violation with negative trust score
                 self.update_trust_score(
-                    peer_id, 
-                    TrustEvent.DELETE_VIOLATED, 
+                    peer_id,
+                    TrustEvent.DELETE_VIOLATED,
                     reason=f"Violated delete signal {signal_id}"
                 )
                 logger.warning(f"Marked delete signal {signal_id} as violated by {peer_id}")
@@ -367,6 +416,8 @@ class TrustManager:
     
     def is_peer_trusted(self, peer_id: str, threshold: int = 50) -> bool:
         """Check if a peer is trusted based on their trust score."""
+        if not self.has_explicit_trust_score(peer_id):
+            return False
         return self.get_trust_score(peer_id) >= threshold
     
     def get_trusted_peers(self, threshold: int = 50) -> List[str]:

--- a/canopy/ui/routes.py
+++ b/canopy/ui/routes.py
@@ -3631,24 +3631,6 @@ def create_ui_blueprint() -> Blueprint:
             # Device profiles for peer identification
             peer_device_profiles = channel_manager.get_all_peer_device_profiles() if channel_manager else {}
 
-            # Ensure connected peers have entries
-            all_peer_ids = set(trust_scores.keys())
-            for pid in connected_peers:
-                if pid:
-                    all_peer_ids.add(pid)
-            if trust_manager:
-                for pid in all_peer_ids:
-                    if pid not in trust_scores:
-                        score = trust_manager.get_trust_score(pid)
-                        trust_scores[pid] = {
-                            'score': score,
-                            'last_interaction': None,
-                            'compliance_events': 0,
-                            'violation_events': 0,
-                            'notes': 'discovered',
-                            'is_trusted': score >= 50
-                        }
-            
             # Get trust statistics
             trust_stats = trust_manager.get_trust_statistics() if trust_manager else {}
             
@@ -3669,9 +3651,9 @@ def create_ui_blueprint() -> Blueprint:
                 score = score_info.get('score', 0)
                 if score >= 80:
                     tier = 'safe'
-                elif score >= 60:
-                    tier = 'guarded'
                 elif score >= 40:
+                    tier = 'guarded'
+                elif score > 0:
                     tier = 'restricted'
                 else:
                     tier = 'quarantine'
@@ -3680,10 +3662,15 @@ def create_ui_blueprint() -> Blueprint:
             # Potential peers list (introduced but not yet assigned a trust tier)
             potential_peers = []
             existing_peer_ids = set(trust_scores.keys())
+            for pid in connected_peers:
+                if pid and pid not in existing_peer_ids:
+                    potential_peers.append({'peer_id': pid, 'status': 'connected'})
+                    existing_peer_ids.add(pid)
             for peer in introduced_peers:
                 pid = peer.get('peer_id') if isinstance(peer, dict) else None
                 if pid and pid not in existing_peer_ids:
                     potential_peers.append(peer)
+                    existing_peer_ids.add(pid)
             
             return render_template('trust.html',
                                  trust_scores=trust_scores,
@@ -3722,9 +3709,9 @@ def create_ui_blueprint() -> Blueprint:
             if score is None:
                 tier_map = {
                     'safe': 90,
-                    'guarded': 65,
-                    'restricted': 40,
-                    'quarantine': 10
+                    'guarded': 40,
+                    'restricted': 10,
+                    'quarantine': 0
                 }
                 if tier not in tier_map:
                     return jsonify({'error': 'Invalid tier'}), 400
@@ -8565,7 +8552,7 @@ def create_ui_blueprint() -> Blueprint:
             data = request.get_json()
             content = data.get('content', '').strip()
             post_type = data.get('post_type', 'text')
-            visibility = data.get('visibility', 'network')
+            visibility = data.get('visibility', 'private')
             permissions = data.get('permissions', [])
             metadata = data.get('metadata')
             file_attachments = data.get('attachments', [])
@@ -8629,7 +8616,7 @@ def create_ui_blueprint() -> Blueprint:
             
             # Convert visibility to PostVisibility enum
             try:
-                visibility_enum = PostVisibility(visibility if visibility in ['network', 'trusted', 'public', 'private', 'custom'] else 'network')
+                visibility_enum = PostVisibility(visibility if visibility in ['network', 'trusted', 'public', 'private', 'custom'] else 'private')
             except ValueError as e:
                 return jsonify({'error': f'Invalid visibility: {e}'}), 400
             
@@ -9516,6 +9503,7 @@ def create_ui_blueprint() -> Blueprint:
                                 content=updated.content,
                                 post_type=updated.post_type.value,
                                 visibility=updated.visibility.value,
+                                previous_visibility=existing_post.visibility.value if getattr(existing_post, 'visibility', None) else None,
                                 timestamp=updated.created_at.isoformat() if hasattr(updated.created_at, 'isoformat') else str(updated.created_at),
                                 metadata=updated.metadata,
                                 expires_at=updated.expires_at.isoformat() if getattr(updated, 'expires_at', None) else None,

--- a/canopy/ui/static/js/canopy-main.js
+++ b/canopy/ui/static/js/canopy-main.js
@@ -670,9 +670,11 @@
             }
 
             const visiblePeers = visibleSidebarCardItems('peers', activePeers);
+            const peerFrag = document.createDocumentFragment();
             visiblePeers.forEach(record => {
-                listEl.appendChild(createSidebarPeerElement(record));
+                peerFrag.appendChild(createSidebarPeerElement(record));
             });
+            listEl.appendChild(peerFrag);
             setSidebarPeerCount(activePeers.length);
             updateSidebarCardChrome('peers', activePeers.length);
             renderSidebarPeerModalList();
@@ -862,6 +864,16 @@
             const totalUnread = normalized.reduce((sum, contact) => sum + Math.max(0, Number(contact && contact.unread_count) || 0), 0);
             if (totalEl) totalEl.textContent = String(totalUnread);
 
+            // Render-key diffing: skip DOM writes when data is unchanged
+            const dmRenderKey = visibleContacts.map(c =>
+                `${c.user_id}:${c.unread_count}:${c.status_state}:${c.latest_preview}:${c.latest_message_at}`
+            ).join('|');
+            if (listEl.__canopyDmRenderKey === dmRenderKey && listEl.childElementCount > 0) {
+                updateSidebarCardChrome('dm', normalized.length);
+                return;
+            }
+            listEl.__canopyDmRenderKey = dmRenderKey;
+
             listEl.innerHTML = '';
             if (!normalized.length) {
                 const empty = document.createElement('div');
@@ -872,6 +884,7 @@
                 return;
             }
 
+            const dmFrag = document.createDocumentFragment();
             visibleContacts.forEach(contact => {
                 const link = document.createElement('a');
                 link.className = 'sidebar-dm-contact';
@@ -940,8 +953,9 @@
                 }
                 link.appendChild(time);
 
-                listEl.appendChild(link);
+                dmFrag.appendChild(link);
             });
+            listEl.appendChild(dmFrag);
 
             updateSidebarCardChrome('dm', normalized.length);
         }
@@ -1308,7 +1322,7 @@
             requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
             requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
             pollCanopyWorkspaceAttentionEvents();
-            canopySidebarAttentionState.pollHandle = window.setInterval(pollCanopyWorkspaceAttentionEvents, 2500);
+            canopySidebarAttentionState.pollHandle = window.setInterval(pollCanopyWorkspaceAttentionEvents, 5000);
             canopySidebarAttentionState.safetyHandle = window.setInterval(() => {
                 requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
                 requestCanopySidebarDmRefresh({ force: false }).catch(() => {});

--- a/canopy/ui/templates/base.html
+++ b/canopy/ui/templates/base.html
@@ -677,6 +677,7 @@
         .sidebar-media-mini.is-visible {
             display: block;
             animation: miniPlayerSlideIn 0.28s cubic-bezier(0.2, 0.7, 0.2, 1);
+            will-change: transform, opacity;
         }
 
         @keyframes miniPlayerSlideIn {
@@ -1026,6 +1027,7 @@
             background: linear-gradient(90deg, rgba(6, 182, 212, 0.14), rgba(255, 255, 255, 0.03));
             box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.16), 0 12px 26px rgba(0, 0, 0, 0.22);
             animation: sidebarPeerPing 1.1s ease;
+            will-change: transform;
         }
 
         .sidebar-peer.activity .trust-pill {

--- a/canopy/ui/templates/channels.html
+++ b/canopy/ui/templates/channels.html
@@ -2519,11 +2519,11 @@
                                     </a></li>
                                     <li><a class="dropdown-item" href="#" onclick="setChannelPrivacy('guarded')">
                                         <i class="bi bi-shield-check me-2"></i>Guarded
-                                        <small class="text-muted d-block">Signed, limited metadata</small>
+                                        <small class="text-muted d-block">Moderated and visible to the mesh. Not private.</small>
                                     </a></li>
                                     <li><a class="dropdown-item" href="#" onclick="setChannelPrivacy('private')">
                                         <i class="bi bi-lock-fill me-2"></i>Private
-                                        <small class="text-muted d-block">E2EE-ready (pilot)</small>
+                                        <small class="text-muted d-block">Targeted membership. Use this for sensitive work.</small>
                                     </a></li>
                                     <li><a class="dropdown-item" href="#" onclick="setChannelPrivacy('confidential')">
                                         <i class="bi bi-shield-lock me-2"></i>Confidential
@@ -6178,7 +6178,7 @@ function displayMessages(messages, options = {}) {
     const userIds = [...userIdSet];
     
     // Fetch user display info and mention candidates in parallel; build handle->display_name map
-    Promise.all([
+    return Promise.all([
         fetchUserDisplayInfo(userIds),
         fetchChannelMentionCandidates(currentChannelId)
     ]).then(([userInfo, candidates]) => {
@@ -6213,9 +6213,10 @@ function displayMessages(messages, options = {}) {
             }
         });
 
-        // Render orphan replies whose thread root isn't in view
+        // Render orphan replies whose thread root isn't in view (O(n) via Set)
+        const rootIdSet = new Set(rootMessages.map(m => m.id));
         Object.keys(repliesByRoot).forEach(rid => {
-            if (!rootMessages.find(m => m.id === rid)) {
+            if (!rootIdSet.has(rid)) {
                 repliesByRoot[rid].forEach(r => { html += renderMessage(r, userInfo, true); });
             }
         });

--- a/canopy/ui/templates/feed.html
+++ b/canopy/ui/templates/feed.html
@@ -136,9 +136,10 @@
                         <option value="network">Local Network</option>
                         <option value="trusted">Trusted Peers Only</option>
                         <option value="public">Everyone</option>
-                        <option value="private">Only Me</option>
+                        <option value="private" selected>Only Me</option>
                         <option value="custom">Custom Permissions</option>
                     </select>
+                    <div class="form-text">Default is private. `Trusted` only reaches peers you have explicitly reviewed.</div>
                 </div>
 
                 <div class="col-md-4">
@@ -5275,7 +5276,7 @@
                     id: postId,
                     content: currentContent,
                     post_type: 'text',
-                    visibility: 'network',
+                    visibility: 'private',
                     metadata: {},
                 });
             })
@@ -5338,9 +5339,10 @@
                         <option value="network">Local Network</option>
                         <option value="trusted">Trusted Peers Only</option>
                         <option value="public">Everyone</option>
-                        <option value="private">Only Me</option>
+                        <option value="private" selected>Only Me</option>
                         <option value="custom">Custom Permissions</option>
                     </select>
+                    <div class="form-text small mt-1">Private is the safe default. Promote only when you mean to share.</div>
                 </div>
             </div>
             <div class="mt-2" data-inline-post-existing-attachments></div>
@@ -5398,7 +5400,7 @@
         }
         const visibilitySelect = panel.querySelector('select[data-inline-post-visibility]');
         if (visibilitySelect) {
-            const visibilityValue = String(post.visibility || 'network');
+            const visibilityValue = String(post.visibility || 'private');
             if (visibilitySelect.querySelector(`option[value="${visibilityValue}"]`)) {
                 visibilitySelect.value = visibilityValue;
             }
@@ -5566,7 +5568,7 @@
         const visibilitySelect = panel.querySelector('select[data-inline-post-visibility]');
         const content = ((textarea && textarea.value) || '').trim();
         const postType = ((typeSelect && typeSelect.value) || 'text').trim();
-        const visibility = ((visibilitySelect && visibilitySelect.value) || 'network').trim();
+        const visibility = ((visibilitySelect && visibilitySelect.value) || 'private').trim();
 
         if (!content && state.existingAttachments.length === 0 && state.newAttachments.length === 0) {
             showAlert('Post content or attachments are required', 'warning');

--- a/canopy/ui/templates/settings.html
+++ b/canopy/ui/templates/settings.html
@@ -432,6 +432,8 @@
                             <strong>Broker Only</strong> (recommended) helps peers find and establish direct connections with minimal bandwidth cost.
                             <br>
                             <strong>Full Relay</strong> also carries traffic for peers that cannot connect directly, which uses your bandwidth and resources.
+                            <br>
+                            For a public relay, use a separate node from your primary owner mesh.
                         </small>
                     </div>
                     <div class="col-md-6">

--- a/canopy/ui/templates/trust.html
+++ b/canopy/ui/templates/trust.html
@@ -617,7 +617,7 @@
             <div class="trust-map-header">
                 <div>
                     <h2 class="trust-map-title">Trust Zones</h2>
-                    <p class="trust-map-sub">Layer your mesh so humans and agents stay inside the right permission band.</p>
+                    <p class="trust-map-sub">Manual trust bands for peers you have explicitly reviewed. New peers stay pending until you place them.</p>
                 </div>
                 <div class="trust-map-legend">
                     <span class="legend-chip safe">Safe</span>
@@ -631,7 +631,7 @@
                 <div class="trust-zone-header">
                     <div>
                         <h3 class="trust-zone-title">Safe Zone</h3>
-                        <p class="trust-zone-sub">Full relay + private data access.</p>
+                        <p class="trust-zone-sub">Explicitly trusted peers. Suitable for broker help and trusted-only sharing.</p>
                     </div>
                     <div class="trust-zone-count" data-zone-count="safe">{{ trust_tiers.safe|length }}</div>
                 </div>
@@ -648,7 +648,7 @@
                 <div class="trust-zone-header">
                     <div>
                         <h3 class="trust-zone-title">Guarded</h3>
-                        <p class="trust-zone-sub">Messaging ok, sensitive data gated.</p>
+                        <p class="trust-zone-sub">Known peers under review. Do not treat this as a privacy boundary.</p>
                     </div>
                     <div class="trust-zone-count" data-zone-count="guarded">{{ trust_tiers.guarded|length }}</div>
                 </div>
@@ -665,7 +665,7 @@
                 <div class="trust-zone-header">
                     <div>
                         <h3 class="trust-zone-title">Restricted</h3>
-                        <p class="trust-zone-sub">Limited participation, no relay.</p>
+                        <p class="trust-zone-sub">Limited participation. Keep them off broker and relay paths.</p>
                     </div>
                     <div class="trust-zone-count" data-zone-count="restricted">{{ trust_tiers.restricted|length }}</div>
                 </div>
@@ -727,7 +727,7 @@
 
             <div class="trust-side-card">
                 <div class="trust-side-title">Potential Peers</div>
-                <div class="trust-side-sub">Introduced by your network. Drag into a zone to trust.</div>
+                <div class="trust-side-sub">Connected or introduced peers without an explicit trust score. Drag into a zone only after review.</div>
                 <div class="trust-side-list" data-potential-list>
                     {% if potential_peers %}
                         {% for peer in potential_peers %}
@@ -762,9 +762,9 @@
             <div class="trust-side-card">
                 <div class="trust-side-title">Trust Policy</div>
                 <ul class="trust-policy-list">
-                    <li><span class="trust-policy-dot"></span>Safe peers can relay and access protected data.</li>
-                    <li><span class="trust-policy-dot"></span>Guarded peers can message but cannot relay.</li>
-                    <li><span class="trust-policy-dot"></span>Restricted peers are read-mostly and monitored.</li>
+                    <li><span class="trust-policy-dot"></span>Peers are pending by default until you assign an explicit trust score.</li>
+                    <li><span class="trust-policy-dot"></span>Safe peers can participate in trusted-only sharing and broker requests.</li>
+                    <li><span class="trust-policy-dot"></span>Guarded is a review state, not a private zone.</li>
                     <li><span class="trust-policy-dot"></span>Quarantined peers stay isolated until reviewed.</li>
                 </ul>
             </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canopy"
-version = "0.4.105"
+version = "0.4.109"
 description = "Local-first peer-to-peer collaboration for humans and AI agents."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Rolls up four patch releases since v0.4.105:

- **0.4.106** — Privacy-first trust baseline (unknown peers start at 0), feed defaults to private, visibility-scoped propagation with narrowing revocation
- **0.4.107** — Proactive P2P hardening pass: trust boundary enforcement, input validation, API auth tightening, feed visibility defaults
- **0.4.108** — Delete signal authorization, sidebar DOM batching and render-key diffing, GPU compositing hints
- **0.4.109** — Encryption helper robustness, metadata logging cleanup
- **Docs** — Updated README disclaimer, refreshed agent onboarding and API reference
- **Tests** — New regression tests for channels, streams, sidebar, workspace events