### PR TITLE
release: curate public 0.6.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,150 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.6.27] - 2026-04-13
+
+### Changed
+- **Public-facing docs now teach the current connection review workflow instead of older blind-connect assumptions** - the README, Quick Start, Connect FAQ, and peer connection guide now explain device-profile-based peer identity, review-before-connect invite flow, preview-only sync boundaries, Trust-page review actions, and stale-hint refresh guidance using the shipped 0.6.27 behavior.
+
+## [0.6.26] - 2026-04-13
+
+### Fixed
+- **Preview-only peers can now refresh their human recognition hints without approving sync** - the Trust page `Refresh profile` action now clears cached preview identity and safely reconnects to relearn fresh label and avatar hints for untrusted peers, instead of leaving operators stuck with stale first-contact metadata.
+- **Trust review counts and controls now match the actual admin workflow** - `Needs Review` no longer drifts from badge side-effects, repeated connection text was removed from pending peer cards, and trust-tier plus sync-approval actions now consistently require the instance admin.
+
+## [0.6.25] - 2026-04-13
+
+### Changed
+- **Trust pending-peer cards now emphasize the actual operator decision instead of badge noise** - the Trust page keeps the `Connection / Review gate / Identity` summary model, uses clearer peer-recognition wording when only a raw peer ID is known, and ensures mesh-review and sync-review peers count toward the admin attention surface.
+
+## [0.6.24] - 2026-04-13
+
+### Fixed
+- **Untrusted peer rows now stay human-readable even when images are missing** - Connect surfaces for connected, discovered, relayed, and introduced peers now fall back to readable unverified labels plus initials badges instead of raw peer IDs, making first-contact review much safer for human operators.
+- **Saving the device profile now refreshes the node label immediately for new handshakes** - updating the local device profile now refreshes the live advertised peer/instance labels without waiting for a full instance restart, while third-party announced avatar blobs are no longer treated as trusted stored peer profiles.
+
+## [0.6.23] - 2026-04-13
+
+### Changed
+- **Accepted cross-mesh invites can now connect for review instead of stalling in a dead-end mismatch state** - instance admins can import a mismatched peer, keep the transport up for review, then explicitly treat it as the same mesh or keep it as a bridge without silently merging meshes.
+
+### Fixed
+- **Node hints now carry a compact admin-chosen icon fallback when avatar images are unavailable** - device profiles now include a validated standard icon that rides inside invite/public preview metadata so Connect cards still show a recognizable node marker even when remote preview fetches fail or avatars do not load.
+
+## [0.6.22] - 2026-04-13
+
+### Fixed
+- **Meshspace stop/restart now ignores foreign listeners bound to the wrong host/interface** - supervised runtime probing and port-conflict checks now resolve listeners against the meshspace's actual host so stale loopback tunnels or wrong-interface listeners no longer keep a meshspace stuck in `stopping` or block restart with a false port conflict.
+
+## [0.6.21] - 2026-04-13
+
+### Changed
+- **Connect cards now treat the peer as the instance you are connecting to, not the admin account** - invite generation, remote preview enrichment, and the settings/profile guidance now use the device profile as the peer name/avatar shown during connection review, while the mesh page continues to own the mesh identity hints.
+
+## [0.6.20] - 2026-04-13
+
+### Fixed
+- **Remote invite review now probes the right Canopy endpoint for images** - the Connect page no longer tries to fetch public preview metadata from the peer websocket port, and it can now merge the remote peer avatar together with the remote mesh avatar so fresh invite review cards refill both images after a peer is forgotten.
+
+## [0.6.19] - 2026-04-13
+
+### Fixed
+- **Fresh invite review can now recover the remote mesh art and labels after a peer is forgotten** - the Connect page now keeps invite payloads short, then probes only the invite-advertised remote endpoint for public mesh preview metadata so the review card can refill the mesh avatar, mesh name, and peer hints without reintroducing oversized invite codes.
+
+## [0.6.18] - 2026-04-13
+
+### Changed
+- **Connect hint identity setup is now much clearer for admins** - invite and Connect card peer hints now consistently use the instance owner's profile as the primary human-facing identity, while the device profile is labeled as a secondary node hint so operators can set recognition details in the right place.
+- **Profile, Settings, and Mesh pages now preview the full connection review bundle** - admins can now verify the peer image/name, mesh image/name/ID, and node hint from the existing pages before sharing invites, reducing confusion without adding invite payload bloat or a separate hint system.
+
+## [0.6.17] - 2026-04-13
+
+### Added
+- **Connect review cards now carry the live mesh identity operators expect** - invites and reconnect surfaces now advertise the current registry-backed mesh name plus an optional mesh avatar/logo thumbnail so peers are easier to recognize before trust or sync approval.
+
+### Changed
+- **Legacy default meshes can now be promoted to a stable explicit mesh ID with a controlled restart** - the current mesh detail page exposes an admin-only migration flow that preserves the old legacy ID as an alias for transition-safe cross-mesh diagnostics and reconnect review instead of silently continuing to advertise a `legacy-*` ID.
+- **Connect review copy now labels the peer token correctly** - the review card now says `Peer ID` instead of implying the sender-provided value is a separate fingerprint.
+
+## [0.6.16] - 2026-04-13
+
+### Fixed
+- **Fresh LAN-discovered peers now stop at a review boundary instead of immediately populating channels and history** - newly seen peers stay in a preview-only state that preserves identity and mesh hints for operator review while blocking automatic post-connect sync, incoming channel sync, catch-up import, and peer-introduction expansion until sync is explicitly approved.
+- **Trust review now exposes explicit sync approval actions for first-contact peers and whole meshspaces** - the Trust page can now show preview-only peer state, explain why sync is paused, and let an operator approve one peer or promote sync for later peers from the same advertised meshspace without conflating that decision with broader trust scoring.
+
+## [0.6.15] - 2026-04-13
+
+### Fixed
+- **Wrong-mesh peers are now cut off in two additional connection paths that could still slip past the first safety pass** - outbound connections now re-check the peer's mesh hint immediately after handshake and disconnect if a foreign mesh is revealed without approval, and relay offers no longer create routes to known foreign-mesh peers before an admin explicitly allows that bridge.
+- **Cross-mesh connect guidance is clearer on the Connect page for non-admin operators** - invite preview now distinguishes missing mesh hints from actual mismatches, preserves server diagnostic codes for better error copy, and disables the cross-mesh connect button with an explicit admin-required state instead of waiting for a failed click.
+- **Cross-mesh blocked peers no longer get re-added to automatic reconnect cleanup after disconnect** - disconnect cleanup now skips the reconnect loop for peers that already require manual cross-mesh approval, reducing redundant retry work without weakening the boundary.
+
+## [0.6.14] - 2026-04-13
+
+### Fixed
+- **Cross-mesh reconnects now fail more safely after a wrong invite import or stale peer mix-up** - endpoints learned from a verified peer-id mismatch continue to be quarantined instead of silently adopted under a different peer, unapproved incoming cross-mesh handshakes are disconnected before they can linger as an accidental bridge, and automatic reconnect or sync paths stay blocked until the bridge is explicitly approved.
+- **Cross-mesh approval now requires the workspace admin instead of any authenticated operator** - invite import, manual reconnect, and the Connect UI now require instance-admin approval before allowing a different meshspace to be bridged, which reduces the chance of an accidental user action re-linking two private meshes.
+
+## [0.6.13] - 2026-04-12
+
+### Fixed
+- **Same-participant group DMs can now deliberately start a fresh thread without collapsing back into the older discussion** - explicit fresh-group instances carry their own thread metadata so replies, edits, bookmarks, and sidebar links stay on the new conversation while legacy split-relay groups still retain the older alias-repair merge behavior.
+- **Portrait photos with EXIF rotation metadata now generate correctly oriented feed thumbnails instead of showing up sideways** - thumbnail generation now transposes images before resizing and lazily regenerates stale rotated thumbs when the original image still exposes a side-rotation EXIF mismatch.
+
+## [0.6.12] - 2026-04-12
+
+### Fixed
+- **DM and sidebar switching now avoid several redundant refresh bursts that made the UI feel heavier than necessary** - the DM workspace no longer forces a full thread snapshot after every inline edit or every tab-visibility return, while the global sidebar refresh path now coalesces focus/visibility bursts instead of replaying duplicate attention and DM snapshot requests back-to-back.
+
+### Changed
+- **Current-mesh attention summaries now compute at most once per request instead of repeating the same DB-backed summary work for multiple template consumers on the same page render** - the active mesh attention payload is cached in `flask.g` for the life of the request and returned as copies so callers cannot mutate the shared cached value.
+
+## [0.6.11] - 2026-04-11
+
+### Fixed
+- **DM timestamps now localize immediately instead of briefly showing raw UTC strings on first paint or fast refresh paths** - the shared frontend timestamp formatter is now exposed as a reusable global, runs immediately on load, and is reused by DM workspace refreshes and optimistic rows so direct-message timestamps render in the viewer's local time without waiting for the 30-second refresh loop.
+
+## [0.6.10] - 2026-04-11
+
+### Fixed
+- **Inline-edited DMs now immediately regain rich rendering instead of falling back to plain text until the next snapshot refresh** - the inline edit path now reapplies the shared DM rich-content renderer as soon as edited text is written back into the message bubble.
+- **Group DM member resolution no longer burns its alias-repair scan budget on unrelated group rows** - DM group-member expansion now queries only rows that actually involve the current user, which prevents unrelated `group:*` traffic from crowding out relevant relay legs during bounded alias repair.
+
+## [0.6.9] - 2026-04-11
+
+### Fixed
+- **Relay-delivered group DMs now recover a fuller participant set instead of splitting one logical group into multiple partial threads** - group DM conversation lookup, sidebar grouping, reply fanout, edit rebroadcasts, and inbound metadata repair now expand through shared group aliases so relayed partial-member rows can converge back into one thread and target the full known participant union.
+
+## [0.6.8] - 2026-04-11
+
+### Changed
+- **Messages and posts now support a bounded safe Markdown subset without opening the door to raw HTML rendering** - the shared client-side rich-content pipeline can now render lightweight headings, lists, blockquotes, inline code, bold, italic, and strikethrough across channels, DMs, and feed posts while still escaping user HTML first and preserving the existing safe link, image, fenced-code, embed, and math behavior.
+
+## [0.6.7] - 2026-04-11
+
+### Fixed
+- **Direct messages now preserve authored line breaks instead of flattening multiline text into one paragraph** - DM bubble text now renders with whitespace preservation so server-rendered messages, optimistic rows, and inline-edited DM copies all keep intentional newlines and blank lines while still wrapping normally inside the bubble.
+
+## [0.6.6] - 2026-04-11
+
+### Fixed
+- **Approved agents now land in open public channels instead of staying stranded in quarantine-only membership** - the shared default-channel repair path now backfills all open public channels, and the admin approval and classification flows reuse that path immediately after agent quarantine succeeds so newly approved agent accounts can post where operators expect without manual database repair.
+
+## [0.6.5] - 2026-04-10
+
+### Changed
+- **Invite import now gives operators a safer preview with mesh-aware hints before connecting** — the Connect page can decode an invite locally, surface sender-provided mesh, node, fingerprint, reachability, and age hints before import, and still falls back to the existing server-side verification path for the actual peer registration and connection attempt.
+
+## [0.6.4] - 2026-04-09
+
+### Fixed
+- **Compact mobile layouts now do less redundant resize work while keeping drawer and composer state more truthful** — the DM, channel, and feed mobile helpers now coalesce repeated resize-driven layout sync into a single animation-frame pass, the DM chats backdrop updates its accessibility state alongside the drawer toggle, and the feed composer toggle now exposes its controlled region from initial render instead of waiting for client-side setup.
+
+## [0.6.3] - 2026-04-09
+
+### Changed
+- **DMs, channels, and feed now waste less vertical space on phones** — the DM view switches to an active-thread-first mobile layout with a one-tap chats drawer, channel search stays collapsed by default across phone-width layouts until needed, and the feed composer now starts collapsed on compact screens unless there is already draft content or attachments waiting.
+
 ## [0.6.2] - 2026-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.6.0-blue" alt="Version 0.6.0">
+  <img src="https://img.shields.io/badge/version-0.6.27-blue" alt="Version 0.6.27">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 License">
   <img src="https://img.shields.io/badge/encryption-ChaCha20--Poly1305-blueviolet" alt="ChaCha20-Poly1305">
@@ -98,6 +98,10 @@ If you are comparing Canopy to Slack, Discord, or Microsoft Teams, the simplest 
 
 Recent end-user improvements reflected in the app and docs:
 
+- **Human-readable first-contact review** — Connect and Trust now keep untrusted peers recognizable with readable labels, initials, mesh hints, and node hints instead of dumping operators straight into raw peer IDs.
+- **Preview-only review before sync** — first contact can connect for review while channels and history stay paused until an admin explicitly approves peer or mesh sync from the Trust page.
+- **Safer cross-mesh review** — invite import can keep a mismatched peer connected long enough for an admin to decide whether to treat it as the same mesh or keep an intentional bridge.
+- **Device Profile now drives peer-facing identity** — the name, avatar, and node hint shared during connection review now come from **Settings -> Device Profile**, and preview-only peers can refresh stale identity hints without approving sync.
 - **Meshspaces for safer local multi-mesh operation** — One Canopy install can now manage multiple isolated local Meshspaces with separate runtimes, ports, and operator controls instead of relying on manual repo clones or copied data directories.
 - **Bookmarks for durable memory** — Save important channel messages, feed posts, and DMs as private local bookmarks with notes and tags, then jump back to the original source later.
 - **Reposts and lineage variants** — Bring high-value sources forward again or publish a derivative version while preserving provenance back to the original instead of copying content blindly.
@@ -194,9 +198,11 @@ If you specifically want a faster macOS/Linux bootstrap, Docker-based local runs
 1. Open `http://localhost:7770` and create your local user.
 2. Send a message in `#general`.
 3. Create an API key under **API Keys** for scripts or agents.
-4. Open **Connect** and copy your invite code.
-5. Exchange invite codes with another instance and connect.
-6. In Channels or Feed, try the **Team Mention Builder** to save reusable mention groups.
+4. Open **Settings -> Device Profile** and set the machine name/avatar other peers should see during connection review.
+5. Open **Connect** and copy your invite code.
+6. Exchange invite codes with another instance, review the peer + mesh hints, then connect.
+7. If the peer stays preview-only or needs mesh review, open **Trust** to approve sync, treat it as the same mesh, keep a bridge, or refresh stale profile hints.
+8. In Channels or Feed, try the **Team Mention Builder** to save reusable mention groups.
 
 Connect deep-dive and button-by-button reference:
 - [docs/CONNECT_FAQ.md](docs/CONNECT_FAQ.md)
@@ -508,6 +514,8 @@ Full reference: [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
 | You see | What it means | What to do |
 |---|---|---|
 | Two `ws://` addresses in "Reachable at" | Your machine has multiple local interfaces/IPs, such as host and VM NICs. | This is normal. Canopy includes multiple candidate endpoints in invites. |
+| A peer shows as preview-only after first connect | Transport is up, but sync/history are intentionally paused until review is complete. | Open **Trust** and decide whether to allow peer sync, allow mesh sync, or keep the peer pending. |
+| Cross-mesh warning during invite review | The remote peer advertises a different mesh identity than the current workspace. | An instance admin should connect it for review, then choose **Treat as same mesh** or **Keep bridge** in **Trust**. |
 | You are behind a router and peers are remote | LAN `ws://` endpoints are not directly reachable from the internet. | Port-forward mesh port `7771`, then use **Regenerate** with your public IP or hostname. |
 | "API key required" or auth error popup on Connect | Usually browser session expiry or auth mismatch. | Reload, sign in again. For scripts and CLI, include `X-API-Key`. |
 | Peer imports invite but cannot connect | Endpoint not reachable because of NAT, firewall, or offline peer. | Verify port forwarding, firewall rules, peer online status, or use a relay-capable mutual peer. |

--- a/canopy/__init__.py
+++ b/canopy/__init__.py
@@ -8,7 +8,7 @@ Project: Canopy - Local Mesh Communication
 License: Apache 2.0
 """
 
-__version__ = "0.6.2"
+__version__ = "0.6.27"
 __protocol_version__ = 1
 __author__ = "Canopy Contributors"
 __license__ = "Apache-2.0"

--- a/canopy/api/routes.py
+++ b/canopy/api/routes.py
@@ -41,6 +41,7 @@ from ..core.mentions import (
     sync_edited_mention_activity,
 )
 from ..core.profile import (
+    build_local_peer_hint_payload,
     get_default_agent_directives,
     normalize_agent_directives,
 )
@@ -86,6 +87,7 @@ from ..core.messaging import (
     build_dm_security_summary,
     build_dm_preview,
     compute_group_id,
+    compute_group_thread_id,
     filter_local_dm_targets,
 )
 from ..core.inbox import AGENT_SETTABLE_STATUSES, ACTIONABLE_STATUSES
@@ -183,6 +185,188 @@ def _build_meshspace_runtime_payload() -> dict[str, Any]:
             'p2p': p2p_state,
             'workspace_events': workspace_state,
         },
+    }
+
+
+def _current_runtime_mesh_hint_payload() -> dict[str, Any]:
+    """Return the current runtime mesh hint, preferring the registry-backed record."""
+    from ..network.invite import meshspace_fingerprint
+
+    config = current_app.config.get('CANOPY_CONFIG')
+    manager = current_app.config.get('MESHSPACE_REGISTRY_MANAGER')
+    record = current_app.config.get('MESHSPACE_RECORD')
+    mesh_cfg = getattr(config, 'meshspace', None)
+    current_meshspace_id = str(getattr(mesh_cfg, 'meshspace_id', '') or '').strip()
+    if manager and current_meshspace_id:
+        try:
+            fresh = manager.get_meshspace(current_meshspace_id)
+            if isinstance(fresh, dict) and fresh:
+                record = fresh
+                current_app.config['MESHSPACE_RECORD'] = dict(fresh)
+        except Exception:
+            pass
+    record = record if isinstance(record, dict) else {}
+    meshspace_id = str(record.get('meshspace_id') or getattr(mesh_cfg, 'meshspace_id', '') or '').strip()
+    meshspace_name = str(record.get('name') or getattr(mesh_cfg, 'name', '') or '').strip()
+    avatar_preview: dict[str, str] = {}
+    if manager and meshspace_id:
+        try:
+            avatar_preview = manager.get_meshspace_avatar_preview(meshspace_id)
+        except Exception:
+            avatar_preview = {}
+    return {
+        'meshspace_id': meshspace_id,
+        'meshspace_id_aliases': list(record.get('meshspace_id_aliases') or []),
+        'meshspace_name': meshspace_name,
+        'meshspace_fingerprint': meshspace_fingerprint(meshspace_id, meshspace_name),
+        'meshspace_avatar_b64': str(avatar_preview.get('avatar_b64') or '').strip(),
+        'meshspace_avatar_mime': str(avatar_preview.get('avatar_mime') or 'image/png').strip() or 'image/png',
+    }
+
+
+def _current_local_peer_hint_payload(
+    *,
+    fallback_device_label: str = '',
+    device_profile: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    db_manager = current_app.config.get('DB_MANAGER')
+    profile_manager = current_app.config.get('PROFILE_MANAGER')
+    return build_local_peer_hint_payload(
+        db_manager,
+        profile_manager,
+        fallback_device_label=fallback_device_label,
+        device_profile=device_profile,
+    )
+
+
+def _public_mesh_identity_payload() -> dict[str, Any]:
+    """Return a shell-safe public identity payload for invite preview enrichment."""
+    from ..core.device import get_device_label, get_device_profile
+
+    runtime_payload = _build_meshspace_runtime_payload()
+    mesh_hint = _current_runtime_mesh_hint_payload()
+    config = current_app.config.get('CANOPY_CONFIG')
+    fallback_device_label = str(getattr(config, 'device_label', '') or '').strip()
+    device_profile: dict[str, Any] = {}
+    try:
+        device_profile = get_device_profile() or {}
+        if not fallback_device_label:
+            fallback_device_label = str(get_device_label() or '').strip()
+    except Exception:
+        device_profile = {}
+    peer_hint = _current_local_peer_hint_payload(
+        fallback_device_label=fallback_device_label,
+        device_profile=device_profile,
+    )
+
+    meshspace = dict(runtime_payload.get('meshspace') or {})
+    meshspace.update({
+        'meshspace_id': str(mesh_hint.get('meshspace_id') or meshspace.get('meshspace_id') or '').strip(),
+        'meshspace_id_aliases': list(mesh_hint.get('meshspace_id_aliases') or []),
+        'name': str(mesh_hint.get('meshspace_name') or meshspace.get('name') or '').strip(),
+        'meshspace_fingerprint': str(mesh_hint.get('meshspace_fingerprint') or '').strip(),
+        'meshspace_avatar_b64': str(mesh_hint.get('meshspace_avatar_b64') or '').strip(),
+        'meshspace_avatar_mime': str(mesh_hint.get('meshspace_avatar_mime') or 'image/png').strip() or 'image/png',
+    })
+    peer = dict(runtime_payload.get('peer') or {})
+    peer.update({
+        'peer_label': str(peer_hint.get('peer_label') or '').strip(),
+        'instance_label': str(peer_hint.get('instance_label') or '').strip(),
+        'peer_avatar_b64': str(peer_hint.get('peer_avatar_b64') or '').strip(),
+        'peer_avatar_mime': str(peer_hint.get('peer_avatar_mime') or 'image/jpeg').strip() or 'image/jpeg',
+        'peer_icon': str(peer_hint.get('peer_icon') or '').strip(),
+    })
+    return {
+        'meshspace': meshspace,
+        'peer': peer,
+        'version': runtime_payload.get('version'),
+        'setup_required': runtime_payload.get('setup_required'),
+        'ready': runtime_payload.get('ready'),
+    }
+
+
+def _invite_endpoint_identity_urls(endpoint: str) -> list[str]:
+    """Convert an invite websocket endpoint into likely public identity URLs."""
+    from ..network.invite import parse_invite_endpoint
+
+    parsed = parse_invite_endpoint(endpoint)
+    if not parsed:
+        return []
+    host, port, scheme = parsed
+    host_text = f'[{host}]' if ':' in host and not host.startswith('[') else host
+    http_scheme = 'https' if scheme == 'wss' else 'http'
+    candidate_ports: list[int] = []
+    # Canopy normally allocates ports as http=N, mesh=N+1, discovery=N+2.
+    if port > 1:
+        candidate_ports.append(port - 1)
+    candidate_ports.append(port)
+    urls: list[str] = []
+    seen: set[str] = set()
+    for candidate_port in candidate_ports:
+        url = f'{http_scheme}://{host_text}:{candidate_port}/api/v1/mesh/identity'
+        if url in seen:
+            continue
+        seen.add(url)
+        urls.append(url)
+    return urls
+
+
+def _fetch_remote_mesh_identity_preview(endpoint: str, *, timeout_seconds: float = 2.0) -> dict[str, Any]:
+    """Fetch shell-safe preview metadata from a remote invite endpoint."""
+    target_urls = _invite_endpoint_identity_urls(endpoint)
+    if not target_urls:
+        raise ValueError('Invite endpoint is not usable for preview fetch')
+
+    payload: dict[str, Any] | None = None
+    last_error = 'Remote preview fetch failed'
+    source_url = ''
+    for target_url in target_urls:
+        req = Request(target_url, headers={
+            'User-Agent': 'Canopy/1.0 invite-preview',
+            'Accept': 'application/json',
+            'Cache-Control': 'no-cache',
+        })
+        try:
+            with urlopen(req, timeout=max(0.5, float(timeout_seconds))) as resp:
+                final_url = str(getattr(resp, 'geturl', lambda: target_url)() or target_url)
+                if final_url != target_url:
+                    raise ValueError('Redirects are not allowed for remote preview fetches')
+                status_code = int(getattr(resp, 'status', 200) or 200)
+                if status_code != 200:
+                    raise ValueError(f'Remote preview returned HTTP {status_code}')
+                raw = resp.read(32_768 + 1)
+                if len(raw) > 32_768:
+                    raise ValueError('Remote preview payload exceeded size limit')
+                payload = json.loads(raw.decode('utf-8', errors='replace'))
+                source_url = target_url
+                break
+        except Exception as exc:
+            last_error = str(exc)
+    if payload is None:
+        raise ValueError(last_error)
+
+    meshspace = payload.get('meshspace') if isinstance(payload.get('meshspace'), dict) else {}
+    peer = payload.get('peer') if isinstance(payload.get('peer'), dict) else {}
+    return {
+        'meshspace_id': str(meshspace.get('meshspace_id') or '').strip(),
+        'meshspace_id_aliases': [
+            str(value or '').strip()
+            for value in (meshspace.get('meshspace_id_aliases') or [])
+            if str(value or '').strip()
+        ],
+        'meshspace_name': str(meshspace.get('name') or '').strip(),
+        'meshspace_fingerprint': str(meshspace.get('meshspace_fingerprint') or '').strip(),
+        'meshspace_avatar_b64': str(meshspace.get('meshspace_avatar_b64') or '').strip(),
+        'meshspace_avatar_mime': str(meshspace.get('meshspace_avatar_mime') or 'image/png').strip() or 'image/png',
+        'peer_label': str(peer.get('peer_label') or '').strip(),
+        'peer_avatar_b64': str(peer.get('peer_avatar_b64') or '').strip(),
+        'peer_avatar_mime': str(peer.get('peer_avatar_mime') or 'image/jpeg').strip() or 'image/jpeg',
+        'peer_icon': str(peer.get('peer_icon') or '').strip(),
+        'instance_label': str(peer.get('instance_label') or '').strip(),
+        'ready': bool(payload.get('ready')),
+        'version': str(payload.get('version') or '').strip(),
+        'source_endpoint': str(endpoint or '').strip(),
+        'source_url': source_url,
     }
 
 
@@ -571,6 +755,23 @@ def create_api_blueprint() -> Blueprint:
             
             return decorated_function
         return decorator
+
+    def _request_authenticated_user_id() -> str:
+        """Return the authenticated API-key or session user id for this request."""
+        key_info = getattr(g, 'api_key_info', None)
+        if key_info is not None:
+            return str(getattr(key_info, 'user_id', '') or '').strip()
+        return str(session.get('user_id') or '').strip()
+
+    def _request_is_instance_admin(db_manager: Any) -> bool:
+        """Return True when the current request is acting as the instance owner."""
+        try:
+            owner_user_id = str((db_manager.get_instance_owner_user_id() if db_manager else '') or '').strip()
+        except Exception:
+            owner_user_id = ''
+        if not owner_user_id:
+            return False
+        return _request_authenticated_user_id() == owner_user_id
 
     def _cleanup_forgotten_peer_runtime_state(p2p_manager: Any, peer_id: str, *, remove_introduced: bool) -> dict[str, int]:
         counts = {
@@ -1021,7 +1222,10 @@ def create_api_blueprint() -> Blueprint:
         if is_group:
             if user_id != sender_id and user_id not in group_members:
                 return None
-            conversation_group = compute_group_id(group_members) if group_members else (raw_group_id or recipient_id)
+            if str(metadata.get('group_thread_id') or '').strip() and raw_group_id:
+                conversation_group = raw_group_id
+            else:
+                conversation_group = compute_group_id(group_members) if group_members else (raw_group_id or recipient_id)
             other_names = [
                 _bookmark_author_label(member_id, db_manager, profile_manager)
                 for member_id in group_members
@@ -2510,14 +2714,7 @@ def create_api_blueprint() -> Blueprint:
     @api.route('/mesh/identity', methods=['GET'])
     def mesh_identity():
         """Return shell-safe identity metadata for the current mesh runtime."""
-        payload = _build_meshspace_runtime_payload()
-        return jsonify({
-            'meshspace': payload.get('meshspace'),
-            'peer': payload.get('peer'),
-            'version': payload.get('version'),
-            'setup_required': payload.get('setup_required'),
-            'ready': payload.get('ready'),
-        })
+        return jsonify(_public_mesh_identity_payload())
 
     @api.route('/meshspace/shell_summary', methods=['GET'])
     def meshspace_shell_summary():
@@ -2999,6 +3196,7 @@ def create_api_blueprint() -> Blueprint:
     def generate_p2p_invite():
         """Generate an invite code for remote peers to connect."""
         from ..network.invite import generate_invite
+        from ..core.device import get_device_label, get_device_profile
         *_, config, p2p_manager = _get_app_components_any(current_app)
 
         if not p2p_manager or not p2p_manager.identity_manager.local_identity:
@@ -3009,6 +3207,25 @@ def create_api_blueprint() -> Blueprint:
             public_port = request.args.get('public_port', type=int)
             external_endpoint = request.args.get('external_endpoint', type=str)
             mesh_port = config.network.mesh_port if config else 7771
+            mesh_hint = _current_runtime_mesh_hint_payload()
+            mesh_name = str(mesh_hint.get('meshspace_name') or '').strip()
+            meshspace_id = str(mesh_hint.get('meshspace_id') or '').strip()
+            mesh_fingerprint = str(mesh_hint.get('meshspace_fingerprint') or '').strip()
+            instance_label = str(getattr(config, 'device_label', '') or '').strip()
+            device_profile = {}
+            try:
+                device_profile = get_device_profile() or {}
+                if not instance_label:
+                    instance_label = str(get_device_label() or '').strip()
+            except Exception:
+                device_profile = {}
+            peer_hint = _current_local_peer_hint_payload(
+                fallback_device_label=instance_label,
+                device_profile=device_profile,
+            )
+            peer_label = str(peer_hint.get('peer_label') or '').strip()
+            instance_label = str(peer_hint.get('instance_label') or '').strip()
+            peer_icon = str(peer_hint.get('peer_icon') or '').strip()
 
             invite = generate_invite(
                 p2p_manager.identity_manager,
@@ -3016,11 +3233,28 @@ def create_api_blueprint() -> Blueprint:
                 public_host=public_host,
                 public_port=public_port,
                 external_endpoint=external_endpoint,
+                mesh_name=mesh_name or None,
+                meshspace_id=meshspace_id or None,
+                meshspace_id_aliases=list(mesh_hint.get('meshspace_id_aliases') or []) or None,
+                meshspace_fingerprint_value=mesh_fingerprint or None,
+                peer_label=peer_label or None,
+                instance_label=instance_label or None,
+                peer_icon=peer_icon or None,
+                generated_at=datetime.now(timezone.utc).isoformat(),
             )
             return jsonify({
                 'invite_code': invite.encode(),
                 'peer_id': invite.peer_id,
                 'endpoints': invite.endpoints,
+                'meshspace_id': invite.meshspace_id,
+                'meshspace_name': invite.mesh_name,
+                'meshspace_fingerprint': invite.meshspace_fingerprint,
+                'peer_label': peer_label,
+                'instance_label': instance_label,
+                'safety_label': (
+                    f"{invite.mesh_name or 'Canopy mesh'}"
+                    f"{' · ' + invite.meshspace_fingerprint if invite.meshspace_fingerprint else ''}"
+                ),
                 'raw': invite.to_dict(),
             })
         except ValueError as e:
@@ -3030,13 +3264,70 @@ def create_api_blueprint() -> Blueprint:
             logger.error(f"Failed to generate invite: {e}", exc_info=True)
             return jsonify({'error': 'Failed to generate invite'}), 500
 
+    @api.route('/p2p/invite/preview', methods=['POST'])
+    @require_auth(allow_session=True)
+    def preview_p2p_invite():
+        """Fetch a shell-safe remote identity preview for a pasted invite."""
+        from ..network.invite import InviteCode, canonicalize_invite_endpoint
+
+        data = request.get_json() or {}
+        invite_code = str(data.get('invite_code') or '').strip()
+        if not invite_code:
+            return jsonify({'error': 'invite_code required'}), 400
+
+        try:
+            invite = InviteCode.decode(invite_code)
+        except Exception:
+            return jsonify({
+                'ok': False,
+                'status': 'invalid_invite',
+                'message': 'This invite could not be decoded.',
+            }), 200
+
+        endpoints = [
+            canon for canon in (
+                canonicalize_invite_endpoint(str(value or '').strip())
+                for value in (invite.endpoints or [])
+            )
+            if canon
+        ]
+        if not endpoints:
+            return jsonify({
+                'ok': False,
+                'status': 'no_endpoints',
+                'message': 'Invite does not advertise any usable direct endpoints.',
+                'peer_id': invite.peer_id,
+            }), 200
+
+        failures: list[str] = []
+        for endpoint in endpoints[:3]:
+            try:
+                preview = _fetch_remote_mesh_identity_preview(endpoint)
+                return jsonify({
+                    'ok': True,
+                    'status': 'fetched',
+                    'peer_id': invite.peer_id,
+                    **preview,
+                })
+            except Exception as exc:
+                failures.append(str(exc))
+
+        return jsonify({
+            'ok': False,
+            'status': 'unavailable',
+            'message': 'Remote preview could not be refreshed from the advertised endpoints.',
+            'peer_id': invite.peer_id,
+            'attempted_endpoints': endpoints[:3],
+            'failures': failures[:3],
+        }), 200
+
     @api.route('/p2p/invite/import', methods=['POST'])
     @require_auth(allow_session=True)
     def import_p2p_invite():
         """Import an invite code and attempt to connect to the peer."""
         import asyncio
         from ..network.invite import InviteCode, import_invite, parse_invite_endpoint
-        *_, p2p_manager = _get_app_components_any(current_app)
+        db_manager, _, _, _, _, _, _, _, _, config, p2p_manager = _get_app_components_any(current_app)
 
         if not p2p_manager or not p2p_manager.identity_manager.local_identity:
             return jsonify({'error': 'P2P identity not initialized'}), 500
@@ -3047,16 +3338,72 @@ def create_api_blueprint() -> Blueprint:
                 return jsonify({'error': 'invite_code required'}), 400
 
             invite = InviteCode.decode(data['invite_code'])
+            allow_cross_mesh = _as_bool(data.get('allow_cross_mesh'))
+            _, _, _, _, _, _, _, _, _, config, _ = _get_app_components_any(current_app)
+            mesh_cfg = getattr(config, 'meshspace', None) if config else None
+            local_meshspace_id = str(getattr(mesh_cfg, 'meshspace_id', '') or '').strip()
+            local_meshspace_aliases = [
+                str(value or '').strip()
+                for value in (getattr(mesh_cfg, 'meshspace_id_aliases', []) or [])
+                if str(value or '').strip()
+            ]
+            local_meshspace_name = str(getattr(mesh_cfg, 'name', '') or '').strip()
+            explicit_meshspace = bool(getattr(mesh_cfg, 'enabled', False))
+            invite_meshspace_id = str(invite.meshspace_id or '').strip()
+            invite_meshspace_aliases = [
+                str(value or '').strip()
+                for value in (getattr(invite, 'meshspace_id_aliases', None) or [])
+                if str(value or '').strip()
+            ]
+            local_meshspace_ids = {local_meshspace_id, *local_meshspace_aliases}
+            invite_meshspace_ids = {invite_meshspace_id, *invite_meshspace_aliases}
+            local_meshspace_ids.discard('')
+            invite_meshspace_ids.discard('')
+            invite_mesh_identity_mismatch = bool(
+                explicit_meshspace
+                and local_meshspace_ids
+                and invite_meshspace_ids
+                and not local_meshspace_ids.intersection(invite_meshspace_ids)
+            )
+            if invite_mesh_identity_mismatch and not allow_cross_mesh and not _request_is_instance_admin(db_manager):
+                return jsonify({
+                    'status': 'admin_required',
+                    'error': 'Mesh identity review requires instance admin',
+                    'diagnostic_code': 'mesh_identity_admin_required',
+                    'message': (
+                        'This invite advertises a different meshspace. '
+                        'An instance admin can connect it for review, then choose whether to treat it as the same mesh or keep it as a bridge.'
+                    ),
+                    'local_meshspace': {
+                        'meshspace_id': local_meshspace_id,
+                        'name': local_meshspace_name,
+                    },
+                    'invite_meshspace': {
+                        'meshspace_id': invite_meshspace_id,
+                        'name': getattr(invite, 'mesh_name', ''),
+                        'fingerprint': getattr(invite, 'meshspace_fingerprint', ''),
+                    },
+                }), 403
+            if allow_cross_mesh and not _request_is_instance_admin(db_manager):
+                return jsonify({
+                    'error': 'Instance admin required',
+                    'diagnostic_code': 'cross_mesh_admin_required',
+                    'message': (
+                        'Only the instance admin can approve a cross-mesh bridge from this workspace.'
+                    ),
+                }), 403
             result = import_invite(
                 p2p_manager.identity_manager,
                 p2p_manager.connection_manager,
                 invite,
             )
+            if allow_cross_mesh and hasattr(p2p_manager, 'mark_peer_cross_mesh_allowed'):
+                p2p_manager.mark_peer_cross_mesh_allowed(invite.peer_id, True)
 
             # Attempt to connect to each endpoint
             connected = False
             if p2p_manager.connection_manager:
-                for ep in invite.endpoints:
+                for ep in list(getattr(invite, 'endpoints', []) or []):
                     try:
                         _record_connection_event(
                             p2p_manager,
@@ -3074,10 +3421,22 @@ def create_api_blueprint() -> Blueprint:
                         # so the WebSocket stays on the persistent loop
                         ev_loop = p2p_manager._event_loop
                         if ev_loop and not ev_loop.is_closed():
-                            future = asyncio.run_coroutine_threadsafe(
-                                p2p_manager.connection_manager.connect_to_peer(
+                            connect_coro = None
+                            connect_to_endpoint = getattr(type(p2p_manager), '_connect_to_endpoint', None)
+                            if callable(connect_to_endpoint):
+                                connect_coro = connect_to_endpoint(
+                                    p2p_manager,
+                                    invite.peer_id,
+                                    ep,
+                                    allow_cross_mesh=allow_cross_mesh,
+                                    allow_mesh_review=bool(invite_mesh_identity_mismatch and not allow_cross_mesh),
+                                )
+                            else:
+                                connect_coro = p2p_manager.connection_manager.connect_to_peer(
                                     invite.peer_id, host, port, scheme=scheme
-                                ),
+                                )
+                            future = asyncio.run_coroutine_threadsafe(
+                                connect_coro,
                                 ev_loop
                             )
                             connected = future.result(timeout=10.0)
@@ -3086,20 +3445,42 @@ def create_api_blueprint() -> Blueprint:
                             connected = False
 
                         if connected:
-                            result['status'] = 'connected'
+                            cross_status = {}
+                            get_cross_status = getattr(p2p_manager, 'get_peer_cross_mesh_status', None)
+                            if callable(get_cross_status):
+                                try:
+                                    cross_status = dict(get_cross_status(invite.peer_id) or {})
+                                except Exception:
+                                    cross_status = {}
+                            mesh_review_required = bool(cross_status.get('requires_manual_confirmation'))
+                            result['status'] = 'connected_mesh_review_required' if mesh_review_required else 'connected'
                             result['connected_endpoint'] = ep
+                            if cross_status:
+                                result['cross_mesh'] = cross_status
+                                result['mesh_relationship'] = cross_status.get('mesh_relationship')
+                                result['local_meshspace_id'] = cross_status.get('local_meshspace_id')
+                                result['remote_meshspace_id'] = cross_status.get('remote_meshspace_id')
+                            if mesh_review_required:
+                                result['diagnostic_code'] = 'mesh_identity_review_required'
+                                result['message'] = (
+                                    'Peer connected. Mesh identity still needs admin review before same-mesh sync is allowed.'
+                                )
                             _record_connection_event(
                                 p2p_manager,
                                 invite.peer_id,
-                                status='connected',
-                                detail='Invite connected',
+                                status='mesh_review_required' if mesh_review_required else 'connected',
+                                detail=(
+                                    'Invite connected; mesh identity review required'
+                                    if mesh_review_required else 'Invite connected'
+                                ),
                                 endpoint=ep,
                             )
                             # Trigger channel-sync + catch-up for the new peer
-                            try:
-                                p2p_manager.trigger_peer_sync(invite.peer_id)
-                            except Exception as sync_err:
-                                logger.warning(f"Post-connect sync failed for {invite.peer_id}: {sync_err}")
+                            if not mesh_review_required:
+                                try:
+                                    p2p_manager.trigger_peer_sync(invite.peer_id)
+                                except Exception as sync_err:
+                                    logger.warning(f"Post-connect sync failed for {invite.peer_id}: {sync_err}")
                             break
                     except Exception as ce:
                         logger.warning(f"Connection to {ep} failed: {ce}")
@@ -3115,10 +3496,16 @@ def create_api_blueprint() -> Blueprint:
                     )
                 else:
                     result['diagnostic_code'] = 'direct_connect_failed'
-                    result['message'] = (
-                        'Peer registered but could not connect to any advertised endpoint. '
-                        'The peer may be offline, the endpoint may be stale, or the connection may require broker/relay help.'
-                    )
+                    if invite_mesh_identity_mismatch and not allow_cross_mesh:
+                        result['message'] = (
+                            'Peer registered for mesh identity review but could not connect to any advertised endpoint yet. '
+                            'When it is reachable, sync remains paused until an admin treats the mesh IDs as the same mesh or keeps a bridge.'
+                        )
+                    else:
+                        result['message'] = (
+                            'Peer registered but could not connect to any advertised endpoint. '
+                            'The peer may be offline, the endpoint may be stale, or the connection may require broker/relay help.'
+                        )
                 _record_connection_event(
                     p2p_manager,
                     invite.peer_id,
@@ -3157,10 +3544,17 @@ def create_api_blueprint() -> Blueprint:
         for pid, identity in im.known_peers.items():
             if identity.is_local():
                 continue
+            meshspace_hint = {}
+            if hasattr(im, 'get_peer_meshspace_hint'):
+                try:
+                    meshspace_hint = im.get_peer_meshspace_hint(pid)
+                except Exception:
+                    meshspace_hint = {}
             peers.append({
                 'peer_id': pid,
                 'display_name': im.peer_display_names.get(pid, ''),
                 'endpoints': im.peer_endpoints.get(pid, []),
+                'meshspace_hint': meshspace_hint,
                 'connected': pid in connected,
             })
         return jsonify({'known_peers': peers})
@@ -3275,9 +3669,14 @@ def create_api_blueprint() -> Blueprint:
                     if not parsed:
                         continue
                     host, port, scheme = parsed
+                    connect_to_endpoint = getattr(type(p2p_manager), '_connect_to_endpoint', None)
+                    if callable(connect_to_endpoint):
+                        connect_coro = connect_to_endpoint(p2p_manager, peer_id, ep)
+                    else:
+                        connect_coro = p2p_manager.connection_manager.connect_to_peer(
+                            peer_id, host, port, scheme=scheme)
                     future = asyncio.run_coroutine_threadsafe(
-                        p2p_manager.connection_manager.connect_to_peer(
-                            peer_id, host, port, scheme=scheme),
+                        connect_coro,
                         ev_loop
                     )
                     connected = future.result(timeout=10.0)
@@ -3441,7 +3840,7 @@ def create_api_blueprint() -> Blueprint:
     def reconnect_known_peer():
         """Reconnect to a previously known peer."""
         import asyncio
-        *_, p2p_manager = _get_app_components_any(current_app)
+        db_manager, _, _, _, _, _, _, _, _, _, p2p_manager = _get_app_components_any(current_app)
         if not p2p_manager or not p2p_manager.connection_manager:
             return jsonify({'error': 'P2P not running'}), 500
 
@@ -3449,6 +3848,37 @@ def create_api_blueprint() -> Blueprint:
         peer_id = data.get('peer_id')
         if not peer_id:
             return jsonify({'error': 'peer_id required'}), 400
+        allow_cross_mesh = _as_bool(data.get('allow_cross_mesh'))
+
+        cross_status = {}
+        get_cross_status = getattr(p2p_manager, 'get_peer_cross_mesh_status', None)
+        if callable(get_cross_status):
+            try:
+                cross_status = dict(get_cross_status(peer_id) or {})
+            except Exception:
+                cross_status = {}
+        if cross_status.get('requires_manual_confirmation') and not allow_cross_mesh:
+            return jsonify({
+                'status': 'confirmation_required',
+                'error': 'Cross-mesh reconnect requires confirmation',
+                'diagnostic_code': 'cross_mesh_reconnect_confirmation_required',
+                'message': (
+                    'This peer last advertised a different meshspace. '
+                    'Reconnect this peer only if the bridge is intentional.'
+                ),
+                'cross_mesh': cross_status,
+            }), 409
+        if allow_cross_mesh and not _request_is_instance_admin(db_manager):
+            return jsonify({
+                'error': 'Instance admin required',
+                'diagnostic_code': 'cross_mesh_admin_required',
+                'message': (
+                    'Only the instance admin can approve a cross-mesh reconnect from this workspace.'
+                ),
+                'cross_mesh': cross_status,
+            }), 403
+        if allow_cross_mesh and hasattr(p2p_manager, 'mark_peer_cross_mesh_allowed'):
+            p2p_manager.mark_peer_cross_mesh_allowed(peer_id, True)
 
         if p2p_manager.connection_manager.is_connected(peer_id):
             return jsonify({'status': 'connected', 'peer_id': peer_id,
@@ -3547,9 +3977,19 @@ def create_api_blueprint() -> Blueprint:
                 if not parsed:
                     continue
                 host, port, scheme = parsed
+                connect_to_endpoint = getattr(type(p2p_manager), '_connect_to_endpoint', None)
+                if callable(connect_to_endpoint):
+                    connect_coro = connect_to_endpoint(
+                        p2p_manager,
+                        peer_id,
+                        ep,
+                        allow_cross_mesh=allow_cross_mesh,
+                    )
+                else:
+                    connect_coro = p2p_manager.connection_manager.connect_to_peer(
+                        peer_id, host, port, scheme=scheme)
                 future = asyncio.run_coroutine_threadsafe(
-                    p2p_manager.connection_manager.connect_to_peer(
-                        peer_id, host, port, scheme=scheme),
+                    connect_coro,
                     ev_loop
                 )
                 connected = future.result(timeout=10.0)
@@ -3624,6 +4064,66 @@ def create_api_blueprint() -> Blueprint:
             return jsonify({'status': 'failed', 'message': 'Disconnect failed'}), 500
 
         return jsonify({'status': 'disconnected', 'peer_id': peer_id})
+
+    @api.route('/p2p/mesh_relationship', methods=['POST'])
+    @require_auth(allow_session=True)
+    def resolve_peer_mesh_relationship():
+        """Resolve a peer's mesh identity mismatch without conflating bridge and alias decisions."""
+        db_manager, _, _, _, _, _, _, _, _, _, p2p_manager = _get_app_components_any(current_app)
+        if not _request_is_instance_admin(db_manager):
+            return jsonify({
+                'error': 'Instance admin required',
+                'diagnostic_code': 'mesh_identity_admin_required',
+                'message': 'Only the instance admin can resolve peer mesh identity relationships.',
+            }), 403
+        if not p2p_manager:
+            return jsonify({'error': 'P2P not running'}), 500
+
+        data = request.get_json() or {}
+        peer_id = str(data.get('peer_id') or '').strip()
+        action = str(data.get('action') or data.get('relationship') or '').strip().lower()
+        if not peer_id:
+            return jsonify({'error': 'peer_id required'}), 400
+        if action in {'same_mesh', 'same_mesh_alias', 'treat_as_same_mesh', 'alias'}:
+            mark_same = getattr(p2p_manager, 'mark_peer_meshspace_equivalent', None)
+            if not callable(mark_same):
+                return jsonify({'error': 'Mesh alias reconciliation unavailable'}), 500
+            try:
+                status = dict(mark_same(peer_id) or {})
+            except Exception as exc:
+                return jsonify({'error': str(exc) or 'Could not treat peer as same mesh'}), 400
+            return jsonify({
+                'success': True,
+                'status': 'same_mesh_alias_confirmed',
+                'peer_id': peer_id,
+                'cross_mesh': status,
+                'message': 'Remote mesh ID saved as a compatibility alias for this mesh.',
+            })
+        if action in {'bridge', 'cross_mesh_bridge', 'keep_bridge', 'allow_cross_mesh'}:
+            mark_bridge = getattr(p2p_manager, 'mark_peer_cross_mesh_allowed', None)
+            get_status = getattr(p2p_manager, 'get_peer_cross_mesh_status', None)
+            if not callable(mark_bridge):
+                return jsonify({'error': 'Cross-mesh bridge approval unavailable'}), 500
+            mark_bridge(peer_id, True)
+            status = dict(get_status(peer_id) or {}) if callable(get_status) else {}
+            return jsonify({
+                'success': True,
+                'status': 'cross_mesh_bridge_allowed',
+                'peer_id': peer_id,
+                'cross_mesh': status,
+                'message': 'Peer kept as an intentional cross-mesh bridge. No mesh aliases were created.',
+            })
+        if action in {'forget', 'disconnect_forget', 'disconnect'}:
+            result = _forget_peer_with_cleanup(
+                db_manager,
+                p2p_manager,
+                peer_id,
+                remove_introduced=True,
+                purge_residue=True,
+                remove_shadow_users=True,
+            )
+            return jsonify(result), (200 if result.get('success') else 400)
+        return jsonify({'error': 'Unsupported mesh relationship action'}), 400
 
     @api.route('/p2p/forget', methods=['POST'])
     @require_auth(allow_session=True)
@@ -3724,9 +4224,14 @@ def create_api_blueprint() -> Blueprint:
                 if not parsed:
                     continue
                 host, port, scheme = parsed
+                connect_to_endpoint = getattr(type(p2p_manager), '_connect_to_endpoint', None)
+                if callable(connect_to_endpoint):
+                    connect_coro = connect_to_endpoint(p2p_manager, peer_id, ep)
+                else:
+                    connect_coro = p2p_manager.connection_manager.connect_to_peer(
+                        peer_id, host, port, scheme=scheme)
                 future = _asyncio.run_coroutine_threadsafe(
-                    p2p_manager.connection_manager.connect_to_peer(
-                        peer_id, host, port, scheme=scheme),
+                    connect_coro,
                     ev_loop,
                 )
                 connected = future.result(timeout=10.0)
@@ -3893,7 +4398,7 @@ def create_api_blueprint() -> Blueprint:
         """Update this device's profile.
 
         Body: {"display_name": "...", "description": "...",
-               "avatar_b64": "...", "avatar_mime": "..."}
+               "avatar_b64": "...", "avatar_mime": "...", "icon": "..."}
         """
         from canopy.core.device import set_device_profile
         data = request.get_json()
@@ -3905,12 +4410,18 @@ def create_api_blueprint() -> Blueprint:
                 description=data.get('description'),
                 avatar_b64=data.get('avatar_b64'),
                 avatar_mime=data.get('avatar_mime'),
+                icon=data.get('icon'),
             )
         except ValueError as exc:
             return jsonify({'error': str(exc)}), 400
         if ok:
-            # Broadcast updated device profile to connected peers
             *_, p2p_manager = _get_app_components_any(current_app)
+            if p2p_manager and hasattr(p2p_manager, 'refresh_local_public_identity_hint'):
+                try:
+                    p2p_manager.refresh_local_public_identity_hint()
+                except Exception:
+                    pass
+            # Broadcast updated device profile to connected peers
             if p2p_manager and p2p_manager.is_running():
                 try:
                     p2p_manager.broadcast_profile_update(
@@ -4122,6 +4633,11 @@ def create_api_blueprint() -> Blueprint:
             reply_to = str(data.get('reply_to') or '').strip()
             if reply_to:
                 metadata['reply_to'] = reply_to
+            force_new_group = bool(
+                data.get('force_new_group')
+                or data.get('new_group_thread')
+                or data.get('start_new_group_thread')
+            )
             
             # Warn if caller seems to want a channel message
             if data.get('channel_id'):
@@ -4158,12 +4674,24 @@ def create_api_blueprint() -> Blueprint:
             broadcast_targets: list[str] = []
             if len(recipients_unique) > 1:
                 group_members = sorted({g.api_key_info.user_id, *recipients_unique})
-                effective_recipient_id = compute_group_id(group_members)
+                base_group_id = compute_group_id(group_members)
+                group_thread_token = ''
+                if force_new_group:
+                    group_thread_token = (
+                        str(data.get('group_thread_id') or metadata.get('group_thread_id') or '').strip()
+                        or f"gt_{secrets.token_hex(8)}"
+                    )
+                    effective_recipient_id = compute_group_thread_id(group_members, group_thread_token)
+                else:
+                    effective_recipient_id = base_group_id
                 metadata.update({
                     'group_id': effective_recipient_id,
                     'group_members': group_members,
                     'is_group': True,
                 })
+                if group_thread_token:
+                    metadata['group_thread_id'] = group_thread_token
+                    metadata['base_group_id'] = base_group_id
                 broadcast_targets = list(recipients_unique)
             elif recipients_unique:
                 effective_recipient_id = recipients_unique[0]
@@ -4226,6 +4754,10 @@ def create_api_blueprint() -> Blueprint:
                                 payload['group_id'] = metadata.get('group_id')
                             if metadata.get('group_members'):
                                 payload['group_members'] = metadata.get('group_members')
+                            if metadata.get('group_thread_id'):
+                                payload['group_thread_id'] = metadata.get('group_thread_id')
+                            if metadata.get('base_group_id'):
+                                payload['base_group_id'] = metadata.get('base_group_id')
                             inbox_manager.sync_source_triggers(
                                 source_type='dm',
                                 source_id=message.id,
@@ -4246,6 +4778,10 @@ def create_api_blueprint() -> Blueprint:
                 }
                 if metadata.get('group_id'):
                     response_payload['group_id'] = metadata.get('group_id')
+                if metadata.get('group_thread_id'):
+                    response_payload['group_thread_id'] = metadata.get('group_thread_id')
+                if metadata.get('base_group_id'):
+                    response_payload['base_group_id'] = metadata.get('base_group_id')
                 return jsonify(response_payload), 201
             else:
                 return jsonify({'error': 'Failed to send message'}), 500
@@ -4315,6 +4851,19 @@ def create_api_blueprint() -> Blueprint:
 
             if group_members:
                 group_id = str(original_meta.get('group_id') or original.recipient_id or '').strip()
+                group_thread_id = str(original_meta.get('group_thread_id') or '').strip()
+                base_group_id = str(original_meta.get('base_group_id') or '').strip()
+                if group_thread_id:
+                    group_members = sorted(set(group_members))
+                else:
+                    try:
+                        group_members = message_manager.resolve_group_members(
+                            g.api_key_info.user_id,
+                            group_id or compute_group_id(sorted(set(group_members))),
+                            group_members,
+                        )
+                    except Exception:
+                        group_members = sorted(set(group_members))
                 recipients = [member_id for member_id in group_members if member_id != g.api_key_info.user_id]
                 if not recipients:
                     return jsonify({'error': 'No other group members to reply to'}), 400
@@ -4325,6 +4874,10 @@ def create_api_blueprint() -> Blueprint:
                     'group_members': sorted(set(group_members)),
                     'is_group': True,
                 })
+                if group_thread_id:
+                    reply_meta['group_thread_id'] = group_thread_id
+                if base_group_id:
+                    reply_meta['base_group_id'] = base_group_id
                 reply_meta['security'] = build_dm_security_summary(
                     db_manager,
                     p2p_manager,
@@ -4379,6 +4932,10 @@ def create_api_blueprint() -> Blueprint:
                             inbox_payload['group_members'] = reply_meta.get('group_members')
                         if reply_meta.get('is_group') is not None:
                             inbox_payload['is_group'] = bool(reply_meta.get('is_group'))
+                        if reply_meta.get('group_thread_id'):
+                            inbox_payload['group_thread_id'] = reply_meta.get('group_thread_id')
+                        if reply_meta.get('base_group_id'):
+                            inbox_payload['base_group_id'] = reply_meta.get('base_group_id')
                         inbox_manager.sync_source_triggers(
                             source_type='dm',
                             source_id=message.id,
@@ -4420,6 +4977,10 @@ def create_api_blueprint() -> Blueprint:
             }
             if reply_meta.get('group_id'):
                 response_payload['group_id'] = reply_meta.get('group_id')
+            if reply_meta.get('group_thread_id'):
+                response_payload['group_thread_id'] = reply_meta.get('group_thread_id')
+            if reply_meta.get('base_group_id'):
+                response_payload['base_group_id'] = reply_meta.get('base_group_id')
             return jsonify(response_payload), 201
         except Exception as e:
             logger.error(f"Failed to reply to message: {e}")
@@ -4475,6 +5036,22 @@ def create_api_blueprint() -> Blueprint:
                     for member_id in (final_metadata.get('group_members') or [])
                     if str(member_id).strip() and str(member_id).strip() != g.api_key_info.user_id
                 ]
+                if group_members_for_security and not str(final_metadata.get('group_thread_id') or '').strip():
+                    try:
+                        resolved_group_members = message_manager.resolve_group_members(
+                            g.api_key_info.user_id,
+                            str(final_metadata.get('group_id') or msg.recipient_id or '').strip(),
+                            [g.api_key_info.user_id, *group_members_for_security],
+                        )
+                        if resolved_group_members:
+                            final_metadata['group_members'] = resolved_group_members
+                            group_members_for_security = [
+                                member_id
+                                for member_id in resolved_group_members
+                                if member_id != g.api_key_info.user_id
+                            ]
+                    except Exception:
+                        pass
             target_ids_for_security = group_members_for_security or ([str(msg.recipient_id).strip()] if msg.recipient_id else [])
             if target_ids_for_security:
                 final_metadata['security'] = build_dm_security_summary(
@@ -4557,6 +5134,10 @@ def create_api_blueprint() -> Blueprint:
                             payload['group_id'] = final_metadata.get('group_id')
                         if isinstance(final_metadata, dict) and final_metadata.get('group_members'):
                             payload['group_members'] = final_metadata.get('group_members')
+                        if isinstance(final_metadata, dict) and final_metadata.get('group_thread_id'):
+                            payload['group_thread_id'] = final_metadata.get('group_thread_id')
+                        if isinstance(final_metadata, dict) and final_metadata.get('base_group_id'):
+                            payload['base_group_id'] = final_metadata.get('base_group_id')
                         inbox_manager.sync_source_triggers(
                             source_type='dm',
                             source_id=message_id,

--- a/canopy/core/app.py
+++ b/canopy/core/app.py
@@ -25,13 +25,17 @@ from .database import DatabaseManager
 from .logging_config import setup_logging
 from .files import FileManager
 from .interactions import InteractionManager
-from .profile import ProfileManager
+from .profile import ProfileManager, build_local_peer_hint_payload
 from .feed import FeedManager
 from .bookmarks import BookmarkManager
 from .tasks import TaskManager
 from .search import SearchManager
 from .streams import StreamManager
-from .meshspaces import MeshspaceRegistryManager, build_meshspace_shell_summary
+from .meshspaces import (
+    MeshspaceRegistryManager,
+    apply_meshspace_record_to_config,
+    build_meshspace_shell_summary,
+)
 from ..security.api_keys import ApiKeyManager
 from ..security.trust import TrustManager
 from .messaging import (
@@ -41,6 +45,7 @@ from .messaging import (
     MessageType,
     build_dm_preview,
     build_dm_security_summary,
+    compute_group_id,
     filter_local_dm_targets,
     is_local_dm_user,
     unwrap_dm_transport_bundle,
@@ -81,6 +86,7 @@ from .large_attachments import (
     is_large_attachment_reference,
 )
 from ..network.manager import P2PNetworkManager
+from ..network.invite import meshspace_fingerprint
 from ..network.routing import (
     decrypt_with_channel_key,
     decrypt_key_from_peer,
@@ -435,7 +441,9 @@ def create_app(config: Optional[Config] = None) -> Flask:
         logger.info(f"P2P network manager initialized (relay_policy={relay_policy})")
 
         logger.info("Initializing meshspace registry manager...")
-        meshspace_registry = MeshspaceRegistryManager()
+        registry_root_value = str(getattr(config.meshspace, 'registry_root', '') or '').strip()
+        registry_root = Path(registry_root_value).expanduser() if registry_root_value else None
+        meshspace_registry = MeshspaceRegistryManager(registry_root=registry_root)
         local_peer_id = None
         try:
             local_peer_id = p2p_manager.get_peer_id()
@@ -445,6 +453,25 @@ def create_app(config: Optional[Config] = None) -> Flask:
             config,
             peer_id=local_peer_id,
         )
+        meshspace_avatar_preview = meshspace_registry.get_meshspace_avatar_preview(
+            str(meshspace_record.get('meshspace_id') or '').strip()
+        )
+        apply_meshspace_record_to_config(
+            config,
+            meshspace_record,
+            avatar_preview=meshspace_avatar_preview,
+        )
+        connection_manager = getattr(p2p_manager, 'connection_manager', None)
+        if connection_manager:
+            connection_manager.local_meshspace_id = str(config.meshspace.meshspace_id or '').strip()
+            connection_manager.local_meshspace_name = str(config.meshspace.name or '').strip()
+            connection_manager.local_meshspace_fingerprint = meshspace_fingerprint(
+                connection_manager.local_meshspace_id,
+                connection_manager.local_meshspace_name,
+            )
+            connection_manager.local_meshspace_id_aliases = list(getattr(config.meshspace, 'meshspace_id_aliases', []) or [])
+            connection_manager.local_meshspace_avatar_b64 = str(getattr(config.meshspace, 'avatar_preview_b64', '') or '').strip()
+            connection_manager.local_meshspace_avatar_mime = str(getattr(config.meshspace, 'avatar_preview_mime', 'image/png') or 'image/png').strip() or 'image/png'
         app.config['MESHSPACE_REGISTRY_MANAGER'] = meshspace_registry
         app.config['MESHSPACE_RECORD'] = meshspace_record
         logger.info(
@@ -3383,6 +3410,13 @@ def create_app(config: Optional[Config] = None) -> Flask:
             clean_peer = str(peer_id or '').strip()
             if not clean_peer or not trust_manager:
                 return False
+            if p2p_manager and hasattr(p2p_manager, 'get_peer_sync_status'):
+                try:
+                    sync_status = dict(p2p_manager.get_peer_sync_status(clean_peer) or {})
+                    if bool(sync_status.get('preview_only')):
+                        return False
+                except Exception:
+                    pass
             try:
                 if hasattr(trust_manager, 'has_explicit_trust_score') and not trust_manager.has_explicit_trust_score(clean_peer):
                     return False
@@ -3409,6 +3443,16 @@ def create_app(config: Optional[Config] = None) -> Flask:
 
         def _meshspace_blocks_untrusted_sync(peer_id: Any) -> bool:
             return _meshspace_network_quarantined() and not _peer_is_trusted_for_content(peer_id)
+
+        def _peer_requires_sync_approval(peer_id: Any) -> bool:
+            clean_peer = str(peer_id or '').strip()
+            if not clean_peer or not p2p_manager or not hasattr(p2p_manager, 'get_peer_sync_status'):
+                return False
+            try:
+                sync_status = dict(p2p_manager.get_peer_sync_status(clean_peer) or {})
+                return bool(sync_status.get('preview_only'))
+            except Exception:
+                return False
 
         def _channel_definition_is_public(channel_type: Any, privacy_mode: Any) -> bool:
             if not channel_manager:
@@ -4476,6 +4520,12 @@ def create_app(config: Optional[Config] = None) -> Flask:
         def _on_channel_sync(channels, from_peer):
             """Handle a CHANNEL_SYNC (bulk list) from a connected peer."""
             try:
+                if _peer_requires_sync_approval(from_peer):
+                    logger.info(
+                        "Ignoring channel sync from preview-only peer %s until sync is approved",
+                        from_peer,
+                    )
+                    return
                 trusted_content = _peer_is_trusted_for_content(from_peer)
                 if _meshspace_blocks_untrusted_sync(from_peer):
                     logger.info(
@@ -4822,6 +4872,12 @@ def create_app(config: Optional[Config] = None) -> Flask:
             async task so the event loop stays responsive.
             """
             try:
+                if _peer_requires_sync_approval(from_peer):
+                    logger.info(
+                        "Ignoring catchup request from preview-only peer %s until sync is approved",
+                        from_peer,
+                    )
+                    return
                 trusted_content = _peer_is_trusted_for_content(from_peer)
                 if _meshspace_blocks_untrusted_sync(from_peer):
                     logger.info(
@@ -5255,6 +5311,12 @@ def create_app(config: Optional[Config] = None) -> Flask:
             has_extra = bool(feed_posts) or bool(circle_entries) or bool(circle_votes) or bool(circles) or bool(tasks)
             if not has_messages and not has_extra:
                 return
+            if _peer_requires_sync_approval(from_peer):
+                logger.info(
+                    "Ignoring catchup response from preview-only peer %s until sync is approved",
+                    from_peer,
+                )
+                return
             trusted_content = _peer_is_trusted_for_content(from_peer)
             if _meshspace_blocks_untrusted_sync(from_peer):
                 logger.info(
@@ -5676,9 +5738,6 @@ def create_app(config: Optional[Config] = None) -> Flask:
             profiles arriving via relay before any messages.
             """
             try:
-                if not _peer_is_trusted_for_content(from_peer):
-                    logger.info("Ignoring profile sync from untrusted peer %s", from_peer)
-                    return
                 remote_peer_id = profile_data.get('peer_id', from_peer)
 
                 # ---- Store device profile FIRST (independent of user/hash) ----
@@ -5704,6 +5763,20 @@ def create_app(config: Optional[Config] = None) -> Flask:
                         bool(device_info.get('avatar_b64')),
                         str(device_info.get('display_name') or '').strip() or remote_peer_id[:12],
                     )
+                    if p2p_manager and getattr(p2p_manager, 'identity_manager', None):
+                        display_name = str(device_info.get('display_name') or '').strip()
+                        if display_name:
+                            try:
+                                p2p_manager.identity_manager.peer_display_names[remote_peer_id] = display_name
+                            except Exception:
+                                pass
+
+                if not _peer_is_trusted_for_content(from_peer):
+                    logger.info(
+                        "Stored preview device identity and skipped profile import from untrusted peer %s",
+                        from_peer,
+                    )
+                    return
 
                 # ---- Skip unchanged profiles (version hash dedup) ----
                 # Exception: if our copy of this user's avatar file is missing (e.g. after
@@ -6207,6 +6280,27 @@ def create_app(config: Optional[Config] = None) -> Flask:
 
         p2p_manager.get_local_profile_card = _get_local_profile_card
 
+        def _get_local_peer_public_hint() -> dict[str, Any]:
+            """Return compact local peer labels for handshake/invite preview."""
+            try:
+                from .device import get_device_label, get_device_profile
+
+                fallback_device_label = str(getattr(config, 'device_label', '') or '').strip()
+                device_profile = get_device_profile() or {}
+                if not fallback_device_label:
+                    fallback_device_label = str(get_device_label() or '').strip()
+                return build_local_peer_hint_payload(
+                    db_manager,
+                    profile_manager,
+                    fallback_device_label=fallback_device_label,
+                    device_profile=device_profile,
+                )
+            except Exception as exc:
+                logger.debug("Could not build local peer public hint: %s", exc, exc_info=True)
+                return {}
+
+        p2p_manager.get_local_peer_public_hint = _get_local_peer_public_hint
+
         def _get_all_local_profile_cards():
             """Return profile cards for ALL registered local users.
             
@@ -6234,6 +6328,12 @@ def create_app(config: Optional[Config] = None) -> Flask:
             them from the Connect page.
             """
             try:
+                if _peer_requires_sync_approval(from_peer):
+                    logger.info(
+                        "Ignoring peer announcement from preview-only peer %s until sync is approved",
+                        from_peer,
+                    )
+                    return
                 if _meshspace_blocks_untrusted_sync(from_peer):
                     logger.info(
                         "Ignoring peer announcement from untrusted peer %s because this meshspace is isolated",
@@ -6255,19 +6355,6 @@ def create_app(config: Optional[Config] = None) -> Flask:
                             )
                         except Exception as e:
                             logger.warning(f"Could not register introduced peer {pid}: {e}")
-                    # Store device profile if provided (helps show friendly names for contacts list)
-                    if pid and device_profile and channel_manager:
-                        try:
-                            channel_manager.store_peer_device_profile(
-                                pid,
-                                display_name=device_profile.get('display_name'),
-                                description=device_profile.get('description'),
-                                avatar_b64=device_profile.get('avatar_b64'),
-                                avatar_mime=device_profile.get('avatar_mime'),
-                            )
-                        except Exception:
-                            pass
-
                 p2p_manager.store_introduced_peers(introduced_peers, from_peer)
                 logger.info(f"Peer announcement from {from_peer}: "
                             f"{len(introduced_peers)} peer(s) introduced")
@@ -7444,6 +7531,23 @@ def create_app(config: Optional[Config] = None) -> Flask:
                     meta_payload = dict(meta_payload)
                     meta_payload.setdefault('origin_peer', from_peer)
                     meta_payload['security'] = dict(resolved_security)
+                    if meta_payload.get('group_id') or meta_payload.get('group_members'):
+                        normalized_members = []
+                        raw_members = meta_payload.get('group_members')
+                        if not isinstance(raw_members, (list, tuple, set)):
+                            raw_members = []
+                        for raw_member in raw_members:
+                            member_id = str(raw_member or '').strip()
+                            if member_id and member_id not in normalized_members:
+                                normalized_members.append(member_id)
+                        for required_member in (sender_id, recipient_id):
+                            member_id = str(required_member or '').strip()
+                            if member_id and not member_id.startswith('group:') and member_id not in normalized_members:
+                                normalized_members.append(member_id)
+                        if normalized_members:
+                            meta_payload['group_members'] = sorted(normalized_members)
+                            meta_payload.setdefault('group_id', compute_group_id(normalized_members))
+                            meta_payload['is_group'] = True
 
                 dm_target_ids = []
                 if isinstance(meta_payload, dict) and meta_payload.get('group_members'):

--- a/canopy/core/config.py
+++ b/canopy/core/config.py
@@ -12,6 +12,7 @@ License: Apache 2.0
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
 from typing import Dict, Any, Optional, cast
 from dataclasses import dataclass, field
@@ -25,6 +26,17 @@ from .meshspaces import (
 )
 
 logger = logging.getLogger('canopy.config')
+
+
+def _resolve_meshspace_registry_root(config: 'Config', data_root: str) -> str:
+    """Choose the registry root for this runtime."""
+    override = os.getenv('CANOPY_MESHSPACE_REGISTRY_ROOT', '').strip()
+    if override:
+        return str(Path(override).expanduser())
+    if config.testing:
+        base_root = Path(data_root).expanduser() if str(data_root or '').strip() else Path(tempfile.gettempdir()) / 'canopy-testing'
+        return str(base_root / '.meshspaces-registry')
+    return str(meshspaces_root_dir())
 
 
 @dataclass
@@ -84,6 +96,7 @@ class MeshspaceConfig:
     """Meshspace runtime configuration."""
     enabled: bool = False
     meshspace_id: str = ""
+    meshspace_id_aliases: list[str] = field(default_factory=list)
     name: str = ""
     description: str = ""
     data_root: str = ""
@@ -93,6 +106,10 @@ class MeshspaceConfig:
     supervised: bool = False
     network_quarantined: bool = False
     session_cookie_name: str = ""
+    avatar_path: str = ""
+    avatar_mime: str = ""
+    avatar_preview_b64: str = ""
+    avatar_preview_mime: str = ""
 
 
 def _load_or_create_secret_key(data_dir: Optional[Path] = None) -> str:
@@ -212,7 +229,7 @@ def _apply_meshspace_paths(
     config.meshspace.meshspace_id = normalized_id
     config.meshspace.name = str(meshspace_name or normalized_id).strip() or normalized_id
     config.meshspace.data_root = str(root)
-    config.meshspace.registry_root = str(meshspaces_root_dir())
+    config.meshspace.registry_root = _resolve_meshspace_registry_root(config, str(root))
     config.meshspace.runtime_mode = "meshspace"
     config.meshspace.is_default = False
     config.meshspace.supervised = bool(supervised)
@@ -236,7 +253,7 @@ def _finalize_legacy_meshspace(config: 'Config') -> None:
     config.meshspace.meshspace_id = meshspace_id
     config.meshspace.name = "Default Mesh"
     config.meshspace.data_root = data_dir
-    config.meshspace.registry_root = str(meshspaces_root_dir())
+    config.meshspace.registry_root = _resolve_meshspace_registry_root(config, data_dir)
     config.meshspace.runtime_mode = "legacy-default"
     config.meshspace.is_default = True
     config.meshspace.supervised = False

--- a/canopy/core/device.py
+++ b/canopy/core/device.py
@@ -212,6 +212,30 @@ def set_device_label(label: str) -> bool:
 _DEVICE_PROFILE_FILE = _DEVICE_DIR / 'device_profile.json'
 _DEVICE_AVATAR_MAX_SIZE = 256
 _DEVICE_AVATAR_MAX_BYTES = 48 * 1024
+DEFAULT_DEVICE_ICON = 'bi-pc-display-horizontal'
+DEVICE_PROFILE_ICON_CHOICES = (
+    {'value': 'bi-pc-display-horizontal', 'label': 'Desktop'},
+    {'value': 'bi-laptop', 'label': 'Laptop'},
+    {'value': 'bi-phone', 'label': 'Phone'},
+    {'value': 'bi-tablet', 'label': 'Tablet'},
+    {'value': 'bi-cpu', 'label': 'Compute'},
+    {'value': 'bi-hdd-network', 'label': 'Storage node'},
+    {'value': 'bi-router', 'label': 'Router'},
+    {'value': 'bi-server', 'label': 'Server'},
+)
+_DEVICE_PROFILE_ICON_SET = {
+    str(choice.get('value') or '').strip()
+    for choice in DEVICE_PROFILE_ICON_CHOICES
+    if str(choice.get('value') or '').strip()
+}
+
+
+def normalize_device_icon(icon: Optional[str]) -> str:
+    """Clamp device profile icon to a safe, standard set."""
+    clean = str(icon or '').strip()
+    if clean in _DEVICE_PROFILE_ICON_SET:
+        return clean
+    return DEFAULT_DEVICE_ICON
 
 
 def get_device_profile() -> Dict[str, Any]:
@@ -228,6 +252,7 @@ def get_device_profile() -> Dict[str, Any]:
         'description': '',
         'avatar_b64': '',
         'avatar_mime': '',
+        'icon': DEFAULT_DEVICE_ICON,
     }
     if _DEVICE_PROFILE_FILE.exists():
         try:
@@ -235,6 +260,7 @@ def get_device_profile() -> Dict[str, Any]:
             for k in default:
                 if k not in data:
                     data[k] = default[k]
+            data['icon'] = normalize_device_icon(data.get('icon'))
             return cast(Dict[str, Any], data)
         except Exception as e:
             logger.warning(f"Could not read device profile: {e}")
@@ -297,7 +323,8 @@ def normalize_device_avatar(avatar_b64: Optional[str],
 def set_device_profile(display_name: Optional[str] = None,
                        description: Optional[str] = None,
                        avatar_b64: Optional[str] = None,
-                       avatar_mime: Optional[str] = None) -> bool:
+                       avatar_mime: Optional[str] = None,
+                       icon: Optional[str] = None) -> bool:
     """Update one or more device profile fields.  None = keep existing."""
     try:
         profile = get_device_profile()
@@ -305,6 +332,8 @@ def set_device_profile(display_name: Optional[str] = None,
             profile['display_name'] = display_name
         if description is not None:
             profile['description'] = description
+        if icon is not None:
+            profile['icon'] = normalize_device_icon(icon)
         if avatar_b64 is not None or avatar_mime is not None:
             normalized_b64, normalized_mime = normalize_device_avatar(avatar_b64, avatar_mime)
             profile['avatar_b64'] = normalized_b64

--- a/canopy/core/files.py
+++ b/canopy/core/files.py
@@ -28,6 +28,7 @@ from .large_attachments import (
 # Pillow for thumbnail generation (optional — graceful degradation)
 try:
     from PIL import Image
+    from PIL import ImageOps
     import io as _io
     _PILLOW_AVAILABLE = True
 except ImportError:
@@ -549,12 +550,39 @@ class FileManager:
     # ------------------------------------------------------------------
 
     THUMB_MAX_SIZE = 800  # longest side in px
+    _EXIF_ORIENTATION_TAG = 274
 
     def _thumb_path_for(self, original_path: Path) -> Path:
         """Return the expected thumbnail path for a given original file path."""
         stem = original_path.stem
         suffix = original_path.suffix
         return original_path.with_name(f"{stem}_thumb{suffix}")
+
+    def _image_exif_orientation(self, image: Any) -> Optional[int]:
+        """Return the EXIF orientation tag if present."""
+        try:
+            exif = image.getexif()
+            orientation = int(exif.get(self._EXIF_ORIENTATION_TAG, 1)) if exif else 1
+            return orientation
+        except Exception:
+            return None
+
+    def _thumbnail_orientation_mismatch(self, original_path: Path, thumb_path: Path) -> bool:
+        """Detect old thumbnails that ignored side-rotation EXIF orientation."""
+        if not _PILLOW_AVAILABLE or not original_path.exists() or not thumb_path.exists():
+            return False
+        try:
+            original = Image.open(str(original_path))
+            orientation = self._image_exif_orientation(original)
+            if orientation not in {5, 6, 7, 8}:
+                return False
+            normalized = ImageOps.exif_transpose(original)
+            thumb = Image.open(str(thumb_path))
+            expected_portrait = normalized.size[1] > normalized.size[0]
+            actual_portrait = thumb.size[1] > thumb.size[0]
+            return expected_portrait != actual_portrait
+        except Exception:
+            return False
 
     def _generate_thumbnail(self, file_data: bytes, original_path: Path,
                             file_extension: str) -> None:
@@ -564,9 +592,13 @@ class FileManager:
         """
         try:
             img: Any = Image.open(_io.BytesIO(file_data))
+            orientation = self._image_exif_orientation(img)
+            needs_orientation_fix = bool(orientation and orientation != 1)
+            if needs_orientation_fix:
+                img = ImageOps.exif_transpose(img)
             # Skip tiny images that are already smaller than the thumb size
             w, h = img.size
-            if max(w, h) <= self.THUMB_MAX_SIZE:
+            if max(w, h) <= self.THUMB_MAX_SIZE and not needs_orientation_fix:
                 logger.debug(f"Image {original_path.name} already ≤{self.THUMB_MAX_SIZE}px, skipping thumbnail")
                 return
 
@@ -610,6 +642,12 @@ class FileManager:
         original_path = self._resolve_file_disk_path(file_info.file_path)
 
         thumb_path = self._thumb_path_for(original_path)
+        if _PILLOW_AVAILABLE and str(file_info.content_type or '').startswith('image/') and original_path.exists():
+            if not thumb_path.exists() or self._thumbnail_orientation_mismatch(original_path, thumb_path):
+                try:
+                    self._generate_thumbnail(original_path.read_bytes(), original_path, original_path.suffix)
+                except Exception as e:
+                    logger.debug(f"Lazy thumbnail normalization skipped for {file_id}: {e}")
         target = thumb_path if thumb_path.exists() else original_path
 
         if not target.exists():

--- a/canopy/core/meshspaces.py
+++ b/canopy/core/meshspaces.py
@@ -8,6 +8,7 @@ metadata; it does not read child runtime databases directly.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import logging
@@ -20,6 +21,7 @@ import threading
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 from urllib.error import HTTPError, URLError
@@ -41,6 +43,8 @@ _PORT_BLOCK_BASE = 7800
 _PORT_BLOCK_SIZE = 3
 _MESHSPACE_AVATAR_MAX_BYTES = 5 * 1024 * 1024
 _MESHSPACE_AVATAR_MAX_DIMENSION = 768
+_MESHSPACE_AVATAR_PREVIEW_MAX_BYTES = 24 * 1024
+_MESHSPACE_AVATAR_PREVIEW_DIMENSION = 96
 _PROBE_CACHE_TTL = 2.0
 _WINDOWS_DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
 _WINDOWS_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
@@ -379,12 +383,14 @@ def meshspaces_root_dir() -> Path:
     return root
 
 
-def _registry_file_path() -> Path:
-    return meshspaces_root_dir() / "registry.json"
+def _registry_file_path(registry_root: Optional[Path] = None) -> Path:
+    root = Path(registry_root).expanduser() if registry_root is not None else meshspaces_root_dir()
+    return root / "registry.json"
 
 
-def _registry_lock_path() -> Path:
-    return meshspaces_root_dir() / "registry.lock"
+def _registry_lock_path(registry_root: Optional[Path] = None) -> Path:
+    root = Path(registry_root).expanduser() if registry_root is not None else meshspaces_root_dir()
+    return root / "registry.lock"
 
 
 def default_meshspace_root(meshspace_id: str) -> Path:
@@ -531,6 +537,51 @@ def meshspace_cookie_name(meshspace_id: str) -> str:
     return f"canopy_session_{suffix}"
 
 
+def _normalize_meshspace_id_aliases(raw: Any, *, current_id: str = "") -> List[str]:
+    aliases: List[str] = []
+    values = raw if isinstance(raw, (list, tuple, set)) else ([raw] if raw else [])
+    current = sanitize_meshspace_id(current_id, fallback="") if current_id else ""
+    for value in values:
+        alias = sanitize_meshspace_id(str(value or "").strip(), fallback="")
+        if not alias or alias == current or alias in aliases:
+            continue
+        aliases.append(alias)
+    return aliases
+
+
+def apply_meshspace_record_to_config(
+    config: Any,
+    record: Dict[str, Any],
+    *,
+    avatar_preview: Optional[Dict[str, str]] = None,
+) -> None:
+    """Copy registry-backed mesh identity fields onto the active config."""
+    if not config or not isinstance(record, dict):
+        return
+    mesh_cfg = getattr(config, "meshspace", None)
+    if not mesh_cfg:
+        return
+    mesh_cfg.meshspace_id = str(record.get("meshspace_id") or mesh_cfg.meshspace_id or "").strip()
+    mesh_cfg.meshspace_id_aliases = _normalize_meshspace_id_aliases(
+        record.get("meshspace_id_aliases"),
+        current_id=mesh_cfg.meshspace_id,
+    )
+    mesh_cfg.name = str(record.get("name") or mesh_cfg.name or "").strip()
+    mesh_cfg.description = str(record.get("description") or "").strip()
+    mesh_cfg.runtime_mode = str(record.get("runtime_mode") or mesh_cfg.runtime_mode or "").strip() or "meshspace"
+    mesh_cfg.is_default = bool(record.get("is_default"))
+    mesh_cfg.supervised = bool(record.get("supervised"))
+    mesh_cfg.network_quarantined = bool(record.get("network_quarantined"))
+    mesh_cfg.session_cookie_name = str(
+        record.get("session_cookie_name") or mesh_cfg.session_cookie_name or meshspace_cookie_name(mesh_cfg.meshspace_id)
+    ).strip()
+    mesh_cfg.avatar_path = str(record.get("avatar_path") or "").strip()
+    mesh_cfg.avatar_mime = str(record.get("avatar_mime") or "image/png").strip() or "image/png"
+    preview = avatar_preview if isinstance(avatar_preview, dict) else {}
+    mesh_cfg.avatar_preview_b64 = str(preview.get("avatar_b64") or "").strip()
+    mesh_cfg.avatar_preview_mime = str(preview.get("avatar_mime") or "image/png").strip() or "image/png"
+
+
 def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -573,7 +624,34 @@ def _port_accepts_connections(host: str, port: int, timeout: float = 0.5) -> boo
         return False
 
 
-def _windows_listener_pid_for_port(port: int) -> int:
+def _normalize_listener_host(host: str) -> str:
+    """Normalize a listener host string for host-aware PID matching."""
+    value = str(host or "").strip().lower()
+    if not value:
+        return ""
+    if value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+    if value == "localhost":
+        return "127.0.0.1"
+    return value
+
+
+def _listener_host_matches(local_host: str, expected_host: Optional[str]) -> bool:
+    """Return True when a listener host is compatible with the expected host."""
+    normalized_local = _normalize_listener_host(local_host)
+    normalized_expected = _normalize_listener_host(expected_host or "")
+    if not normalized_expected:
+        return True
+    if normalized_local == normalized_expected:
+        return True
+    if normalized_local in {"0.0.0.0", "::", "*"}:
+        return True
+    if normalized_expected == "127.0.0.1" and normalized_local == "::1":
+        return True
+    return False
+
+
+def _windows_listener_pid_for_port(port: int, host: Optional[str] = None) -> int:
     """Resolve the PID listening on TCP *port* using ``netstat -ano`` (Windows).
 
     Without this, supervised mesh stop/restart falls back to registry PIDs, which
@@ -613,13 +691,15 @@ def _windows_listener_pid_for_port(port: int) -> int:
         host_part, _, port_part = local_addr.rpartition(":")
         if not host_part or port_part != port_s:
             continue
+        if not _listener_host_matches(host_part, host):
+            continue
         pid_str = parts[-1]
         if pid_str.isdigit():
             return int(pid_str)
     return 0
 
 
-def _ss_listener_pid_for_port(port: int) -> int:
+def _ss_listener_pid_for_port(port: int, host: Optional[str] = None) -> int:
     """Resolve the PID listening on TCP *port* using ``ss -tlnp`` on Linux."""
     if port <= 0:
         return 0
@@ -640,6 +720,12 @@ def _ss_listener_pid_for_port(port: int) -> int:
     for line in (result.stdout or "").splitlines():
         if f":{port_s}" not in line:
             continue
+        parts = line.split()
+        if len(parts) >= 4:
+            local_addr = parts[3]
+            local_host, _, local_port = local_addr.rpartition(":")
+            if local_port != port_s or not _listener_host_matches(local_host, host):
+                continue
         for part in line.split(","):
             part = part.strip()
             if part.startswith("pid="):
@@ -649,32 +735,47 @@ def _ss_listener_pid_for_port(port: int) -> int:
     return 0
 
 
-def _listener_pid_for_port(port: int) -> int:
-    """Best-effort lookup for the PID listening on a TCP port."""
+def _listener_pid_for_port(port: int, host: Optional[str] = None) -> int:
+    """Best-effort lookup for the PID listening on a TCP port and host."""
     if port <= 0:
         return 0
     try:
         lsof = shutil.which("lsof")
         if lsof:
             result = subprocess.run(
-                [lsof, "-tiTCP:%d" % port, "-sTCP:LISTEN"],
+                [lsof, "-nP", "-iTCP:%d" % port, "-sTCP:LISTEN", "-Fp", "-Fn"],
                 capture_output=True,
                 text=True,
                 timeout=2,
                 check=False,
             )
+            current_pid = 0
             for line in (result.stdout or "").splitlines():
                 line = line.strip()
-                if line.isdigit():
-                    return int(line)
+                if not line:
+                    continue
+                if line.startswith("p") and line[1:].isdigit():
+                    current_pid = int(line[1:])
+                    continue
+                if not line.startswith("n") or current_pid <= 0:
+                    continue
+                name = line[1:].strip()
+                if name.lower().startswith("tcp "):
+                    name = name[4:].strip()
+                name = name.replace(" (LISTEN)", "").strip()
+                local_host, _, local_port = name.rpartition(":")
+                if local_port != str(int(port)):
+                    continue
+                if _listener_host_matches(local_host, host):
+                    return current_pid
     except Exception:
         pass
     if not _is_windows_platform():
-        ss_pid = _ss_listener_pid_for_port(port)
+        ss_pid = _ss_listener_pid_for_port(port, host=host)
         if ss_pid > 0:
             return ss_pid
     if _is_windows_platform():
-        win_pid = _windows_listener_pid_for_port(port)
+        win_pid = _windows_listener_pid_for_port(port, host=host)
         if win_pid > 0:
             return win_pid
     return 0
@@ -693,8 +794,8 @@ def _http_json(url: str, timeout: float = 1.0) -> Dict[str, Any]:
 
 
 @contextmanager
-def _locked_registry_file() -> Iterator[None]:
-    lock_path = _registry_lock_path()
+def _locked_registry_file(registry_root: Optional[Path] = None) -> Iterator[None]:
+    lock_path = _registry_lock_path(registry_root)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "a+b") as fh:
         try:
@@ -718,8 +819,8 @@ def _locked_registry_file() -> Iterator[None]:
                 pass
 
 
-def _read_registry_file() -> Dict[str, Any]:
-    path = _registry_file_path()
+def _read_registry_file(registry_root: Optional[Path] = None) -> Dict[str, Any]:
+    path = _registry_file_path(registry_root)
     if not path.exists():
         return {"version": 1, "meshspaces": []}
     try:
@@ -738,8 +839,8 @@ def _read_registry_file() -> Dict[str, Any]:
     }
 
 
-def _write_registry_file(payload: Dict[str, Any]) -> None:
-    path = _registry_file_path()
+def _write_registry_file(payload: Dict[str, Any], registry_root: Optional[Path] = None) -> None:
+    path = _registry_file_path(registry_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(prefix="registry-", suffix=".json.tmp", dir=str(path.parent))
     try:
@@ -767,6 +868,60 @@ class MeshspaceRegistryManager:
         self.registry_root = Path(registry_root or meshspaces_root_dir())
         self.registry_root.mkdir(parents=True, exist_ok=True)
         self._probe_cache: Dict[str, Dict[str, Any]] = {}
+
+    def _path_under_system_temp(self, value: str | Path) -> bool:
+        raw = str(value or "").strip()
+        if not raw:
+            return False
+        candidate = _resolved_path(raw)
+        temp_root = _resolved_path(Path(tempfile.gettempdir()))
+        return candidate == temp_root or temp_root in candidate.parents
+
+    def _record_port_signature(self, record: Dict[str, Any]) -> tuple[int, int, int]:
+        return (
+            int(record.get("http_port") or 0),
+            int(record.get("mesh_port") or 0),
+            int(record.get("discovery_port") or 0),
+        )
+
+    def _should_prune_registry_record(
+        self,
+        record: Dict[str, Any],
+        *,
+        stable_legacy_signatures: Optional[set[tuple[int, int, int]]] = None,
+    ) -> bool:
+        runtime_mode = str(record.get("runtime_mode") or "").strip().lower()
+        if runtime_mode != "legacy-default":
+            return False
+        data_dir = str(record.get("data_dir") or "").strip()
+        if not data_dir or not self._path_under_system_temp(data_dir):
+            return False
+        signature = self._record_port_signature(record)
+        if stable_legacy_signatures and signature in stable_legacy_signatures:
+            return True
+        status = str(record.get("status") or "").strip().lower()
+        return status not in {"running", "starting", "degraded", "stopping"}
+
+    def _prune_registry_payload(self, payload: Dict[str, Any]) -> tuple[Dict[str, Any], bool]:
+        meshspaces = [item for item in payload.get("meshspaces", []) if isinstance(item, dict)]
+        stable_legacy_signatures = {
+            self._record_port_signature(item)
+            for item in meshspaces
+            if str(item.get("runtime_mode") or "").strip().lower() == "legacy-default"
+            and not self._path_under_system_temp(str(item.get("data_dir") or "").strip())
+        }
+        kept = []
+        removed = False
+        for item in meshspaces:
+            if self._should_prune_registry_record(item, stable_legacy_signatures=stable_legacy_signatures):
+                removed = True
+                continue
+            kept.append(item)
+        if not removed:
+            return payload, False
+        pruned = dict(payload)
+        pruned["meshspaces"] = kept
+        return pruned, True
 
     def _avatar_root(self) -> Path:
         path = self.registry_root / "avatars"
@@ -859,6 +1014,10 @@ class MeshspaceRegistryManager:
         )
         normalized = {
             "meshspace_id": meshspace_id,
+            "meshspace_id_aliases": _normalize_meshspace_id_aliases(
+                record.get("meshspace_id_aliases"),
+                current_id=meshspace_id,
+            ),
             "name": str(record.get("name") or meshspace_id).strip() or meshspace_id,
             "description": str(record.get("description") or "").strip(),
             "icon": str(record.get("icon") or "bi-grid-1x2").strip() or "bi-grid-1x2",
@@ -893,8 +1052,11 @@ class MeshspaceRegistryManager:
         return normalized
 
     def list_meshspaces(self) -> List[Dict[str, Any]]:
-        with _locked_registry_file():
-            payload = _read_registry_file()
+        with _locked_registry_file(self.registry_root):
+            payload = _read_registry_file(self.registry_root)
+            payload, changed = self._prune_registry_payload(payload)
+            if changed:
+                _write_registry_file(payload, self.registry_root)
         records = [self._normalize_record(cast) for cast in payload.get("meshspaces", []) if isinstance(cast, dict)]
         records.sort(key=lambda rec: (not rec.get("is_default"), str(rec.get("name") or "").lower()))
         return records
@@ -908,8 +1070,9 @@ class MeshspaceRegistryManager:
 
     def _upsert_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
         normalized = self._normalize_record(record)
-        with _locked_registry_file():
-            payload = _read_registry_file()
+        with _locked_registry_file(self.registry_root):
+            payload = _read_registry_file(self.registry_root)
+            payload, _ = self._prune_registry_payload(payload)
             meshspaces = [item for item in payload.get("meshspaces", []) if isinstance(item, dict)]
             updated = []
             found = False
@@ -927,7 +1090,30 @@ class MeshspaceRegistryManager:
                 normalized["updated_at"] = _utcnow_iso()
                 updated.append(normalized)
             payload["meshspaces"] = updated
-            _write_registry_file(payload)
+            _write_registry_file(payload, self.registry_root)
+        self._probe_cache.pop(normalized["meshspace_id"], None)
+        return self.get_meshspace(normalized["meshspace_id"]) or normalized
+
+    def _replace_record(self, old_meshspace_id: str, new_record: Dict[str, Any]) -> Dict[str, Any]:
+        normalized_old = sanitize_meshspace_id(old_meshspace_id, fallback="")
+        normalized = self._normalize_record(new_record)
+        with _locked_registry_file(self.registry_root):
+            payload = _read_registry_file(self.registry_root)
+            payload, _ = self._prune_registry_payload(payload)
+            updated: List[Dict[str, Any]] = []
+            for item in payload.get("meshspaces", []):
+                if not isinstance(item, dict):
+                    continue
+                item_id = sanitize_meshspace_id(str(item.get("meshspace_id") or ""), fallback="")
+                if item_id in {normalized_old, normalized["meshspace_id"]}:
+                    continue
+                updated.append(item)
+            normalized["updated_at"] = _utcnow_iso()
+            normalized["created_at"] = str(normalized.get("created_at") or _utcnow_iso())
+            updated.append(normalized)
+            payload["meshspaces"] = updated
+            _write_registry_file(payload, self.registry_root)
+        self._probe_cache.pop(normalized_old, None)
         self._probe_cache.pop(normalized["meshspace_id"], None)
         return self.get_meshspace(normalized["meshspace_id"]) or normalized
 
@@ -952,6 +1138,116 @@ class MeshspaceRegistryManager:
                 raise ValueError(
                     f"Meshspace root '{target_root}' overlaps existing meshspace '{existing_id}'"
                 )
+
+    def _port_block_from_http_port(self, http_port: Any) -> Dict[str, int]:
+        """Return the derived 3-port runtime block for a base HTTP port."""
+        try:
+            base = int(str(http_port).strip())
+        except Exception as exc:
+            raise ValueError("Base HTTP port must be a number") from exc
+        if base < 1024 or base > 65533:
+            raise ValueError("Base HTTP port must be between 1024 and 65533")
+        return {
+            "http_port": base,
+            "mesh_port": base + 1,
+            "discovery_port": base + 2,
+        }
+
+    def _probe_host_for_record(self, record: Dict[str, Any]) -> str:
+        host = str(record.get("http_host") or "127.0.0.1").strip() or "127.0.0.1"
+        return "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+
+    def _listener_filter_host_for_record(self, record: Dict[str, Any]) -> Optional[str]:
+        host = str(record.get("http_host") or "127.0.0.1").strip() or "127.0.0.1"
+        return None if host in {"0.0.0.0", "::"} else host
+
+    def _launch_url_for_record(self, record: Dict[str, Any], *, http_port: Optional[int] = None) -> str:
+        host = self._probe_host_for_record(record)
+        port = int(http_port if http_port is not None else (record.get("http_port") or 0))
+        return f"http://{host}:{port}" if port > 0 else ""
+
+    def _validate_port_block_registry_ownership(
+        self,
+        meshspace_id: str,
+        block: Dict[str, int],
+    ) -> None:
+        normalized_id = sanitize_meshspace_id(meshspace_id, fallback="")
+        requested_ports = {
+            int(block["http_port"]),
+            int(block["mesh_port"]),
+            int(block["discovery_port"]),
+        }
+        for record in self.list_meshspaces():
+            other_id = sanitize_meshspace_id(str(record.get("meshspace_id") or ""), fallback="")
+            if not other_id or other_id == normalized_id:
+                continue
+            other_ports = {
+                int(record.get("http_port") or 0),
+                int(record.get("mesh_port") or 0),
+                int(record.get("discovery_port") or 0),
+            }
+            overlaps = sorted(port for port in (requested_ports & other_ports) if port > 0)
+            if overlaps:
+                other_name = str(record.get("name") or other_id).strip() or other_id
+                raise ValueError(
+                    f"Port block conflicts with meshspace '{other_name}' "
+                    f"({', '.join(str(port) for port in overlaps)})"
+                )
+
+    def _validate_port_block_listener_availability(
+        self,
+        record: Dict[str, Any],
+        block: Dict[str, int],
+    ) -> None:
+        listener_host = self._listener_filter_host_for_record(record)
+        display_host = listener_host or str(record.get("http_host") or "all interfaces").strip() or "all interfaces"
+        occupied: List[str] = []
+        for label, port in (
+            ("HTTP", int(block["http_port"])),
+            ("mesh", int(block["mesh_port"])),
+            ("discovery", int(block["discovery_port"])),
+        ):
+            pid = _listener_pid_for_port(port, host=listener_host)
+            if pid > 0:
+                occupied.append(f"{label}:{port} pid:{pid}")
+        if occupied:
+            raise ValueError(
+                "Cannot assign that port block because a listener is already active on "
+                f"{display_host} ({', '.join(occupied)})"
+            )
+
+    def update_meshspace_ports(self, meshspace_id: str, *, http_port: Any) -> Optional[Dict[str, Any]]:
+        """Change a stopped meshspace to a new derived HTTP/mesh/discovery port block."""
+        record = self.get_meshspace(meshspace_id)
+        if not record:
+            return None
+
+        current = self.reconcile_meshspace_runtime(meshspace_id) or record
+        probe = self.probe_meshspace_runtime(meshspace_id)
+        if probe.get("live"):
+            raise ValueError("Stop this meshspace before changing its ports")
+
+        status = str(probe.get("effective_status") or current.get("status") or "").strip().lower()
+        if status not in {"defined", "stopped", "crashed", "degraded"}:
+            raise ValueError(f"Ports can only be changed while the meshspace is stopped (current state: {status or 'unknown'})")
+
+        block = self._port_block_from_http_port(http_port)
+        existing_block = self._port_block_from_http_port(int(current.get("http_port") or 0)) if int(current.get("http_port") or 0) else {}
+        if existing_block and all(int(current.get(key) or 0) == int(block[key]) for key in ("http_port", "mesh_port", "discovery_port")):
+            current["launch_url"] = self._launch_url_for_record(current, http_port=block["http_port"])
+            current["updated_at"] = _utcnow_iso()
+            return self._upsert_record(current)
+
+        self._validate_port_block_registry_ownership(meshspace_id, block)
+        self._validate_port_block_listener_availability(current, block)
+
+        updated = dict(current)
+        updated.update(block)
+        updated["launch_url"] = self._launch_url_for_record(updated, http_port=block["http_port"])
+        updated["pid"] = 0
+        updated["status"] = status if status in {"defined", "crashed", "degraded"} else "stopped"
+        updated["updated_at"] = _utcnow_iso()
+        return self._upsert_record(updated)
 
     def ensure_runtime_registered(self, config: Any, peer_id: Optional[str] = None) -> Dict[str, Any]:
         mesh_cfg = getattr(config, "meshspace", None)
@@ -1134,6 +1430,42 @@ class MeshspaceRegistryManager:
         candidate = Path(raw).expanduser()
         return candidate if candidate.exists() else None
 
+    def get_meshspace_avatar_preview(
+        self,
+        meshspace_id: str,
+        *,
+        max_dimension: int = _MESHSPACE_AVATAR_PREVIEW_DIMENSION,
+        max_bytes: int = _MESHSPACE_AVATAR_PREVIEW_MAX_BYTES,
+    ) -> Dict[str, str]:
+        """Return a compact base64 PNG preview for invite/handshake hints."""
+        avatar_path = self.get_meshspace_avatar_path(meshspace_id)
+        if not avatar_path or not avatar_path.exists():
+            return {}
+        try:
+            from PIL import Image
+        except Exception:
+            return {}
+        resampling = getattr(getattr(Image, "Resampling", Image), "LANCZOS", getattr(Image, "LANCZOS", 1))
+        try:
+            with Image.open(avatar_path) as opened_image:
+                opened_image.load()
+                if opened_image.mode not in ("RGB", "RGBA"):
+                    image = opened_image.convert("RGBA" if "A" in opened_image.getbands() else "RGB")
+                else:
+                    image = opened_image.copy()
+            image.thumbnail((max_dimension, max_dimension), resampling)
+            buffer = BytesIO()
+            image.save(buffer, format="PNG", optimize=True)
+            payload = buffer.getvalue()
+        except Exception:
+            return {}
+        if not payload or len(payload) > max_bytes:
+            return {}
+        return {
+            "avatar_b64": base64.b64encode(payload).decode("ascii"),
+            "avatar_mime": "image/png",
+        }
+
     def create_meshspace(
         self,
         *,
@@ -1204,6 +1536,75 @@ class MeshspaceRegistryManager:
         if default_agent_permissions is not None:
             record["default_agent_permissions"] = _normalize_agent_permission_values(default_agent_permissions)
         return self._upsert_record(record)
+
+    def add_meshspace_aliases(self, meshspace_id: str, aliases: List[str]) -> Optional[Dict[str, Any]]:
+        """Persist additional admin-approved compatibility aliases for a meshspace."""
+        record = self.get_meshspace(meshspace_id)
+        if not record:
+            return None
+        current_id = str(record.get("meshspace_id") or meshspace_id or "").strip()
+        merged_aliases = _normalize_meshspace_id_aliases(
+            list(record.get("meshspace_id_aliases") or []) + list(aliases or []),
+            current_id=current_id,
+        )
+        if merged_aliases == list(record.get("meshspace_id_aliases") or []):
+            return record
+        updated = dict(record)
+        updated["meshspace_id_aliases"] = merged_aliases
+        return self._upsert_record(updated)
+
+    def promote_legacy_meshspace(
+        self,
+        meshspace_id: str,
+        *,
+        new_meshspace_id: str,
+        new_name: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Convert a legacy-default runtime record into a stable explicit mesh identity."""
+        record = self.get_meshspace(meshspace_id)
+        if not record:
+            return None
+        runtime_mode = str(record.get("runtime_mode") or "").strip().lower()
+        if runtime_mode != "legacy-default":
+            raise ValueError("Only legacy default meshes can be promoted to a stable mesh ID")
+        old_meshspace_id = str(record.get("meshspace_id") or "").strip()
+        normalized_new_id = sanitize_meshspace_id(new_meshspace_id, fallback="")
+        if len(normalized_new_id) < 2:
+            raise ValueError("Mesh ID must contain at least 2 letters or numbers")
+        existing = self.get_meshspace(normalized_new_id)
+        if existing and str(existing.get("meshspace_id") or "").strip() != old_meshspace_id:
+            raise ValueError(f"Meshspace '{normalized_new_id}' already exists")
+
+        avatar_path_raw = str(record.get("avatar_path") or "").strip()
+        old_avatar_path = Path(avatar_path_raw).expanduser() if avatar_path_raw else self._avatar_path_for(old_meshspace_id)
+        avatar_path = str(old_avatar_path)
+        if old_avatar_path.exists():
+            new_avatar_path = self._avatar_path_for(normalized_new_id)
+            try:
+                if old_avatar_path != new_avatar_path:
+                    new_avatar_path.parent.mkdir(parents=True, exist_ok=True)
+                    os.replace(old_avatar_path, new_avatar_path)
+                avatar_path = str(new_avatar_path)
+            except Exception:
+                avatar_path = str(old_avatar_path)
+
+        promoted = dict(record)
+        promoted["meshspace_id"] = normalized_new_id
+        promoted["meshspace_id_aliases"] = _normalize_meshspace_id_aliases(
+            list(record.get("meshspace_id_aliases") or []) + [old_meshspace_id],
+            current_id=normalized_new_id,
+        )
+        if new_name is not None:
+            cleaned_name = str(new_name or "").strip()
+            if len(cleaned_name) < 2:
+                raise ValueError("Mesh name must be at least 2 characters")
+            promoted["name"] = cleaned_name
+        promoted["runtime_mode"] = "meshspace"
+        promoted["is_default"] = False
+        promoted["session_cookie_name"] = meshspace_cookie_name(normalized_new_id)
+        promoted["avatar_path"] = avatar_path if avatar_path and Path(avatar_path).expanduser().exists() else str(record.get("avatar_path") or "")
+        promoted["updated_at"] = _utcnow_iso()
+        return self._replace_record(old_meshspace_id, promoted)
 
     def allocate_port_block(self) -> Dict[str, int]:
         records = self.list_meshspaces()
@@ -1305,7 +1706,7 @@ class MeshspaceRegistryManager:
         mesh_port = int(record.get("mesh_port") or 0)
         registry_pid = int(record.get("pid") or 0)
         registry_pid_alive = _pid_is_alive(registry_pid) if registry_pid > 0 else False
-        detected_pid = _listener_pid_for_port(http_port) or _listener_pid_for_port(mesh_port)
+        detected_pid = _listener_pid_for_port(http_port, host=probe_host) or _listener_pid_for_port(mesh_port, host=probe_host)
         http_listening = _port_accepts_connections(probe_host, http_port) if http_port > 0 else False
         health = _http_json(f"http://{probe_host}:{http_port}/api/v1/health", timeout=0.9) if http_port > 0 else {}
         health_meshspace = (health.get("meshspace") or {}) if isinstance(health.get("meshspace"), dict) else {}
@@ -1317,7 +1718,8 @@ class MeshspaceRegistryManager:
             or str(health.get("status") or "").strip().lower() in {"healthy", "ready"}
         )
         registry_status = str(record.get("status") or "defined").strip().lower() or "defined"
-        live = bool((registry_pid_alive or detected_pid > 0 or http_listening or health_ok) and not wrong_meshspace_detected)
+        registry_pid_counts_as_live = bool(registry_pid_alive and registry_status == "starting")
+        live = bool((registry_pid_counts_as_live or detected_pid > 0 or http_listening or health_ok) and not wrong_meshspace_detected)
         effective_status = registry_status
         if live:
             if health_ok or http_listening:
@@ -1428,8 +1830,9 @@ class MeshspaceRegistryManager:
         # either assigned runtime port is already occupied.
         http_port = int(record.get("http_port") or 0)
         mesh_port = int(record.get("mesh_port") or 0)
-        http_listener_pid = _listener_pid_for_port(http_port) if http_port > 0 else 0
-        mesh_listener_pid = _listener_pid_for_port(mesh_port) if mesh_port > 0 else 0
+        probe_host = "127.0.0.1" if str(record.get("http_host") or "").strip() in {"0.0.0.0", "::"} else str(record.get("http_host") or "127.0.0.1").strip() or "127.0.0.1"
+        http_listener_pid = _listener_pid_for_port(http_port, host=probe_host) if http_port > 0 else 0
+        mesh_listener_pid = _listener_pid_for_port(mesh_port, host=probe_host) if mesh_port > 0 else 0
         if http_listener_pid > 0 or mesh_listener_pid > 0:
             in_use = []
             if http_listener_pid > 0:

--- a/canopy/core/messaging.py
+++ b/canopy/core/messaging.py
@@ -256,6 +256,65 @@ def compute_group_id(member_ids: Sequence[str]) -> str:
     return f"group:{digest}"
 
 
+def compute_group_thread_id(member_ids: Sequence[str], thread_token: str) -> str:
+    """Create a stable group DM identifier for one explicit same-member thread."""
+    clean_thread_token = str(thread_token or "").strip()
+    if not clean_thread_token:
+        return compute_group_id(member_ids)
+    cleaned = sorted({str(member_id).strip() for member_id in (member_ids or []) if str(member_id).strip()})
+    digest = hashlib.sha256(
+        ("|".join(cleaned) + f"|thread:{clean_thread_token}").encode("utf-8")
+    ).hexdigest()[:12]
+    return f"group:{digest}"
+
+
+def _normalize_group_member_ids(raw_members: Any) -> List[str]:
+    members: List[str] = []
+    if isinstance(raw_members, (list, tuple, set)):
+        for raw in raw_members:
+            member_id = str(raw or "").strip()
+            if member_id and member_id not in members:
+                members.append(member_id)
+    return members
+
+
+def _group_message_aliases(
+    metadata: Optional[Dict[str, Any]],
+    recipient_id: Optional[str],
+    group_members: Sequence[str],
+) -> set[str]:
+    aliases: set[str] = set()
+    meta = metadata if isinstance(metadata, dict) else {}
+    group_id = str(meta.get("group_id") or "").strip()
+    if group_id:
+        aliases.add(group_id)
+    clean_recipient = str(recipient_id or "").strip()
+    if clean_recipient.startswith("group:"):
+        aliases.add(clean_recipient)
+    # Explicit same-member group threads must not collapse back into the
+    # member-set canonical alias; legacy/partial relay rows still use it so
+    # split deliveries with the same group_id continue to merge.
+    has_explicit_thread = bool(str(meta.get("group_thread_id") or "").strip())
+    if group_members and not has_explicit_thread:
+        aliases.add(compute_group_id(group_members))
+    return aliases
+
+
+def _canonical_group_key(
+    metadata: Optional[Dict[str, Any]],
+    recipient_id: Optional[str],
+    group_members: Sequence[str],
+) -> Optional[str]:
+    meta = metadata if isinstance(metadata, dict) else {}
+    group_id = str(meta.get("group_id") or "").strip()
+    if str(meta.get("group_thread_id") or "").strip() and group_id:
+        return group_id
+    if group_members:
+        return compute_group_id(group_members)
+    clean_recipient = str(recipient_id or "").strip()
+    return group_id or (clean_recipient if clean_recipient.startswith("group:") else None)
+
+
 def build_dm_preview(content: str, attachments: Optional[Sequence[Dict[str, Any]]] = None) -> Optional[str]:
     """Build a human-readable preview for DM inbox/catchup payloads."""
     text = str(content or "").strip()
@@ -1038,6 +1097,88 @@ class MessageManager:
             logger.error(f"Failed to search messages: {e}")
             return []
 
+    def resolve_group_members(
+        self,
+        user_id: str,
+        group_id: Optional[str],
+        seed_members: Optional[Sequence[str]] = None,
+    ) -> List[str]:
+        """Resolve a group DM's member union across rows sharing an alias."""
+        clean_user_id = str(user_id or "").strip()
+        requested_group_id = str(group_id or "").strip()
+        resolved_members = set(_normalize_group_member_ids(seed_members))
+        if clean_user_id:
+            resolved_members.add(clean_user_id)
+
+        target_aliases: set[str] = set()
+        if requested_group_id:
+            target_aliases.add(requested_group_id)
+        if resolved_members:
+            target_aliases.add(compute_group_id(sorted(resolved_members)))
+        if not target_aliases and not resolved_members:
+            return []
+
+        try:
+            with self.db.get_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT sender_id, recipient_id, metadata
+                    FROM messages
+                    WHERE (
+                        sender_id = ?
+                        OR recipient_id = ?
+                        OR EXISTS (
+                            SELECT 1
+                            FROM json_each(
+                                CASE WHEN json_valid(metadata) THEN metadata ELSE '{}' END,
+                                '$.group_members'
+                            ) gm
+                            WHERE CAST(gm.value AS TEXT) = ?
+                        )
+                    )
+                    ORDER BY created_at ASC
+                    LIMIT 1000
+                    """,
+                    (clean_user_id, clean_user_id, clean_user_id),
+                )
+                decoded_rows: list[tuple[list[str], set[str], str]] = []
+                for row in cursor.fetchall():
+                    try:
+                        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+                    except Exception:
+                        meta = {}
+                    metadata = meta if isinstance(meta, dict) else {}
+                    members = _normalize_group_member_ids(metadata.get("group_members"))
+                    recipient_id = str(row["recipient_id"] or "").strip()
+                    row_group_id = str(metadata.get("group_id") or "").strip()
+                    is_group_msg = recipient_id.startswith("group:") or bool(row_group_id) or bool(members)
+                    if is_group_msg and members and clean_user_id not in members and row["sender_id"] != clean_user_id:
+                        continue
+                    if is_group_msg and not members and row["sender_id"] != clean_user_id:
+                        continue
+                    aliases = _group_message_aliases(metadata, recipient_id, members)
+                    if aliases or members:
+                        decoded_rows.append((members, aliases, str(row["sender_id"] or "").strip()))
+
+                changed = True
+                while changed:
+                    changed = False
+                    for members, aliases, sender_id in decoded_rows:
+                        if not aliases.intersection(target_aliases):
+                            continue
+                        before_alias_count = len(target_aliases)
+                        before_member_count = len(resolved_members)
+                        target_aliases.update(aliases)
+                        resolved_members.update(members)
+                        if sender_id:
+                            resolved_members.add(sender_id)
+                        if len(target_aliases) != before_alias_count or len(resolved_members) != before_member_count:
+                            changed = True
+        except Exception as e:
+            logger.debug(f"Failed to resolve group members for {group_id}: {e}")
+
+        return sorted(member for member in resolved_members if member)
+
     def get_group_conversation(self, user_id: str, group_id: str,
                                limit: int = 100) -> List[Message]:
         """Get conversation for a group DM by group_id."""
@@ -1052,7 +1193,6 @@ class MessageManager:
                     WHERE (
                         m.sender_id = ?
                         OR m.recipient_id = ?
-                        OR m.recipient_id LIKE 'group:%'
                         OR EXISTS (
                             SELECT 1
                             FROM json_each(
@@ -1078,18 +1218,12 @@ class MessageManager:
 
                     meta = json.loads(row['metadata']) if row['metadata'] else None
                     metadata = meta if isinstance(meta, dict) else {}
-                    row_group_members = [
-                        str(member_id).strip()
-                        for member_id in (metadata.get('group_members') or [])
-                        if str(member_id).strip()
-                    ]
+                    row_group_members = _normalize_group_member_ids(metadata.get('group_members'))
                     # Determine whether this row is a group-targeted message so we
                     # can apply the correct membership guard.  We check the recipient
                     # prefix and the group_id metadata field before the aliases set is
-                    # built, because the SQL WHERE clause uses an overly broad
-                    # `recipient_id LIKE 'group:%'` predicate that would otherwise
-                    # allow a non-member to read group messages that have no
-                    # group_members list (e.g. legacy or malformed rows).
+                    # built so rows with missing membership metadata still require the
+                    # sender shortcut before they can be surfaced.
                     _rcp_early = str(row['recipient_id'] or '').strip()
                     _gid_early = str(metadata.get('group_id') or '').strip()
                     _is_group_msg = _rcp_early.startswith('group:') or bool(_gid_early)
@@ -1101,24 +1235,35 @@ class MessageManager:
                     elif row_group_members and user_id not in row_group_members:
                         continue
 
-                    row_aliases: set[str] = set()
-                    row_group_id = str(metadata.get('group_id') or '').strip()
-                    if row_group_id:
-                        row_aliases.add(row_group_id)
                     row_recipient_id = str(row['recipient_id'] or '').strip()
-                    if row_recipient_id.startswith('group:'):
-                        row_aliases.add(row_recipient_id)
-                    row_canonical_key = compute_group_id(row_group_members) if row_group_members else None
-                    if row_canonical_key:
-                        row_aliases.add(row_canonical_key)
+                    row_aliases = _group_message_aliases(metadata, row_recipient_id, row_group_members)
+                    row_canonical_key = _canonical_group_key(metadata, row_recipient_id, row_group_members)
 
                     decoded_rows.append((row, content, metadata or None, row_group_members, row_aliases, row_canonical_key))
 
-                    if requested_group_id in row_aliases and row_canonical_key:
-                        target_canonical_keys.add(row_canonical_key)
+                    if requested_group_id in row_aliases:
+                        target_aliases.update(row_aliases)
+                        if row_canonical_key:
+                            target_canonical_keys.add(row_canonical_key)
 
                 if requested_group_id.startswith('group:'):
                     target_canonical_keys.add(requested_group_id)
+
+                changed = True
+                while changed:
+                    changed = False
+                    for _, _, _, _, row_aliases, row_canonical_key in decoded_rows:
+                        if not row_aliases.intersection(target_aliases) and (
+                            not row_canonical_key or row_canonical_key not in target_canonical_keys
+                        ):
+                            continue
+                        before_alias_count = len(target_aliases)
+                        before_key_count = len(target_canonical_keys)
+                        target_aliases.update(row_aliases)
+                        if row_canonical_key:
+                            target_canonical_keys.add(row_canonical_key)
+                        if len(target_aliases) != before_alias_count or len(target_canonical_keys) != before_key_count:
+                            changed = True
 
                 for row, content, meta, row_group_members, row_aliases, row_canonical_key in decoded_rows:
                     if not row_aliases and not row_group_members:

--- a/canopy/core/profile.py
+++ b/canopy/core/profile.py
@@ -94,6 +94,101 @@ def get_default_agent_directives(username: Optional[str], account_type: Optional
     return preset.get('content')
 
 
+def build_local_peer_hint_payload(
+    db_manager: Any,
+    profile_manager: Any,
+    *,
+    fallback_device_label: str = '',
+    device_profile: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the local peer identity hints shared by Connect/invite surfaces.
+
+    The primary peer identity comes from the instance/device profile because
+    that is the actual peer another node is connecting to. Owner profile data
+    is retained only as secondary context for future UI use.
+    """
+    owner_user_id = ''
+    owner_label = ''
+    peer_username = ''
+    peer_avatar_url = ''
+    owner_avatar_b64 = ''
+    owner_avatar_mime = ''
+
+    instance_label = ''
+    instance_description = ''
+    instance_avatar_b64 = ''
+    instance_avatar_mime = ''
+    instance_icon = ''
+    if isinstance(device_profile, dict):
+        instance_label = str(device_profile.get('display_name') or '').strip()
+        instance_description = str(device_profile.get('description') or '').strip()
+        instance_avatar_b64 = str(device_profile.get('avatar_b64') or '').strip()
+        instance_avatar_mime = str(device_profile.get('avatar_mime') or '').strip()
+        instance_icon = str(device_profile.get('icon') or '').strip()
+    if not instance_label:
+        instance_label = str(fallback_device_label or '').strip()
+
+    try:
+        owner_user_id = str(db_manager.get_instance_owner_user_id() or '').strip() if db_manager else ''
+    except Exception:
+        owner_user_id = ''
+
+    if owner_user_id and profile_manager:
+        try:
+            card = profile_manager.get_profile_card(owner_user_id) or {}
+            if isinstance(card, dict):
+                owner_label = str(card.get('display_name') or card.get('username') or '').strip()
+                peer_username = str(card.get('username') or '').strip()
+                owner_avatar_b64 = str(card.get('avatar_thumbnail') or '').strip()
+                owner_avatar_mime = str(card.get('avatar_content_type') or '').strip()
+            if hasattr(profile_manager, 'get_user_avatar_url'):
+                peer_avatar_url = str(profile_manager.get_user_avatar_url(owner_user_id) or '').strip()
+        except Exception:
+            pass
+
+    if owner_user_id and db_manager and (not owner_label or not peer_username):
+        try:
+            owner = db_manager.get_user(owner_user_id) or {}
+            if not owner_label:
+                owner_label = str(owner.get('display_name') or owner.get('username') or '').strip()
+            if not peer_username:
+                peer_username = str(owner.get('username') or '').strip()
+        except Exception:
+            pass
+
+    peer_label = instance_label
+    if not peer_label:
+        peer_label = owner_label
+
+    peer_avatar_b64 = instance_avatar_b64
+    peer_avatar_mime = instance_avatar_mime
+    if peer_avatar_b64 and not peer_avatar_mime:
+        peer_avatar_mime = 'image/jpeg'
+    if peer_avatar_b64 and peer_avatar_mime:
+        peer_avatar_url = f'data:{peer_avatar_mime};base64,{peer_avatar_b64}'
+
+    if instance_avatar_b64 and not instance_avatar_mime:
+        instance_avatar_mime = 'image/jpeg'
+
+    return {
+        'owner_user_id': owner_user_id,
+        'peer_label': peer_label,
+        'peer_username': peer_username,
+        'peer_avatar_url': peer_avatar_url,
+        'peer_avatar_b64': peer_avatar_b64,
+        'peer_avatar_mime': peer_avatar_mime,
+        'peer_icon': instance_icon,
+        'instance_label': instance_label,
+        'instance_description': instance_description,
+        'instance_avatar_b64': instance_avatar_b64,
+        'instance_avatar_mime': instance_avatar_mime,
+        'instance_icon': instance_icon,
+        'owner_label': owner_label,
+        'owner_avatar_b64': owner_avatar_b64,
+        'owner_avatar_mime': owner_avatar_mime,
+    }
+
+
 @dataclass
 class UserProfile:
     """Represents a user profile with all settings and preferences."""

--- a/canopy/network/connection.py
+++ b/canopy/network/connection.py
@@ -173,6 +173,14 @@ class PeerConnection:
     protocol_version: Optional[int] = None
     endpoint_uri: Optional[str] = None
     advertised_endpoints: List[str] = field(default_factory=list)
+    meshspace_id: Optional[str] = None
+    meshspace_id_aliases: List[str] = field(default_factory=list)
+    meshspace_name: Optional[str] = None
+    meshspace_fingerprint: Optional[str] = None
+    meshspace_avatar_b64: Optional[str] = None
+    meshspace_avatar_mime: Optional[str] = None
+    peer_label: Optional[str] = None
+    instance_label: Optional[str] = None
     failure_reason: Optional[str] = None
     failure_detail: Optional[str] = None
     _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
@@ -210,6 +218,14 @@ class ConnectionManager:
                  advertised_endpoints_provider: Optional[Callable[[], List[str]]] = None,
                  canopy_version: str = "0.1.0",
                  protocol_version: int = 1,
+                 meshspace_id: str = "",
+                 meshspace_id_aliases: Optional[List[str]] = None,
+                 meshspace_name: str = "",
+                 meshspace_fingerprint: str = "",
+                 meshspace_avatar_b64: str = "",
+                 meshspace_avatar_mime: str = "",
+                 peer_label: str = "",
+                 instance_label: str = "",
                  reject_protocol_mismatch: bool = False):
         """
         Initialize connection manager.
@@ -235,6 +251,14 @@ class ConnectionManager:
         self.advertised_endpoints_provider = advertised_endpoints_provider
         self.local_canopy_version = str(canopy_version or '0.1.0').strip() or '0.1.0'
         self.local_protocol_version = self._coerce_protocol_version(protocol_version, default=1)
+        self.local_meshspace_id = str(meshspace_id or '').strip()
+        self.local_meshspace_id_aliases = self._normalize_endpoint_payload(meshspace_id_aliases or [])
+        self.local_meshspace_name = str(meshspace_name or '').strip()
+        self.local_meshspace_fingerprint = str(meshspace_fingerprint or '').strip()
+        self.local_meshspace_avatar_b64 = str(meshspace_avatar_b64 or '').strip()
+        self.local_meshspace_avatar_mime = str(meshspace_avatar_mime or 'image/png').strip() or 'image/png'
+        self.local_peer_label = self._sanitize_public_label(peer_label)
+        self.local_instance_label = self._sanitize_public_label(instance_label)
         self.reject_protocol_mismatch = bool(reject_protocol_mismatch)
         
         # TLS configuration
@@ -295,11 +319,17 @@ class ConnectionManager:
         actual_peer_id: str,
         endpoint_uri: str,
     ) -> None:
-        """Clean up stale endpoint ownership after a verified peer-id mismatch."""
+        """Quarantine a stale endpoint after a verified peer-id mismatch.
+
+        Do not auto-register the unexpected peer against this endpoint. A stale
+        endpoint answering as another peer is exactly the condition that can
+        pollute a mesh during automatic reconnects; the unexpected peer must be
+        imported or connected explicitly by the user.
+        """
         clean_endpoint = str(endpoint_uri or '').strip()
         if clean_endpoint.endswith('/p2p'):
             clean_endpoint = clean_endpoint[:-4]
-        action_taken = 'mapping_reset'
+        action_taken = 'stale_endpoint_quarantined'
         if not clean_endpoint:
             logger.warning(
                 "handshake_peerid_mismatch expected_peer=%s actual_peer=%s endpoint=unknown action_taken=%s",
@@ -310,9 +340,8 @@ class ConnectionManager:
             return
         try:
             self.identity_manager.remove_endpoint(expected_peer_id, clean_endpoint)
-            self.identity_manager.record_endpoint(actual_peer_id, clean_endpoint, claim=True)
         except Exception:
-            action_taken = 'endpoint_quarantine'
+            action_taken = 'endpoint_quarantine_failed'
         logger.warning(
             "handshake_peerid_mismatch expected_peer=%s actual_peer=%s endpoint=%s action_taken=%s",
             expected_peer_id,
@@ -472,7 +501,57 @@ class ConnectionManager:
             extra['protocol_version'] = payload.get('protocol_version')
         if 'advertised_endpoints' in payload:
             extra['advertised_endpoints'] = payload.get('advertised_endpoints')
+        if 'meshspace_id' in payload:
+            extra['meshspace_id'] = payload.get('meshspace_id')
+        if 'meshspace_id_aliases' in payload:
+            extra['meshspace_id_aliases'] = payload.get('meshspace_id_aliases')
+        if 'meshspace_name' in payload:
+            extra['meshspace_name'] = payload.get('meshspace_name')
+        if 'meshspace_fingerprint' in payload:
+            extra['meshspace_fingerprint'] = payload.get('meshspace_fingerprint')
+        if 'meshspace_avatar_b64' in payload:
+            extra['meshspace_avatar_b64'] = payload.get('meshspace_avatar_b64')
+        if 'meshspace_avatar_mime' in payload:
+            extra['meshspace_avatar_mime'] = payload.get('meshspace_avatar_mime')
+        if 'peer_label' in payload:
+            extra['peer_label'] = payload.get('peer_label')
+        if 'instance_label' in payload:
+            extra['instance_label'] = payload.get('instance_label')
         return extra
+
+    @staticmethod
+    def _sanitize_public_label(value: Any, *, limit: int = 96) -> str:
+        """Return a compact printable label safe for handshake preview metadata."""
+        text = str(value or '').replace('\r', ' ').replace('\n', ' ').strip()
+        text = ''.join(ch for ch in text if ch == '\t' or ord(ch) >= 32)
+        while '  ' in text:
+            text = text.replace('  ', ' ')
+        return text[:limit]
+
+    def _remote_public_label(self, payload: Dict[str, Any]) -> str:
+        """Prefer peer label, then instance label, for untrusted UI display."""
+        return (
+            self._sanitize_public_label(payload.get('peer_label'))
+            or self._sanitize_public_label(payload.get('instance_label'))
+        )
+
+    def _add_known_peer_with_label(self, remote_identity: Any, display_name: str = "") -> None:
+        """Persist peer keys and an optional unverified display hint compatibly."""
+        clean_label = self._sanitize_public_label(display_name)
+        try:
+            self.identity_manager.add_known_peer(
+                remote_identity,
+                display_name=clean_label or None,
+            )
+        except TypeError:
+            self.identity_manager.add_known_peer(remote_identity)
+        if clean_label:
+            try:
+                self.identity_manager.peer_display_names[remote_identity.peer_id] = clean_label
+                if hasattr(self.identity_manager, '_save_known_peers'):
+                    self.identity_manager._save_known_peers()
+            except Exception:
+                logger.debug("Could not persist peer display hint for %s", remote_identity.peer_id, exc_info=True)
 
     @staticmethod
     def _normalize_endpoint_payload(raw: Any) -> List[str]:
@@ -808,8 +887,11 @@ class ConnectionManager:
             
             logger.debug(f"Verified identity of incoming peer: {peer_id}")
             
-            # Store verified peer identity
-            self.identity_manager.add_known_peer(remote_identity)
+            # Store verified peer identity and compact untrusted display hint.
+            self._add_known_peer_with_label(
+                remote_identity,
+                self._remote_public_label(handshake_data),
+            )
             
             # Create connection
             connection = PeerConnection(
@@ -825,6 +907,16 @@ class ConnectionManager:
                     handshake_data.get('protocol_version', 1),
                     default=1,
                 ),
+                meshspace_id=str(handshake_data.get('meshspace_id') or '').strip() or None,
+                meshspace_id_aliases=self._normalize_endpoint_payload(
+                    handshake_data.get('meshspace_id_aliases', [])
+                ),
+                meshspace_name=str(handshake_data.get('meshspace_name') or '').strip() or None,
+                meshspace_fingerprint=str(handshake_data.get('meshspace_fingerprint') or '').strip() or None,
+                meshspace_avatar_b64=str(handshake_data.get('meshspace_avatar_b64') or '').strip() or None,
+                meshspace_avatar_mime=str(handshake_data.get('meshspace_avatar_mime') or '').strip() or None,
+                peer_label=self._sanitize_public_label(handshake_data.get('peer_label')) or None,
+                instance_label=self._sanitize_public_label(handshake_data.get('instance_label')) or None,
             )
             connection.capabilities = {
                 cap: True for cap in self._normalize_capabilities(
@@ -880,6 +972,14 @@ class ConnectionManager:
                             'protocol_version': connection.protocol_version,
                             'capabilities': list(connection.capabilities or {}),
                             'advertised_endpoints': list(connection.advertised_endpoints or []),
+                            'meshspace_id': connection.meshspace_id,
+                            'meshspace_id_aliases': list(connection.meshspace_id_aliases or []),
+                            'meshspace_name': connection.meshspace_name,
+                            'meshspace_fingerprint': connection.meshspace_fingerprint,
+                            'meshspace_avatar_b64': connection.meshspace_avatar_b64,
+                            'meshspace_avatar_mime': connection.meshspace_avatar_mime,
+                            'peer_label': connection.peer_label,
+                            'instance_label': connection.instance_label,
                         }
                         self.on_peer_authenticated(peer_id, peer_meta)
                     except TypeError:
@@ -952,6 +1052,14 @@ class ConnectionManager:
                 'canopy_version': self.local_canopy_version,
                 'protocol_version': self.local_protocol_version,
                 'advertised_endpoints': self._get_advertised_endpoints(),
+                'meshspace_id': self.local_meshspace_id,
+                'meshspace_id_aliases': list(self.local_meshspace_id_aliases or []),
+                'meshspace_name': self.local_meshspace_name,
+                'meshspace_fingerprint': self.local_meshspace_fingerprint,
+                'meshspace_avatar_b64': self.local_meshspace_avatar_b64,
+                'meshspace_avatar_mime': self.local_meshspace_avatar_mime,
+                'peer_label': self.local_peer_label,
+                'instance_label': self.local_instance_label,
                 'signature': signature.hex()
             }
             
@@ -1054,8 +1162,11 @@ class ConnectionManager:
                 connection.failure_detail = f'Handshake signature verification failed for {resp_peer_id}'
                 return False
             
-            # Store the verified peer identity
-            self.identity_manager.add_known_peer(remote_identity)
+            # Store the verified peer identity and compact untrusted display hint.
+            self._add_known_peer_with_label(
+                remote_identity,
+                self._remote_public_label(response),
+            )
 
             connection.handshake_version = str(response.get('version', '0.1.0') or '0.1.0')
             connection.canopy_version = str(response.get('canopy_version') or response.get('version', '0.1.0') or '0.1.0')
@@ -1063,6 +1174,16 @@ class ConnectionManager:
                 response.get('protocol_version', 1),
                 default=1,
             )
+            connection.meshspace_id = str(response.get('meshspace_id') or '').strip() or None
+            connection.meshspace_id_aliases = self._normalize_endpoint_payload(
+                response.get('meshspace_id_aliases', [])
+            )
+            connection.meshspace_name = str(response.get('meshspace_name') or '').strip() or None
+            connection.meshspace_fingerprint = str(response.get('meshspace_fingerprint') or '').strip() or None
+            connection.meshspace_avatar_b64 = str(response.get('meshspace_avatar_b64') or '').strip() or None
+            connection.meshspace_avatar_mime = str(response.get('meshspace_avatar_mime') or '').strip() or None
+            connection.peer_label = self._sanitize_public_label(response.get('peer_label')) or None
+            connection.instance_label = self._sanitize_public_label(response.get('instance_label')) or None
 
             connection.capabilities = {
                 cap: True for cap in self._normalize_capabilities(
@@ -1152,6 +1273,14 @@ class ConnectionManager:
                 'canopy_version': self.local_canopy_version,
                 'protocol_version': self.local_protocol_version,
                 'advertised_endpoints': self._get_advertised_endpoints(),
+                'meshspace_id': self.local_meshspace_id,
+                'meshspace_id_aliases': list(self.local_meshspace_id_aliases or []),
+                'meshspace_name': self.local_meshspace_name,
+                'meshspace_fingerprint': self.local_meshspace_fingerprint,
+                'meshspace_avatar_b64': self.local_meshspace_avatar_b64,
+                'meshspace_avatar_mime': self.local_meshspace_avatar_mime,
+                'peer_label': self.local_peer_label,
+                'instance_label': self.local_instance_label,
                 'signature': signature.hex()
             }
             

--- a/canopy/network/identity.py
+++ b/canopy/network/identity.py
@@ -13,6 +13,7 @@ import base58
 import hashlib
 import json
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Dict, Any
 from dataclasses import dataclass, asdict
@@ -150,6 +151,10 @@ class IdentityManager:
         self.peer_endpoints: Dict[str, list] = {}
         # Display names for known peers (peer_id -> display_name)
         self.peer_display_names: Dict[str, str] = {}
+        # Meshspace hints learned from invites/handshakes (peer_id -> metadata).
+        # These hints are not cryptographic authorization; they are safety rails
+        # for preventing silent reconnects across visibly different meshspaces.
+        self.peer_meshspace_hints: Dict[str, Dict[str, Any]] = {}
         
         # Persistence path for known peers
         self._known_peers_path = self.identity_path.parent / 'known_peers.json'
@@ -275,6 +280,9 @@ class IdentityManager:
                 entry = identity.to_dict(include_private=False)
                 entry['endpoints'] = self.peer_endpoints.get(pid, [])
                 entry['display_name'] = self.peer_display_names.get(pid, '')
+                hint = self.peer_meshspace_hints.get(pid)
+                if isinstance(hint, dict) and hint:
+                    entry['meshspace_hint'] = hint
                 peers_data.append(entry)
 
             self._known_peers_path.parent.mkdir(parents=True, exist_ok=True)
@@ -307,6 +315,11 @@ class IdentityManager:
                         self.peer_endpoints[identity.peer_id] = entry['endpoints']
                     if entry.get('display_name'):
                         self.peer_display_names[identity.peer_id] = entry['display_name']
+                    hint = entry.get('meshspace_hint')
+                    if isinstance(hint, dict):
+                        cleaned = self._normalize_meshspace_hint(hint)
+                        if cleaned:
+                            self.peer_meshspace_hints[identity.peer_id] = cleaned
                     loaded += 1
                 except Exception as e:
                     logger.warning(f"Skipping invalid known peer entry: {e}")
@@ -327,6 +340,198 @@ class IdentityManager:
             self.peer_display_names[identity.peer_id] = display_name
         self._save_known_peers()
         logger.debug(f"Added known peer: {identity.peer_id}")
+
+    @staticmethod
+    def _normalize_meshspace_hint(raw: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a compact, persistence-safe meshspace hint dict."""
+        out: Dict[str, Any] = {}
+        field_map = {
+            'meshspace_id': 160,
+            'meshspace_name': 160,
+            'meshspace_fingerprint': 64,
+            'source': 64,
+            'last_source': 64,
+            'sync_approval_scope': 16,
+            'sync_approved_at': 64,
+            'mesh_relationship': 48,
+            'meshspace_avatar_mime': 80,
+        }
+        for key, limit in field_map.items():
+            text = str(raw.get(key) or '').strip()
+            if text:
+                out[key] = text[:limit]
+        aliases = raw.get('meshspace_id_aliases')
+        if isinstance(aliases, (list, tuple, set)):
+            cleaned_aliases = []
+            current_id = str(out.get('meshspace_id') or '').strip()
+            for value in aliases:
+                alias = str(value or '').strip()
+                if not alias or alias == current_id or alias in cleaned_aliases:
+                    continue
+                cleaned_aliases.append(alias[:160])
+            if cleaned_aliases:
+                out['meshspace_id_aliases'] = cleaned_aliases[:8]
+        avatar_b64 = str(raw.get('meshspace_avatar_b64') or '').strip()
+        if avatar_b64:
+            out['meshspace_avatar_b64'] = avatar_b64[:65536]
+        if 'cross_mesh_allowed' in raw:
+            out['cross_mesh_allowed'] = bool(raw.get('cross_mesh_allowed'))
+        if 'last_seen_at' in raw:
+            text = str(raw.get('last_seen_at') or '').strip()
+            if text:
+                out['last_seen_at'] = text[:64]
+        return out
+
+    def record_peer_meshspace_hint(
+        self,
+        peer_id: str,
+        *,
+        meshspace_id: Optional[str] = None,
+        meshspace_id_aliases: Optional[list[str]] = None,
+        meshspace_name: Optional[str] = None,
+        meshspace_fingerprint: Optional[str] = None,
+        meshspace_avatar_b64: Optional[str] = None,
+        meshspace_avatar_mime: Optional[str] = None,
+        source: str = '',
+        cross_mesh_allowed: Optional[bool] = None,
+        mesh_relationship: Optional[str] = None,
+    ) -> None:
+        """Persist the meshspace identity a peer advertised.
+
+        The hint is intentionally separate from cryptographic peer identity.
+        It supports UI review and avoids automatic reconnects silently crossing
+        meshspace boundaries.
+        """
+        if not peer_id:
+            return
+        if self.local_identity and peer_id == self.local_identity.peer_id:
+            return
+
+        incoming: Dict[str, Any] = {
+            'meshspace_id': meshspace_id,
+            'meshspace_id_aliases': meshspace_id_aliases or [],
+            'meshspace_name': meshspace_name,
+            'meshspace_fingerprint': meshspace_fingerprint,
+            'meshspace_avatar_b64': meshspace_avatar_b64,
+            'meshspace_avatar_mime': meshspace_avatar_mime,
+            'last_source': source,
+        }
+        if cross_mesh_allowed is not None:
+            incoming['cross_mesh_allowed'] = bool(cross_mesh_allowed)
+        if mesh_relationship is not None:
+            incoming['mesh_relationship'] = str(mesh_relationship or '').strip()
+
+        normalized = self._normalize_meshspace_hint(incoming)
+        existing = dict(self.peer_meshspace_hints.get(peer_id) or {})
+        changed = False
+        for key, value in normalized.items():
+            if value is None or value == '':
+                continue
+            if existing.get(key) != value:
+                existing[key] = value
+                changed = True
+        if source and existing.get('last_source') != source:
+            existing['last_source'] = source
+            changed = True
+        if normalized.get('meshspace_id_aliases') and existing.get('meshspace_id_aliases') != normalized.get('meshspace_id_aliases'):
+            existing['meshspace_id_aliases'] = list(normalized.get('meshspace_id_aliases') or [])
+            changed = True
+        if normalized.get('meshspace_avatar_b64') and existing.get('meshspace_avatar_b64') != normalized.get('meshspace_avatar_b64'):
+            existing['meshspace_avatar_b64'] = normalized.get('meshspace_avatar_b64')
+            changed = True
+        if normalized.get('meshspace_avatar_mime') and existing.get('meshspace_avatar_mime') != normalized.get('meshspace_avatar_mime'):
+            existing['meshspace_avatar_mime'] = normalized.get('meshspace_avatar_mime')
+            changed = True
+        if changed:
+            self.peer_meshspace_hints[peer_id] = self._normalize_meshspace_hint(existing)
+            self._save_known_peers()
+
+    def get_peer_meshspace_hint(self, peer_id: str) -> Dict[str, Any]:
+        """Return the persisted meshspace hint for a peer, if any."""
+        return dict(self.peer_meshspace_hints.get(peer_id, {}) or {})
+
+    @staticmethod
+    def _meshspace_hints_match(left: Dict[str, Any], right: Dict[str, Any]) -> bool:
+        """Return True when two peer hints appear to refer to the same meshspace."""
+        left_fingerprint = str(left.get('meshspace_fingerprint') or '').strip()
+        right_fingerprint = str(right.get('meshspace_fingerprint') or '').strip()
+        if left_fingerprint and right_fingerprint:
+            return left_fingerprint == right_fingerprint
+        left_ids = {str(left.get('meshspace_id') or '').strip()}
+        right_ids = {str(right.get('meshspace_id') or '').strip()}
+        left_ids.update(str(item or '').strip() for item in (left.get('meshspace_id_aliases') or []))
+        right_ids.update(str(item or '').strip() for item in (right.get('meshspace_id_aliases') or []))
+        left_ids.discard('')
+        right_ids.discard('')
+        if left_ids and right_ids:
+            return bool(left_ids.intersection(right_ids))
+        return False
+
+    def set_peer_sync_approval(self, peer_id: str, scope: Optional[str]) -> None:
+        """Persist whether a peer is approved for sync preview exit."""
+        clean_peer = str(peer_id or '').strip()
+        if not clean_peer:
+            return
+        if self.local_identity and clean_peer == self.local_identity.peer_id:
+            return
+        clean_scope = str(scope or '').strip().lower()
+        if clean_scope not in {'', 'peer', 'mesh'}:
+            raise ValueError(f"Unsupported sync approval scope: {scope}")
+        existing = dict(self.peer_meshspace_hints.get(clean_peer) or {})
+        changed = False
+        if clean_scope:
+            if existing.get('sync_approval_scope') != clean_scope:
+                existing['sync_approval_scope'] = clean_scope
+                changed = True
+            approved_at = datetime.now(timezone.utc).isoformat()
+            if existing.get('sync_approved_at') != approved_at:
+                existing['sync_approved_at'] = approved_at
+                changed = True
+        else:
+            for key in ('sync_approval_scope', 'sync_approved_at'):
+                if key in existing:
+                    del existing[key]
+                    changed = True
+        if changed:
+            normalized = self._normalize_meshspace_hint(existing)
+            if normalized:
+                self.peer_meshspace_hints[clean_peer] = normalized
+            else:
+                self.peer_meshspace_hints.pop(clean_peer, None)
+            self._save_known_peers()
+
+    def get_peer_sync_approval_status(self, peer_id: str) -> Dict[str, Any]:
+        """Return explicit/effective sync approval state for a peer."""
+        clean_peer = str(peer_id or '').strip()
+        hint = dict(self.peer_meshspace_hints.get(clean_peer, {}) or {})
+        explicit_scope = str(hint.get('sync_approval_scope') or '').strip().lower()
+        effective_scope = explicit_scope if explicit_scope in {'peer', 'mesh'} else ''
+        inherited_from_peer_id = ''
+        if not effective_scope and hint:
+            for other_peer_id, other_hint in self.peer_meshspace_hints.items():
+                if other_peer_id == clean_peer or not isinstance(other_hint, dict):
+                    continue
+                other_scope = str(other_hint.get('sync_approval_scope') or '').strip().lower()
+                if other_scope != 'mesh':
+                    continue
+                if self._meshspace_hints_match(hint, other_hint):
+                    effective_scope = 'mesh'
+                    inherited_from_peer_id = other_peer_id
+                    break
+        approved_at = ''
+        if effective_scope == explicit_scope:
+            approved_at = str(hint.get('sync_approved_at') or '').strip()
+        elif inherited_from_peer_id:
+            inherited_hint = dict(self.peer_meshspace_hints.get(inherited_from_peer_id, {}) or {})
+            approved_at = str(inherited_hint.get('sync_approved_at') or '').strip()
+        return {
+            'peer_id': clean_peer,
+            'explicit_scope': explicit_scope,
+            'effective_scope': effective_scope,
+            'preview_only': not bool(effective_scope),
+            'approved_at': approved_at,
+            'inherited_from_peer_id': inherited_from_peer_id,
+        }
 
     def record_endpoint(self, peer_id: str, endpoint: str, *, claim: bool = True) -> None:
         """Record an endpoint for a peer and optionally "claim" it.
@@ -383,6 +588,9 @@ class IdentityManager:
         if peer_id in self.peer_display_names:
             del self.peer_display_names[peer_id]
             changed = True
+        if peer_id in self.peer_meshspace_hints:
+            del self.peer_meshspace_hints[peer_id]
+            changed = True
         if changed:
             self._save_known_peers()
         return changed
@@ -394,7 +602,9 @@ class IdentityManager:
     def create_remote_peer(self, peer_id: str, ed25519_public_key: bytes,
                           x25519_public_key: bytes,
                           endpoints: Optional[list] = None,
-                          display_name: Optional[str] = None) -> PeerIdentity:
+                          display_name: Optional[str] = None,
+                          meshspace_hint: Optional[Dict[str, Any]] = None,
+                          cross_mesh_allowed: Optional[bool] = None) -> PeerIdentity:
         """
         Create identity for a remote peer (without private keys).
         
@@ -416,6 +626,18 @@ class IdentityManager:
         
         self.add_known_peer(identity, endpoints=endpoints,
                            display_name=display_name)
+        if isinstance(meshspace_hint, dict) and meshspace_hint:
+            self.record_peer_meshspace_hint(
+                peer_id,
+                meshspace_id=meshspace_hint.get('meshspace_id'),
+                meshspace_id_aliases=meshspace_hint.get('meshspace_id_aliases'),
+                meshspace_name=meshspace_hint.get('meshspace_name'),
+                meshspace_fingerprint=meshspace_hint.get('meshspace_fingerprint'),
+                meshspace_avatar_b64=meshspace_hint.get('meshspace_avatar_b64'),
+                meshspace_avatar_mime=meshspace_hint.get('meshspace_avatar_mime'),
+                source=str(meshspace_hint.get('source') or 'invite'),
+                cross_mesh_allowed=cross_mesh_allowed,
+            )
         return identity
     
     def verify_peer_id(self, peer_id: str, ed25519_public_key: bytes) -> bool:

--- a/canopy/network/invite.py
+++ b/canopy/network/invite.py
@@ -10,7 +10,17 @@ Invite payload (JSON, then base64url-encoded):
     "pid": "<peer_id>",
     "epk": "<ed25519_public_key base58>",
     "xpk": "<x25519_public_key base58>",
-    "ep": ["ws://<ip>:<port>"]     # list of endpoints to try
+    "ep": ["ws://<ip>:<port>"],    # list of endpoints to try
+    "mn": "<mesh_name>",           # optional mesh hint
+    "mid": "<meshspace_id>",       # optional stable meshspace id hint
+    "mia": ["<old_meshspace_id>"], # optional legacy/current alias hints
+    "mf": "<mesh_fingerprint>",    # optional short human check code
+    "mab": "<mesh_avatar_b64>",    # optional compact mesh avatar preview
+    "mam": "image/png",            # optional mesh avatar mime
+    "pl": "<peer_label>",          # optional node/display hint
+    "il": "<instance_label>",      # optional device/instance hint
+    "pi": "<peer_icon>",           # optional standard node icon hint
+    "ts": "<generated_at>"         # optional ISO timestamp
 }
 
 Project: Canopy - Local Mesh Communication
@@ -18,8 +28,10 @@ License: Apache 2.0
 """
 
 import base64
+import hashlib
 import json
 import logging
+import re
 import socket
 from urllib.parse import urlparse
 from typing import Dict, List, Optional, Any, Tuple
@@ -84,6 +96,15 @@ def _sanitize_invite_endpoints(endpoints: List[str]) -> List[str]:
     return out
 
 
+def meshspace_fingerprint(meshspace_id: Optional[str], mesh_name: Optional[str] = None) -> str:
+    """Return a short stable human check code for a meshspace hint."""
+    seed = str(meshspace_id or '').strip() or str(mesh_name or '').strip()
+    if not seed:
+        return ''
+    digest = hashlib.sha256(seed.encode('utf-8')).hexdigest().upper()
+    return f'{digest[:4]}-{digest[4:8]}'
+
+
 @dataclass
 class InviteCode:
     """Parsed invite code with peer identity and endpoints."""
@@ -91,16 +112,47 @@ class InviteCode:
     ed25519_public_key_b58: str
     x25519_public_key_b58: str
     endpoints: List[str]
+    mesh_name: Optional[str] = None
+    meshspace_id: Optional[str] = None
+    meshspace_id_aliases: Optional[List[str]] = None
+    meshspace_fingerprint: Optional[str] = None
+    meshspace_avatar_b64: Optional[str] = None
+    meshspace_avatar_mime: Optional[str] = None
+    peer_label: Optional[str] = None
+    instance_label: Optional[str] = None
+    peer_icon: Optional[str] = None
+    generated_at: Optional[str] = None
     version: int = 1
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        payload = {
             'v': self.version,
             'pid': self.peer_id,
             'epk': self.ed25519_public_key_b58,
             'xpk': self.x25519_public_key_b58,
             'ep': self.endpoints,
         }
+        if self.mesh_name:
+            payload['mn'] = self.mesh_name
+        if self.meshspace_id:
+            payload['mid'] = self.meshspace_id
+        if self.meshspace_id_aliases:
+            payload['mia'] = [str(value or '').strip() for value in self.meshspace_id_aliases if str(value or '').strip()]
+        if self.meshspace_fingerprint:
+            payload['mf'] = self.meshspace_fingerprint
+        if self.meshspace_avatar_b64:
+            payload['mab'] = self.meshspace_avatar_b64
+        if self.meshspace_avatar_mime:
+            payload['mam'] = self.meshspace_avatar_mime
+        if self.peer_label:
+            payload['pl'] = self.peer_label
+        if self.instance_label:
+            payload['il'] = self.instance_label
+        if self.peer_icon:
+            payload['pi'] = self.peer_icon
+        if self.generated_at:
+            payload['ts'] = self.generated_at
+        return payload
 
     def encode(self) -> str:
         """Encode invite as a compact base64url string prefixed with 'canopy:'."""
@@ -120,19 +172,28 @@ class InviteCode:
         """
         code = code.strip()
 
+        # Accept labeled invite blocks copied from the UI, as long as they
+        # contain one canopy:<payload> token.
+        if code and not code.lstrip().startswith('{') and not code.startswith('canopy:'):
+            match = re.search(r'canopy:[A-Za-z0-9_\-]+', code)
+            if match:
+                code = match.group(0)
+
         # Strip prefix
         if code.startswith('canopy:'):
             code = code[len('canopy:'):]
 
         # Try base64url decode
+        original_code = code
         try:
             # Restore padding
             padding = 4 - len(code) % 4
+            candidate = code
             if padding != 4:
-                code += '=' * padding
-            raw = base64.urlsafe_b64decode(code).decode('utf-8')
+                candidate += '=' * padding
+            raw = base64.urlsafe_b64decode(candidate).decode('utf-8')
         except Exception:
-            raw = code  # maybe it's raw JSON
+            raw = original_code  # maybe it's raw JSON
 
         data = json.loads(raw)
         return cls(
@@ -141,6 +202,16 @@ class InviteCode:
             ed25519_public_key_b58=data['epk'],
             x25519_public_key_b58=data['xpk'],
             endpoints=data.get('ep', []),
+            mesh_name=data.get('mn') or None,
+            meshspace_id=data.get('mid') or None,
+            meshspace_id_aliases=data.get('mia') or None,
+            meshspace_fingerprint=data.get('mf') or None,
+            meshspace_avatar_b64=data.get('mab') or None,
+            meshspace_avatar_mime=data.get('mam') or None,
+            peer_label=data.get('pl') or None,
+            instance_label=data.get('il') or None,
+            peer_icon=data.get('pi') or None,
+            generated_at=data.get('ts') or None,
         )
 
 
@@ -175,7 +246,17 @@ def get_local_ips() -> List[str]:
 def generate_invite(identity_manager: Any, mesh_port: int,
                     public_host: Optional[str] = None,
                     public_port: Optional[int] = None,
-                    external_endpoint: Optional[str] = None) -> InviteCode:
+                    external_endpoint: Optional[str] = None,
+                    mesh_name: Optional[str] = None,
+                    meshspace_id: Optional[str] = None,
+                    meshspace_id_aliases: Optional[List[str]] = None,
+                    meshspace_fingerprint_value: Optional[str] = None,
+                    meshspace_avatar_b64: Optional[str] = None,
+                    meshspace_avatar_mime: Optional[str] = None,
+                    peer_label: Optional[str] = None,
+                    instance_label: Optional[str] = None,
+                    peer_icon: Optional[str] = None,
+                    generated_at: Optional[str] = None) -> InviteCode:
     """
     Generate an invite code from the local peer identity.
 
@@ -185,6 +266,16 @@ def generate_invite(identity_manager: Any, mesh_port: int,
         public_host: Optional public/external IP or hostname
         public_port: Optional public port (if port-forwarded)
         external_endpoint: Optional full ws:// or wss:// endpoint
+        mesh_name: Optional human-facing mesh label for preview UX
+        meshspace_id: Optional stable meshspace identifier for preview UX
+        meshspace_id_aliases: Optional legacy/current alias IDs for transition-aware preview UX
+        meshspace_fingerprint_value: Optional precomputed short mesh check code
+        meshspace_avatar_b64: Optional compact mesh avatar preview art
+        meshspace_avatar_mime: Optional mime for mesh avatar preview art
+        peer_label: Optional human-facing peer label for preview UX
+        instance_label: Optional device/instance label for preview UX
+        peer_icon: Optional standard icon hint for the node/device
+        generated_at: Optional ISO timestamp for invite age hints
 
     Returns:
         InviteCode ready to .encode()
@@ -221,6 +312,24 @@ def generate_invite(identity_manager: Any, mesh_port: int,
         ed25519_public_key_b58=epk,
         x25519_public_key_b58=xpk,
         endpoints=endpoints,
+        mesh_name=str(mesh_name or '').strip() or None,
+        meshspace_id=str(meshspace_id or '').strip() or None,
+        meshspace_id_aliases=[
+            str(value or '').strip()
+            for value in (meshspace_id_aliases or [])
+            if str(value or '').strip()
+        ] or None,
+        meshspace_fingerprint=(
+            str(meshspace_fingerprint_value or '').strip()
+            or meshspace_fingerprint(meshspace_id, mesh_name)
+            or None
+        ),
+        meshspace_avatar_b64=str(meshspace_avatar_b64 or '').strip() or None,
+        meshspace_avatar_mime=str(meshspace_avatar_mime or '').strip() or None,
+        peer_label=str(peer_label or '').strip() or None,
+        instance_label=str(instance_label or '').strip() or None,
+        peer_icon=str(peer_icon or '').strip() or None,
+        generated_at=str(generated_at or '').strip() or None,
     )
 
     logger.info(f"Generated invite code for peer {local.peer_id} with {len(endpoints)} endpoint(s)")
@@ -251,12 +360,22 @@ def import_invite(identity_manager: Any, connection_manager: Any, invite: Invite
     # Register as known peer and persist invite endpoints so reconnect
     # can recover even if the initial direct session drops later.
     endpoints = _sanitize_invite_endpoints(invite.endpoints or [])
+    meshspace_hint = {
+        'meshspace_id': invite.meshspace_id,
+        'meshspace_id_aliases': invite.meshspace_id_aliases or [],
+        'meshspace_name': invite.mesh_name,
+        'meshspace_fingerprint': invite.meshspace_fingerprint,
+        'meshspace_avatar_b64': invite.meshspace_avatar_b64,
+        'meshspace_avatar_mime': invite.meshspace_avatar_mime,
+        'source': 'invite',
+    }
 
     identity_manager.create_remote_peer(
         invite.peer_id,
         ed25519_pub,
         x25519_pub,
         endpoints=endpoints,
+        meshspace_hint=meshspace_hint,
     )
 
     logger.info(f"Imported invite for peer {invite.peer_id} with {len(endpoints)} endpoint(s)")
@@ -264,4 +383,7 @@ def import_invite(identity_manager: Any, connection_manager: Any, invite: Invite
         'peer_id': invite.peer_id,
         'endpoints': endpoints,
         'status': 'imported',
+        'meshspace_hint': {
+            key: value for key, value in meshspace_hint.items() if value
+        },
     }

--- a/canopy/network/manager.py
+++ b/canopy/network/manager.py
@@ -39,6 +39,7 @@ from ..core.large_attachments import (
 from .identity import IdentityManager, PeerIdentity
 from .discovery import PeerDiscovery, DiscoveredPeer
 from .connection import ConnectionManager, PeerConnection
+from .invite import meshspace_fingerprint
 from .routing import (
     MessageRouter,
     P2PMessage,
@@ -151,6 +152,7 @@ class P2PNetworkManager:
         self.on_profile_sync: Optional[Callable] = None
         self.get_local_profile_card: Optional[Callable] = None
         self.get_all_local_profile_cards: Optional[Callable] = None
+        self.get_local_peer_public_hint: Optional[Callable[[], Dict[str, Any]]] = None
         # Optional callback to fetch a device profile for a peer_id
         self.get_peer_device_profile: Optional[Callable[[str], Optional[Dict[str, Any]]]] = None
 
@@ -202,10 +204,11 @@ class P2PNetworkManager:
                 '1', 'true', 'yes', 'on'
             )
 
-        # Startup grace period — serializes syncs and limits concurrency
+        # Startup grace period throttles initial syncs without making new or
+        # restarted peers wait minutes before catch-up repair begins.
         self._startup_time: Optional[float] = None
-        self._STARTUP_GRACE_PERIOD = 10.0  # seconds
-        self._POST_CONNECT_SETTLE_WINDOW_S = 1.5
+        self._STARTUP_GRACE_PERIOD = 8.0  # seconds
+        self._POST_CONNECT_SETTLE_WINDOW_S = 1.0
         self._sync_queue: asyncio.Queue[str] = asyncio.Queue()
         self._sync_queue_task: Optional[asyncio.Task] = None
         self._queued_sync_peers: set[str] = set()
@@ -215,8 +218,8 @@ class P2PNetworkManager:
         self._post_connect_retry_tokens: Dict[str, str] = {}
         self._POST_CONNECT_SYNC_MAX_RETRIES = 3
         self._active_catchups: set = set()
-        self._MAX_CONCURRENT_CATCHUPS_STARTUP = 2
-        self._MAX_CONCURRENT_CATCHUPS_NORMAL = 5
+        self._MAX_CONCURRENT_CATCHUPS_STARTUP = 3
+        self._MAX_CONCURRENT_CATCHUPS_NORMAL = 6
         self.sync_digest_enabled = bool(
             getattr(cfg_security, 'sync_digest_enabled', False)
         )
@@ -242,8 +245,416 @@ class P2PNetworkManager:
         logger.info("P2PNetworkManager initialized")
 
     def _meshspace_network_quarantined(self) -> bool:
-        mesh_cfg = getattr(self.config, 'meshspace', None)
+        config = getattr(self, 'config', None)
+        mesh_cfg = getattr(config, 'meshspace', None)
         return bool(getattr(mesh_cfg, 'network_quarantined', False))
+
+    def _meshspace_boundary_enabled(self) -> bool:
+        """Return True when this runtime has explicit meshspace identity."""
+        config = getattr(self, 'config', None)
+        mesh_cfg = getattr(config, 'meshspace', None)
+        return bool(getattr(mesh_cfg, 'enabled', False))
+
+    @staticmethod
+    def _normalize_meshspace_id_aliases(raw: Any, *, current_id: str = "") -> list[str]:
+        aliases: list[str] = []
+        values = raw if isinstance(raw, (list, tuple, set)) else ([raw] if raw else [])
+        current = str(current_id or '').strip()
+        for value in values:
+            alias = str(value or '').strip()
+            if not alias or alias == current or alias in aliases:
+                continue
+            aliases.append(alias)
+        return aliases
+
+    @classmethod
+    def _meshspace_hint_ids(cls, hint: Dict[str, Any]) -> set[str]:
+        meshspace_id = str(hint.get('meshspace_id') or '').strip()
+        aliases = cls._normalize_meshspace_id_aliases(
+            hint.get('meshspace_id_aliases'),
+            current_id=meshspace_id,
+        )
+        ids = set(aliases)
+        if meshspace_id:
+            ids.add(meshspace_id)
+        return ids
+
+    def _local_meshspace_identity(self) -> Dict[str, Any]:
+        """Return local meshspace metadata used for safety hints."""
+        config = getattr(self, 'config', None)
+        mesh_cfg = getattr(config, 'meshspace', None)
+        meshspace_id = str(getattr(mesh_cfg, 'meshspace_id', '') or '').strip()
+        meshspace_name = str(getattr(mesh_cfg, 'name', '') or '').strip()
+        fingerprint = meshspace_fingerprint(meshspace_id, meshspace_name)
+        return {
+            'meshspace_id': meshspace_id,
+            'meshspace_id_aliases': self._normalize_meshspace_id_aliases(
+                getattr(mesh_cfg, 'meshspace_id_aliases', []),
+                current_id=meshspace_id,
+            ),
+            'meshspace_name': meshspace_name,
+            'meshspace_fingerprint': fingerprint,
+            'meshspace_avatar_b64': str(getattr(mesh_cfg, 'avatar_preview_b64', '') or '').strip(),
+            'meshspace_avatar_mime': str(getattr(mesh_cfg, 'avatar_preview_mime', 'image/png') or 'image/png').strip() or 'image/png',
+        }
+
+    def _record_peer_meshspace_hint(
+        self,
+        peer_id: str,
+        mesh_meta: Optional[Dict[str, Any]],
+        *,
+        source: str,
+        cross_mesh_allowed: Optional[bool] = None,
+        mesh_relationship: Optional[str] = None,
+    ) -> None:
+        """Persist a remote meshspace hint when a peer advertises one."""
+        if not peer_id or not isinstance(mesh_meta, dict):
+            return
+        meshspace_id = str(mesh_meta.get('meshspace_id') or '').strip()
+        meshspace_id_aliases = self._normalize_meshspace_id_aliases(
+            mesh_meta.get('meshspace_id_aliases'),
+            current_id=meshspace_id,
+        )
+        meshspace_name = str(mesh_meta.get('meshspace_name') or '').strip()
+        meshspace_fingerprint_value = str(mesh_meta.get('meshspace_fingerprint') or '').strip()
+        meshspace_avatar_b64 = str(mesh_meta.get('meshspace_avatar_b64') or '').strip()
+        meshspace_avatar_mime = str(mesh_meta.get('meshspace_avatar_mime') or '').strip()
+        if not (
+            meshspace_id or meshspace_id_aliases or meshspace_name or meshspace_fingerprint_value
+            or meshspace_avatar_b64 or cross_mesh_allowed is not None
+        ):
+            return
+        identity_manager = getattr(self, 'identity_manager', None)
+        recorder = getattr(identity_manager, 'record_peer_meshspace_hint', None)
+        if not callable(recorder):
+            return
+        try:
+            recorder(
+                peer_id,
+                meshspace_id=meshspace_id or None,
+                meshspace_id_aliases=meshspace_id_aliases or None,
+                meshspace_name=meshspace_name or None,
+                meshspace_fingerprint=meshspace_fingerprint_value or None,
+                meshspace_avatar_b64=meshspace_avatar_b64 or None,
+                meshspace_avatar_mime=meshspace_avatar_mime or None,
+                source=source,
+                cross_mesh_allowed=cross_mesh_allowed,
+                mesh_relationship=mesh_relationship,
+            )
+        except Exception:
+            logger.debug("Could not persist meshspace hint for %s", peer_id, exc_info=True)
+
+    @staticmethod
+    def _sanitize_public_peer_label(value: Any, *, limit: int = 96) -> str:
+        text = str(value or '').replace('\r', ' ').replace('\n', ' ').strip()
+        text = ''.join(ch for ch in text if ch == '\t' or ord(ch) >= 32)
+        while '  ' in text:
+            text = text.replace('  ', ' ')
+        return text[:limit]
+
+    def _local_peer_public_identity_hint(self) -> Dict[str, str]:
+        """Return compact local peer labels to advertise before trust."""
+        hint: Dict[str, Any] = {}
+        provider = getattr(self, 'get_local_peer_public_hint', None)
+        if callable(provider):
+            try:
+                candidate = provider() or {}
+                if isinstance(candidate, dict):
+                    hint = dict(candidate)
+            except Exception:
+                logger.debug("Could not build local peer public hint from callback", exc_info=True)
+        if not hint:
+            device = self._build_local_device_preview() or {}
+            hint = {
+                'peer_label': device.get('display_name') or '',
+                'instance_label': device.get('display_name') or '',
+            }
+        peer_label = self._sanitize_public_peer_label(
+            hint.get('peer_label') or hint.get('node_name') or hint.get('instance_label')
+        )
+        instance_label = self._sanitize_public_peer_label(
+            hint.get('instance_label') or peer_label
+        )
+        return {
+            'peer_label': peer_label,
+            'instance_label': instance_label,
+        }
+
+    def refresh_local_public_identity_hint(self) -> Dict[str, str]:
+        """Refresh the live handshake labels used for new outbound/inbound connections."""
+        hint = self._local_peer_public_identity_hint()
+        connection_manager = getattr(self, 'connection_manager', None)
+        if connection_manager is not None:
+            try:
+                sanitize = getattr(connection_manager, '_sanitize_public_label', None)
+                peer_label = str(hint.get('peer_label') or '').strip()
+                instance_label = str(hint.get('instance_label') or '').strip()
+                connection_manager.local_peer_label = sanitize(peer_label) if callable(sanitize) else peer_label
+                connection_manager.local_instance_label = sanitize(instance_label) if callable(sanitize) else instance_label
+            except Exception:
+                logger.debug("Could not refresh live connection-manager public hint", exc_info=True)
+        return hint
+
+    def _remember_peer_public_identity_hint(
+        self,
+        peer_id: str,
+        peer_meta: Optional[Dict[str, Any]],
+        *,
+        source: str,
+    ) -> Dict[str, str]:
+        """Persist untrusted human-readable peer labels learned during handshake/intro."""
+        clean_peer_id = str(peer_id or '').strip()
+        if not clean_peer_id or not isinstance(peer_meta, dict):
+            return {}
+        peer_label = self._sanitize_public_peer_label(
+            peer_meta.get('peer_label') or peer_meta.get('display_name') or peer_meta.get('node_name')
+        )
+        instance_label = self._sanitize_public_peer_label(peer_meta.get('instance_label'))
+        display_name = peer_label or instance_label
+        if not display_name:
+            return {}
+
+        identity_manager = getattr(self, 'identity_manager', None)
+        changed = False
+        if identity_manager is not None:
+            try:
+                existing = str(getattr(identity_manager, 'peer_display_names', {}).get(clean_peer_id) or '').strip()
+                if existing != display_name:
+                    identity_manager.peer_display_names[clean_peer_id] = display_name
+                    changed = True
+                if changed and hasattr(identity_manager, '_save_known_peers'):
+                    identity_manager._save_known_peers()
+            except Exception:
+                logger.debug("Could not persist public peer label for %s", clean_peer_id, exc_info=True)
+
+        if hasattr(self, '_introduced_peers'):
+            introduced = self._introduced_peers.get(clean_peer_id)
+            if isinstance(introduced, dict):
+                introduced['display_name'] = display_name
+                introduced['peer_label'] = peer_label
+                introduced['instance_label'] = instance_label
+                introduced['public_identity_source'] = source
+
+        return {
+            'display_name': display_name,
+            'peer_label': peer_label,
+            'instance_label': instance_label,
+        }
+
+    def get_peer_cross_mesh_status(self, peer_id: str) -> Dict[str, Any]:
+        """Return whether a peer appears to belong to a different meshspace."""
+        local = self._local_meshspace_identity()
+        identity_manager = getattr(self, 'identity_manager', None)
+        hint_getter = getattr(identity_manager, 'get_peer_meshspace_hint', None)
+        hint: Dict[str, Any] = {}
+        if callable(hint_getter):
+            try:
+                hint = dict(hint_getter(peer_id) or {})
+            except Exception:
+                hint = {}
+        else:
+            hint = dict(getattr(identity_manager, 'peer_meshspace_hints', {}).get(peer_id, {}) or {})
+
+        local_id = str(local.get('meshspace_id') or '').strip()
+        remote_id = str(hint.get('meshspace_id') or '').strip()
+        local_ids = self._meshspace_hint_ids(local)
+        remote_ids = self._meshspace_hint_ids(hint)
+        local_fingerprint = str(local.get('meshspace_fingerprint') or '').strip()
+        remote_fingerprint = str(hint.get('meshspace_fingerprint') or '').strip()
+        mismatch = False
+        if self._meshspace_boundary_enabled():
+            if local_ids and remote_ids:
+                mismatch = not bool(local_ids.intersection(remote_ids))
+            elif local_fingerprint and remote_fingerprint:
+                mismatch = remote_fingerprint != local_fingerprint
+        allowed = bool(hint.get('cross_mesh_allowed'))
+        stored_relationship = str(hint.get('mesh_relationship') or '').strip()
+        if not remote_ids and not remote_fingerprint:
+            relationship = stored_relationship or 'unknown'
+        elif mismatch and allowed:
+            relationship = 'cross_mesh_bridge_allowed'
+        elif mismatch:
+            relationship = 'mesh_mismatch_pending_review'
+        elif (
+            stored_relationship == 'same_mesh_alias_confirmed'
+            or (remote_id and local_id and remote_id != local_id and remote_id in local_ids)
+            or bool(local_ids.intersection(remote_ids) - {local_id})
+        ):
+            relationship = 'same_mesh_alias_confirmed'
+        else:
+            relationship = 'same_mesh_confirmed'
+        return {
+            'peer_id': peer_id,
+            'local_meshspace_id': local_id,
+            'local_meshspace_id_aliases': list(local.get('meshspace_id_aliases') or []),
+            'local_meshspace_name': local.get('meshspace_name') or '',
+            'local_meshspace_fingerprint': local_fingerprint,
+            'remote_meshspace_id': remote_id,
+            'remote_meshspace_id_aliases': list(hint.get('meshspace_id_aliases') or []),
+            'remote_meshspace_name': str(hint.get('meshspace_name') or '').strip(),
+            'remote_meshspace_fingerprint': remote_fingerprint,
+            'remote_meshspace_avatar_b64': str(hint.get('meshspace_avatar_b64') or '').strip(),
+            'remote_meshspace_avatar_mime': str(hint.get('meshspace_avatar_mime') or '').strip(),
+            'mismatch': mismatch,
+            'cross_mesh_allowed': allowed,
+            'mesh_relationship': relationship,
+            'requires_identity_review': bool(relationship == 'mesh_mismatch_pending_review'),
+            'requires_manual_confirmation': bool(relationship == 'mesh_mismatch_pending_review'),
+        }
+
+    def get_peer_sync_status(self, peer_id: str) -> Dict[str, Any]:
+        """Return whether a peer is still preview-only for sync import."""
+        clean_peer = str(peer_id or '').strip()
+        identity_manager = getattr(self, 'identity_manager', None)
+        hint_getter = getattr(identity_manager, 'get_peer_meshspace_hint', None)
+        sync_getter = getattr(identity_manager, 'get_peer_sync_approval_status', None)
+        hint: Dict[str, Any] = {}
+        if callable(hint_getter):
+            try:
+                hint = dict(hint_getter(clean_peer) or {})
+            except Exception:
+                hint = {}
+        sync_status: Dict[str, Any] = {}
+        if callable(sync_getter):
+            try:
+                sync_status = dict(sync_getter(clean_peer) or {})
+            except Exception:
+                sync_status = {}
+        explicit_scope = str(sync_status.get('explicit_scope') or '').strip().lower()
+        effective_scope = str(sync_status.get('effective_scope') or '').strip().lower()
+        default_preview_only = bool(identity_manager is not None and not effective_scope)
+        preview_only = bool(sync_status.get('preview_only', default_preview_only))
+        return {
+            'peer_id': clean_peer,
+            'preview_only': preview_only,
+            'explicit_scope': explicit_scope,
+            'effective_scope': effective_scope,
+            'approved_at': str(sync_status.get('approved_at') or '').strip(),
+            'inherited_from_peer_id': str(sync_status.get('inherited_from_peer_id') or '').strip(),
+            'remote_meshspace_id': str(hint.get('meshspace_id') or '').strip(),
+            'remote_meshspace_id_aliases': list(hint.get('meshspace_id_aliases') or []),
+            'remote_meshspace_name': str(hint.get('meshspace_name') or '').strip(),
+            'remote_meshspace_fingerprint': str(hint.get('meshspace_fingerprint') or '').strip(),
+            'remote_meshspace_avatar_b64': str(hint.get('meshspace_avatar_b64') or '').strip(),
+            'remote_meshspace_avatar_mime': str(hint.get('meshspace_avatar_mime') or '').strip(),
+        }
+
+    def _peer_requires_sync_approval(self, peer_id: str) -> bool:
+        """Return True when a peer is limited to preview-only mode."""
+        return bool(self.get_peer_sync_status(peer_id).get('preview_only'))
+
+    def approve_peer_sync(self, peer_id: str, scope: str = 'peer') -> Dict[str, Any]:
+        """Persist that sync is allowed for one peer or its whole mesh."""
+        clean_scope = str(scope or '').strip().lower()
+        if clean_scope not in {'peer', 'mesh'}:
+            raise ValueError(f"Unsupported sync approval scope: {scope}")
+        identity_manager = getattr(self, 'identity_manager', None)
+        setter = getattr(identity_manager, 'set_peer_sync_approval', None)
+        if not callable(setter):
+            raise RuntimeError("Peer sync approval persistence unavailable")
+        setter(peer_id, clean_scope)
+        return self.get_peer_sync_status(peer_id)
+
+    def _peer_requires_manual_cross_mesh(self, peer_id: str) -> bool:
+        return bool(self.get_peer_cross_mesh_status(peer_id).get('requires_manual_confirmation'))
+
+    def mark_peer_cross_mesh_allowed(self, peer_id: str, allowed: bool = True) -> None:
+        """Persist the admin/user decision that a cross-mesh peer is intentional."""
+        status = self.get_peer_cross_mesh_status(peer_id)
+        self._record_peer_meshspace_hint(
+            peer_id,
+            {
+                'meshspace_id': status.get('remote_meshspace_id'),
+                'meshspace_id_aliases': status.get('remote_meshspace_id_aliases'),
+                'meshspace_name': status.get('remote_meshspace_name'),
+                'meshspace_fingerprint': status.get('remote_meshspace_fingerprint'),
+                'meshspace_avatar_b64': status.get('remote_meshspace_avatar_b64'),
+                'meshspace_avatar_mime': status.get('remote_meshspace_avatar_mime'),
+            },
+            source='manual_cross_mesh_confirmation',
+            cross_mesh_allowed=allowed,
+            mesh_relationship='cross_mesh_bridge_allowed' if allowed else '',
+        )
+
+    def mark_peer_meshspace_equivalent(self, peer_id: str) -> Dict[str, Any]:
+        """Treat the peer's advertised mesh IDs as aliases of the local meshspace."""
+        status = self.get_peer_cross_mesh_status(peer_id)
+        local_meshspace_id = str(status.get('local_meshspace_id') or '').strip()
+        if not local_meshspace_id:
+            raise RuntimeError("Local meshspace identity is unavailable")
+
+        remote_ids: list[str] = []
+        remote_id = str(status.get('remote_meshspace_id') or '').strip()
+        if remote_id:
+            remote_ids.append(remote_id)
+        for alias in status.get('remote_meshspace_id_aliases') or []:
+            clean = str(alias or '').strip()
+            if clean and clean not in remote_ids:
+                remote_ids.append(clean)
+        if not remote_ids:
+            raise RuntimeError("Peer has not advertised a meshspace ID to alias")
+
+        mesh_cfg = getattr(getattr(self, 'config', None), 'meshspace', None)
+        current_aliases = self._normalize_meshspace_id_aliases(
+            getattr(mesh_cfg, 'meshspace_id_aliases', []),
+            current_id=local_meshspace_id,
+        )
+        aliases_to_add = [
+            value for value in remote_ids
+            if value != local_meshspace_id and value not in current_aliases
+        ]
+        merged_aliases = self._normalize_meshspace_id_aliases(
+            current_aliases + aliases_to_add,
+            current_id=local_meshspace_id,
+        )
+        if mesh_cfg is not None:
+            mesh_cfg.meshspace_id_aliases = list(merged_aliases)
+
+        registry_root = str(getattr(mesh_cfg, 'registry_root', '') or '').strip() if mesh_cfg else ''
+        if registry_root and aliases_to_add:
+            try:
+                from ..core.meshspaces import MeshspaceRegistryManager
+
+                registry = MeshspaceRegistryManager(registry_root=Path(registry_root).expanduser())
+                record = registry.add_meshspace_aliases(local_meshspace_id, aliases_to_add)
+                if isinstance(record, dict) and mesh_cfg is not None:
+                    mesh_cfg.meshspace_id_aliases = self._normalize_meshspace_id_aliases(
+                        record.get('meshspace_id_aliases'),
+                        current_id=local_meshspace_id,
+                    )
+            except Exception:
+                logger.warning(
+                    "Could not persist meshspace aliases %s for %s",
+                    aliases_to_add,
+                    local_meshspace_id,
+                    exc_info=True,
+                )
+
+        connection_manager = getattr(self, 'connection_manager', None)
+        if connection_manager is not None:
+            connection_manager.local_meshspace_id_aliases = list(getattr(mesh_cfg, 'meshspace_id_aliases', []) or merged_aliases)
+
+        self._record_peer_meshspace_hint(
+            peer_id,
+            {
+                'meshspace_id': status.get('remote_meshspace_id'),
+                'meshspace_id_aliases': status.get('remote_meshspace_id_aliases'),
+                'meshspace_name': status.get('remote_meshspace_name'),
+                'meshspace_fingerprint': status.get('remote_meshspace_fingerprint'),
+                'meshspace_avatar_b64': status.get('remote_meshspace_avatar_b64'),
+                'meshspace_avatar_mime': status.get('remote_meshspace_avatar_mime'),
+            },
+            source='manual_same_mesh_alias_confirmation',
+            cross_mesh_allowed=False,
+            mesh_relationship='same_mesh_alias_confirmed',
+        )
+        return self.get_peer_cross_mesh_status(peer_id)
+
+    def _cross_mesh_reconnect_detail(self, peer_id: str) -> str:
+        status = self.get_peer_cross_mesh_status(peer_id)
+        remote_name = status.get('remote_meshspace_name') or status.get('remote_meshspace_id') or 'another meshspace'
+        local_name = status.get('local_meshspace_name') or status.get('local_meshspace_id') or 'this meshspace'
+        return f"Cross-mesh reconnect blocked: {remote_name} is not {local_name}"
 
     def _build_local_capabilities(self) -> list[str]:
         """Compute P2P capability advertisement for this node."""
@@ -587,6 +998,8 @@ class P2PNetworkManager:
         local_peer = str(self.get_peer_id() or '').strip()
         if local_peer and clean_peer == local_peer:
             return True
+        if self._peer_requires_sync_approval(clean_peer):
+            return False
         has_explicit = getattr(self, 'has_explicit_trust_score', None)
         if has_explicit:
             try:
@@ -924,7 +1337,7 @@ class P2PNetworkManager:
                     self._syncs_in_progress.add(peer_id)
                     if not await self._acquire_catchup_slot(peer_id):
                         # Wait a bit and retry if at capacity
-                        await asyncio.sleep(2.0)
+                        await asyncio.sleep(0.75)
                         if not await self._acquire_catchup_slot(peer_id):
                             logger.warning(f"Skipping sync for {peer_id}: at capacity")
                             self._sync_queue.task_done()
@@ -934,9 +1347,9 @@ class P2PNetworkManager:
 
                     # Delay between syncs to reduce contention
                     if self._in_startup_grace_period():
-                        await asyncio.sleep(1.0)
+                        await asyncio.sleep(0.5)
                     else:
-                        await asyncio.sleep(0.3)
+                        await asyncio.sleep(0.15)
                 except Exception as e:
                     logger.error(f"Error processing sync for {peer_id}: {e}", exc_info=True)
                 finally:
@@ -1021,6 +1434,8 @@ class P2PNetworkManager:
             network_config = self.config.network
             if self.local_identity is None:
                 raise RuntimeError("Local identity is not initialized")
+            local_meshspace = self._local_meshspace_identity()
+            local_peer_hint = self._local_peer_public_identity_hint()
             
             # Initialize connection manager FIRST (core functionality)
             # Always bind P2P listener to all interfaces for peer connectivity
@@ -1036,6 +1451,14 @@ class P2PNetworkManager:
                 advertised_endpoints_provider=self._get_local_advertised_endpoints,
                 canopy_version=self.local_canopy_version,
                 protocol_version=self.local_protocol_version,
+                meshspace_id=local_meshspace.get('meshspace_id', ''),
+                meshspace_id_aliases=local_meshspace.get('meshspace_id_aliases', []),
+                meshspace_name=local_meshspace.get('meshspace_name', ''),
+                meshspace_fingerprint=local_meshspace.get('meshspace_fingerprint', ''),
+                meshspace_avatar_b64=local_meshspace.get('meshspace_avatar_b64', ''),
+                meshspace_avatar_mime=local_meshspace.get('meshspace_avatar_mime', 'image/png'),
+                peer_label=local_peer_hint.get('peer_label', ''),
+                instance_label=local_peer_hint.get('instance_label', ''),
                 reject_protocol_mismatch=bool(
                     os.getenv('CANOPY_REJECT_PROTOCOL_MISMATCH', '').strip().lower() in ('1', 'true', 'yes', 'on')
                 ),
@@ -1198,6 +1621,15 @@ class P2PNetworkManager:
 
         for peer_id in list(known_peer_ids):
             if peer_id == local_id:
+                continue
+            if self._peer_requires_manual_cross_mesh(peer_id):
+                detail = self._cross_mesh_reconnect_detail(peer_id)
+                logger.warning("Startup reconnect skipped for %s: %s", peer_id, detail)
+                self._record_connection_event(
+                    peer_id,
+                    status='blocked',
+                    detail=detail,
+                )
                 continue
             if self.connection_manager and self.connection_manager.is_connected(peer_id):
                 continue
@@ -1630,7 +2062,14 @@ class P2PNetworkManager:
             })
         return rows
 
-    async def _connect_to_endpoint(self, peer_id: str, endpoint: str) -> bool:
+    async def _connect_to_endpoint(
+        self,
+        peer_id: str,
+        endpoint: str,
+        *,
+        allow_cross_mesh: bool = False,
+        allow_mesh_review: bool = False,
+    ) -> bool:
         """Connect to a peer using a ws:// or wss:// endpoint string."""
         if not self.connection_manager:
             return False
@@ -1638,6 +2077,21 @@ class P2PNetworkManager:
         if peer_id == local_id:
             logger.debug("Reconnect: refusing to connect to self (%s)", peer_id)
             return False
+        if self._peer_requires_manual_cross_mesh(peer_id) and not (allow_cross_mesh or allow_mesh_review):
+            detail = self._cross_mesh_reconnect_detail(peer_id)
+            logger.warning("Reconnect refused for %s: %s", peer_id, detail)
+            self._record_connection_event(
+                peer_id,
+                status='blocked',
+                detail=detail,
+                endpoint=endpoint,
+            )
+            return False
+        if allow_cross_mesh:
+            try:
+                self.mark_peer_cross_mesh_allowed(peer_id, True)
+            except Exception:
+                pass
         canon = self._canonicalize_endpoint(endpoint)
         parsed = self._parse_endpoint(canon or endpoint)
         if not parsed:
@@ -1673,6 +2127,76 @@ class P2PNetworkManager:
         )
         ok = await self.connection_manager.connect_to_peer(peer_id, host, port, scheme=scheme)
         if ok and canon:
+            get_connection = getattr(self.connection_manager, 'get_connection', None)
+            conn = get_connection(peer_id) if callable(get_connection) else None
+            if conn:
+                self._remember_peer_public_identity_hint(
+                    peer_id,
+                    {
+                        'peer_label': getattr(conn, 'peer_label', None),
+                        'instance_label': getattr(conn, 'instance_label', None),
+                    },
+                    source='handshake',
+                )
+                self._record_peer_meshspace_hint(
+                    peer_id,
+                    {
+                        'meshspace_id': getattr(conn, 'meshspace_id', None),
+                        'meshspace_id_aliases': getattr(conn, 'meshspace_id_aliases', None),
+                        'meshspace_name': getattr(conn, 'meshspace_name', None),
+                        'meshspace_fingerprint': getattr(conn, 'meshspace_fingerprint', None),
+                        'meshspace_avatar_b64': getattr(conn, 'meshspace_avatar_b64', None),
+                        'meshspace_avatar_mime': getattr(conn, 'meshspace_avatar_mime', None),
+                    },
+                    source='handshake',
+                    cross_mesh_allowed=allow_cross_mesh if allow_cross_mesh else None,
+                )
+            # A peer first seen through broker/discovery paths can pass the
+            # pre-connection guard because we had no prior mesh hint. Re-check
+            # immediately after the handshake fills that hint in.
+            if not allow_cross_mesh and self._peer_requires_manual_cross_mesh(peer_id):
+                detail = self._cross_mesh_reconnect_detail(peer_id)
+                if allow_mesh_review:
+                    logger.info(
+                        "Outgoing connection to %s left connected for mesh identity review: %s",
+                        peer_id,
+                        detail,
+                    )
+                    self._record_connection_event(
+                        peer_id,
+                        status='mesh_review_required',
+                        detail=detail,
+                        endpoint=canon,
+                    )
+                else:
+                    logger.warning(
+                        "Outgoing connection to %s rejected post-handshake: %s",
+                        peer_id,
+                        detail,
+                    )
+                    self._record_endpoint_result(
+                        peer_id,
+                        canon,
+                        success=False,
+                        reason='cross_mesh_blocked_post_handshake',
+                        detail=detail,
+                        sources=endpoint_sources,
+                    )
+                    self._record_connection_event(
+                        peer_id,
+                        status='blocked',
+                        detail=detail,
+                        endpoint=canon,
+                    )
+                    try:
+                        await self.connection_manager.disconnect_peer(peer_id)
+                    except Exception:
+                        logger.debug(
+                            "Could not disconnect cross-mesh peer %s post-handshake",
+                            peer_id,
+                            exc_info=True,
+                        )
+                    return False
             # Claim the endpoint so stale mappings don't keep retrying the wrong peer_id.
             self.identity_manager.record_endpoint(peer_id, canon, claim=True)
             self._record_endpoint_result(
@@ -1728,6 +2252,11 @@ class P2PNetworkManager:
         local_id = self.local_identity.peer_id if self.local_identity else ''
         if peer_id == local_id:
             return
+        if self._peer_requires_manual_cross_mesh(peer_id):
+            detail = self._cross_mesh_reconnect_detail(peer_id)
+            logger.warning("Automatic reconnect not scheduled for %s: %s", peer_id, detail)
+            self._record_connection_event(peer_id, status='blocked', detail=detail)
+            return
         if self.connection_manager and self.connection_manager.is_connected(peer_id):
             self._reconnect_tasks.pop(peer_id, None)
             return
@@ -1754,6 +2283,12 @@ class P2PNetworkManager:
 
             # Check if still needed
             if not self._running:
+                return
+            if self._peer_requires_manual_cross_mesh(peer_id):
+                detail = self._cross_mesh_reconnect_detail(peer_id)
+                logger.warning("Automatic reconnect cancelled for %s: %s", peer_id, detail)
+                self._record_connection_event(peer_id, status='blocked', detail=detail)
+                self._reconnect_tasks.pop(peer_id, None)
                 return
             if self.connection_manager and self.connection_manager.is_connected(peer_id):
                 logger.debug(f"Reconnect: {peer_id} already connected, skipping")
@@ -1874,6 +2409,11 @@ class P2PNetworkManager:
                     f"Ignoring discovered peer {peer.peer_id} with no usable discovery endpoints"
                 )
                 return
+            if self._peer_requires_manual_cross_mesh(peer.peer_id):
+                detail = self._cross_mesh_reconnect_detail(peer.peer_id)
+                logger.warning("Discovery auto-connect skipped for %s: %s", peer.peer_id, detail)
+                self._record_connection_event(peer.peer_id, status='blocked', detail=detail)
+                return
 
             # If we're already connected, just record/claim the endpoint and stop.
             if self.connection_manager and self.connection_manager.is_connected(peer.peer_id):
@@ -1948,6 +2488,9 @@ class P2PNetworkManager:
             'capabilities': self._normalize_capability_items(
                 list((getattr(conn, 'capabilities', None) or {}).keys())
             ),
+            'meshspace_id': str(getattr(conn, 'meshspace_id', '') or ''),
+            'meshspace_name': str(getattr(conn, 'meshspace_name', '') or ''),
+            'meshspace_fingerprint': str(getattr(conn, 'meshspace_fingerprint', '') or ''),
         }
         self.peer_versions[peer_id] = entry
 
@@ -1974,23 +2517,41 @@ class P2PNetworkManager:
         sync + catch-up on the P2P event loop.
         """
         logger.info(f"Incoming peer authenticated: {peer_id} — scheduling post-connect sync")
-        self._record_connection_event(
-            peer_id,
-            status='connected',
-            detail='Incoming connection authenticated',
-        )
+        cross_mesh_block_detail = ''
         if isinstance(peer_meta, dict):
-            try:
-                self._remember_peer_advertised_endpoints(
-                    peer_id,
-                    list(peer_meta.get('advertised_endpoints') or []),
-                )
-            except Exception:
-                pass
+            self._remember_peer_public_identity_hint(
+                peer_id,
+                peer_meta,
+                source='incoming_handshake',
+            )
+            self._record_peer_meshspace_hint(
+                peer_id,
+                {
+                    'meshspace_id': peer_meta.get('meshspace_id'),
+                    'meshspace_id_aliases': peer_meta.get('meshspace_id_aliases'),
+                    'meshspace_name': peer_meta.get('meshspace_name'),
+                    'meshspace_fingerprint': peer_meta.get('meshspace_fingerprint'),
+                    'meshspace_avatar_b64': peer_meta.get('meshspace_avatar_b64'),
+                    'meshspace_avatar_mime': peer_meta.get('meshspace_avatar_mime'),
+                },
+                source='incoming_handshake',
+            )
+            if self._peer_requires_manual_cross_mesh(peer_id):
+                cross_mesh_block_detail = self._cross_mesh_reconnect_detail(peer_id)
+                logger.warning("Incoming peer %s carries cross-mesh hint: %s", peer_id, cross_mesh_block_detail)
+            else:
+                try:
+                    self._remember_peer_advertised_endpoints(
+                        peer_id,
+                        list(peer_meta.get('advertised_endpoints') or []),
+                    )
+                except Exception:
+                    pass
         # Do not invent reconnect endpoints from socket origin addresses. Only
         # persist discovery-derived endpoints, which are authoritative enough
         # to survive reconnects and peer announcements.
-        self._remember_discovered_peer_endpoints(peer_id)
+        if not cross_mesh_block_detail and not self._peer_requires_manual_cross_mesh(peer_id):
+            self._remember_discovered_peer_endpoints(peer_id)
         try:
             self._refresh_peer_version_info(peer_id)
             if peer_meta and peer_id in self.peer_versions:
@@ -1998,6 +2559,9 @@ class P2PNetworkManager:
                     'canopy_version': str(peer_meta.get('canopy_version') or self.peer_versions[peer_id].get('canopy_version') or 'unknown'),
                     'protocol_version': int(peer_meta.get('protocol_version') or self.peer_versions[peer_id].get('protocol_version') or 1),
                     'version': str(peer_meta.get('version') or self.peer_versions[peer_id].get('version') or '0.1.0'),
+                    'meshspace_id': str(peer_meta.get('meshspace_id') or self.peer_versions[peer_id].get('meshspace_id') or ''),
+                    'meshspace_name': str(peer_meta.get('meshspace_name') or self.peer_versions[peer_id].get('meshspace_name') or ''),
+                    'meshspace_fingerprint': str(peer_meta.get('meshspace_fingerprint') or self.peer_versions[peer_id].get('meshspace_fingerprint') or ''),
                 })
                 self.peer_versions[peer_id]['compatible_protocol'] = (
                     int(self.peer_versions[peer_id].get('protocol_version') or 1) == self.local_protocol_version
@@ -2005,6 +2569,30 @@ class P2PNetworkManager:
         except Exception:
             pass
 
+        if cross_mesh_block_detail:
+            self._record_connection_event(
+                peer_id,
+                status='blocked',
+                detail=(
+                    f"{cross_mesh_block_detail}. "
+                    "Incoming connection rejected until an admin explicitly approves this cross-mesh bridge."
+                ),
+            )
+            if self.connection_manager and self._event_loop and not self._event_loop.is_closed():
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        self.connection_manager.disconnect_peer(peer_id),
+                        self._event_loop,
+                    )
+                except Exception:
+                    logger.warning("Could not disconnect unapproved cross-mesh peer %s", peer_id, exc_info=True)
+            return
+
+        self._record_connection_event(
+            peer_id,
+            status='connected',
+            detail='Incoming connection authenticated',
+        )
         if self._event_loop and not self._event_loop.is_closed():
             asyncio.run_coroutine_threadsafe(
                 self._run_post_connect_sync(peer_id),
@@ -2129,6 +2717,15 @@ class P2PNetworkManager:
                     peer_id,
                 )
                 return
+            if self._peer_requires_manual_cross_mesh(peer_id):
+                detail = self._cross_mesh_reconnect_detail(peer_id)
+                logger.warning("Skipping automatic post-connect sync for %s: %s", peer_id, detail)
+                try:
+                    await self._send_device_preview_to_peer(peer_id)
+                except Exception:
+                    logger.debug("Could not send device preview to mesh-review peer %s", peer_id, exc_info=True)
+                self._record_connection_event(peer_id, status='mesh_review_required', detail=detail)
+                return
             self._refresh_peer_version_info(peer_id)
             if not await self._wait_for_connection_settle(peer_id):
                 connection_manager = getattr(self, 'connection_manager', None)
@@ -2149,6 +2746,22 @@ class P2PNetworkManager:
             # Notify application layer
             if self.on_peer_connected:
                 self.on_peer_connected(peer_id)
+
+            if self._peer_requires_sync_approval(peer_id):
+                sync_status = self.get_peer_sync_status(peer_id)
+                remote_name = (
+                    sync_status.get('remote_meshspace_name')
+                    or sync_status.get('remote_meshspace_id')
+                    or 'this peer'
+                )
+                await self._send_device_preview_to_peer(peer_id)
+                detail = (
+                    f"Preview-only connection: {remote_name} can be reviewed, "
+                    "but channel sync is paused until you approve this peer or meshspace."
+                )
+                logger.info("Skipping automatic post-connect sync for %s: %s", peer_id, detail)
+                self._record_connection_event(peer_id, status='preview_only', detail=detail)
+                return
 
             if not trusted_content:
                 logger.info(
@@ -2203,6 +2816,9 @@ class P2PNetworkManager:
 
         Returns True if the sync was successfully scheduled.
         """
+        if self._peer_requires_sync_approval(peer_id):
+            logger.info("Peer sync trigger refused for %s because preview-only approval is still required", peer_id)
+            return False
         if not self._event_loop or self._event_loop.is_closed():
             logger.warning("Cannot trigger peer sync — event loop unavailable")
             return False
@@ -2216,6 +2832,43 @@ class P2PNetworkManager:
     # ------------------------------------------------------------------ #
     #  Profile sync helpers                                                #
     # ------------------------------------------------------------------ #
+
+    def _build_local_device_preview(self) -> Optional[Dict[str, Any]]:
+        """Return the lightweight local device identity preview."""
+        try:
+            from canopy.core.device import get_device_profile, get_device_id
+
+            dev_profile = get_device_profile()
+            return {
+                'device_id': get_device_id(),
+                'display_name': dev_profile.get('display_name', ''),
+                'description': dev_profile.get('description', ''),
+                'avatar_b64': dev_profile.get('avatar_b64', ''),
+                'avatar_mime': dev_profile.get('avatar_mime', ''),
+            }
+        except Exception:
+            return None
+
+    async def _send_device_preview_to_peer(self, peer_id: str) -> None:
+        """Send only device identity metadata to a preview-only peer."""
+        if not self.message_router:
+            return
+        local_peer_id = self.local_identity.peer_id if self.local_identity else ''
+        if not local_peer_id:
+            return
+        device_info = self._build_local_device_preview()
+        if not device_info:
+            return
+        try:
+            await self.message_router.send_profile_sync(
+                peer_id,
+                {
+                    'peer_id': local_peer_id,
+                    'device': device_info,
+                },
+            )
+        except Exception as e:
+            logger.error("Error sending device preview to %s: %s", peer_id, e, exc_info=True)
 
     async def _send_profile_to_peer(self, peer_id: str) -> None:
         """Send local profile cards (all registered users + device) to a peer.
@@ -2231,19 +2884,7 @@ class P2PNetworkManager:
             return
         try:
             # Build device info once (shared across all cards)
-            device_info = None
-            try:
-                from canopy.core.device import get_device_profile, get_device_id
-                dev_profile = get_device_profile()
-                device_info = {
-                    'device_id': get_device_id(),
-                    'display_name': dev_profile.get('display_name', ''),
-                    'description': dev_profile.get('description', ''),
-                    'avatar_b64': dev_profile.get('avatar_b64', ''),
-                    'avatar_mime': dev_profile.get('avatar_mime', ''),
-                }
-            except Exception:
-                pass
+            device_info = self._build_local_device_preview()
 
             local_peer_id = self.local_identity.peer_id if self.local_identity else ''
 
@@ -2347,9 +2988,12 @@ class P2PNetworkManager:
                     if device_profile and device_profile.get('display_name')
                     else self.identity_manager.peer_display_names.get(pid, pid[:8])
                 )
+                display_name = self._sanitize_public_peer_label(display_name)
                 introduced.append({
                     'peer_id': pid,
                     'display_name': display_name,
+                    'peer_label': display_name,
+                    'instance_label': display_name,
                     'endpoints': endpoints,
                     'ed25519_public_key': base58.b58encode(identity.ed25519_public_key).decode(),
                     'x25519_public_key': base58.b58encode(identity.x25519_public_key).decode(),
@@ -2394,9 +3038,12 @@ class P2PNetworkManager:
                 if device_profile and device_profile.get('display_name')
                 else self.identity_manager.peer_display_names.get(new_peer_id, new_peer_id[:8])
             )
+            display_name = self._sanitize_public_peer_label(display_name)
             new_peer_info = [{
                 'peer_id': new_peer_id,
                 'display_name': display_name,
+                'peer_label': display_name,
+                'instance_label': display_name,
                 'endpoints': endpoints,
                 'ed25519_public_key': base58.b58encode(identity.ed25519_public_key).decode(),
                 'x25519_public_key': base58.b58encode(identity.x25519_public_key).decode(),
@@ -2455,6 +3102,13 @@ class P2PNetworkManager:
             # Preserve prior metadata when possible, then overlay latest data.
             cleaned = dict(existing) if isinstance(existing, dict) else {}
             cleaned.update(dict(p))
+            public_hint = self._remember_peer_public_identity_hint(
+                pid,
+                cleaned,
+                source='announcement',
+            )
+            if public_hint.get('display_name') and not cleaned.get('display_name'):
+                cleaned['display_name'] = public_hint['display_name']
             cleaned['endpoints'] = endpoints
             cleaned['introduced_by'] = from_peer
             cleaned['capabilities'] = self._normalize_capability_items(cleaned.get('capabilities'))
@@ -2633,6 +3287,15 @@ class P2PNetworkManager:
         if hasattr(self, '_introduced_peers'):
             introduced = self._introduced_peers.get(clean_peer_id) or {}
 
+        device_profile: Dict[str, Any] = {}
+        if callable(getattr(self, 'get_peer_device_profile', None)):
+            try:
+                stored_profile = self.get_peer_device_profile(clean_peer_id)
+            except Exception:
+                stored_profile = None
+            if isinstance(stored_profile, dict):
+                device_profile = dict(stored_profile)
+
         node_name = ''
         if isinstance(introduced, dict):
             node_name = str(introduced.get('display_name') or '').strip()
@@ -2650,6 +3313,11 @@ class P2PNetworkManager:
                 result['source'] = 'identity'
 
         if not node_name:
+            node_name = str(device_profile.get('display_name') or '').strip()
+            if node_name:
+                result['source'] = 'profile'
+
+        if not node_name:
             node_name = clean_peer_id[:12]
 
         result['node_name'] = node_name
@@ -2661,7 +3329,11 @@ class P2PNetworkManager:
             initials = (node_name[:2] or clean_peer_id[:2]).upper()
         result['avatar_initials'] = initials
 
-        # Intentionally keep avatar_b64/avatar_mime unset pre-trust.
+        avatar_b64 = str(device_profile.get('avatar_b64') or '').strip()
+        if avatar_b64:
+            result['avatar_b64'] = avatar_b64
+            result['avatar_mime'] = str(device_profile.get('avatar_mime') or 'image/png').strip() or 'image/png'
+
         return result
 
     # ------------------------------------------------------------------ #
@@ -2822,6 +3494,16 @@ class P2PNetworkManager:
             )
             return
 
+        if self._peer_requires_manual_cross_mesh(target_peer):
+            detail = self._cross_mesh_reconnect_detail(target_peer)
+            logger.warning(
+                "Declining relay offer from %s for %s: %s",
+                relay_peer,
+                target_peer,
+                detail,
+            )
+            return
+
         logger.info(f"Accepted relay offer from {relay_peer} for {target_peer}")
         self.message_router.update_routing_table(target_peer, relay_peer)
         self._active_relays[target_peer] = relay_peer
@@ -2970,6 +3652,15 @@ class P2PNetworkManager:
             to_remove = [dest for dest, relay in self._active_relays.items() if relay == peer_id]
             for dest in to_remove:
                 del self._active_relays[dest]
+
+        # A peer that requires explicit cross-mesh approval should not be
+        # re-entered into the automatic reconnect loop on disconnect cleanup.
+        if self._peer_requires_manual_cross_mesh(peer_id):
+            logger.debug(
+                "Peer %s disconnected - skipping auto-reconnect because cross-mesh approval is required",
+                peer_id,
+            )
+            return
 
         # If a reconnect loop is already scheduled/running for this peer,
         # don't restart it (that resets backoff and can cause thrash).
@@ -4982,7 +5673,9 @@ class P2PNetworkManager:
         except Exception as e:
             logger.debug(f"Post-connect key retry for {peer_id} failed: {e}")
 
-    PERIODIC_CATCHUP_INTERVAL = 180  # seconds (3 minutes)
+    PERIODIC_CATCHUP_INITIAL_DELAY = 20  # seconds
+    PERIODIC_CATCHUP_INTERVAL = 90  # seconds
+    PERIODIC_CATCHUP_PEER_STAGGER = 0.75  # seconds
 
     async def _periodic_catchup_loop(self) -> None:
         """Periodically send catch-up requests to all connected peers.
@@ -4993,7 +5686,7 @@ class P2PNetworkManager:
         catch-up only fires once; this loop provides ongoing repair.
         """
         # Initial delay — let startup settle before first periodic run
-        await asyncio.sleep(60)
+        await asyncio.sleep(self.PERIODIC_CATCHUP_INITIAL_DELAY)
 
         while self._running:
             try:
@@ -5016,7 +5709,7 @@ class P2PNetworkManager:
                             logger.debug(f"Periodic catchup to {peer_id} "
                                          f"failed: {per_err}")
                         # Small stagger between peers
-                        await asyncio.sleep(2)
+                        await asyncio.sleep(self.PERIODIC_CATCHUP_PEER_STAGGER)
             except Exception as e:
                 logger.error(f"Error in periodic catchup loop: {e}",
                              exc_info=True)

--- a/canopy/ui/routes.py
+++ b/canopy/ui/routes.py
@@ -52,6 +52,7 @@ from ..security.csrf import generate_csrf_token, validate_csrf_request
 from ..core.profile import (
     DEFAULT_AGENT_DIRECTIVE_PRESETS,
     MAX_AGENT_DIRECTIVES_LENGTH,
+    build_local_peer_hint_payload,
     get_default_agent_directives,
     normalize_agent_directives,
 )
@@ -83,6 +84,7 @@ from ..core.messaging import (
     build_dm_security_summary,
     build_dm_preview,
     compute_group_id,
+    compute_group_thread_id,
     filter_local_dm_targets,
 )
 from ..core.large_attachments import (
@@ -100,6 +102,7 @@ from ..core.large_attachments import (
     set_large_attachment_settings,
 )
 from ..core.meshspaces import (
+    apply_meshspace_record_to_config,
     build_meshspace_notification_summary,
     build_meshspace_shell_summary,
     build_runtime_environment_from_config,
@@ -146,6 +149,124 @@ def _current_meshspace_record() -> dict[str, Any]:
         'runtime_mode': str(getattr(mesh_cfg, 'runtime_mode', '') or ''),
         'status': 'running',
     }
+
+
+def _current_meshspace_hint_payload() -> dict[str, Any]:
+    record = _current_meshspace_record()
+    manager = _get_meshspace_registry_manager()
+    meshspace_id = str(record.get('meshspace_id') or '').strip()
+    meshspace_name = str(record.get('name') or '').strip()
+    avatar_preview: dict[str, str] = {}
+    if manager and meshspace_id:
+        try:
+            avatar_preview = manager.get_meshspace_avatar_preview(meshspace_id)
+        except Exception:
+            avatar_preview = {}
+    from ..network.invite import meshspace_fingerprint
+
+    return {
+        'meshspace_id': meshspace_id,
+        'meshspace_id_aliases': list(record.get('meshspace_id_aliases') or []),
+        'meshspace_name': meshspace_name,
+        'meshspace_fingerprint': meshspace_fingerprint(meshspace_id, meshspace_name),
+        'meshspace_avatar_b64': str(avatar_preview.get('avatar_b64') or '').strip(),
+        'meshspace_avatar_mime': str(avatar_preview.get('avatar_mime') or 'image/png').strip() or 'image/png',
+        'meshspace_avatar_url': _meshspace_avatar_url(record) if record.get('avatar_path') else '',
+    }
+
+
+def _current_local_peer_hint_payload(
+    db_manager: Any,
+    profile_manager: Any,
+    *,
+    fallback_device_label: str = '',
+    device_profile: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    return build_local_peer_hint_payload(
+        db_manager,
+        profile_manager,
+        fallback_device_label=fallback_device_label,
+        device_profile=device_profile,
+    )
+
+
+def _connection_identity_preview_payload(
+    mesh_hint: dict[str, Any],
+    peer_hint: dict[str, Any],
+) -> dict[str, Any]:
+    mesh_name = str(
+        mesh_hint.get('meshspace_name')
+        or mesh_hint.get('name')
+        or ''
+    ).strip() or 'Default Mesh'
+    meshspace_id = str(mesh_hint.get('meshspace_id') or '').strip()
+    return {
+        'peer_label': str(peer_hint.get('peer_label') or '').strip(),
+        'peer_avatar_url': str(peer_hint.get('peer_avatar_url') or '').strip(),
+        'peer_icon': str(peer_hint.get('peer_icon') or '').strip(),
+        'instance_label': str(peer_hint.get('instance_label') or '').strip(),
+        'instance_description': str(peer_hint.get('instance_description') or '').strip(),
+        'instance_icon': str(peer_hint.get('instance_icon') or '').strip(),
+        'mesh_name': mesh_name,
+        'meshspace_id': meshspace_id,
+        'mesh_fingerprint': str(mesh_hint.get('meshspace_fingerprint') or '').strip(),
+        'mesh_avatar_url': str(
+            mesh_hint.get('meshspace_avatar_url')
+            or mesh_hint.get('avatar_url')
+            or ''
+        ).strip(),
+    }
+
+
+def _refresh_runtime_meshspace_advertisement(record: dict[str, Any]) -> None:
+    config = current_app.config.get('CANOPY_CONFIG')
+    if not config:
+        return
+    manager = _get_meshspace_registry_manager()
+    meshspace_id = str(record.get('meshspace_id') or '').strip()
+    avatar_preview: dict[str, str] = {}
+    if manager and meshspace_id:
+        try:
+            avatar_preview = manager.get_meshspace_avatar_preview(meshspace_id)
+        except Exception:
+            avatar_preview = {}
+    apply_meshspace_record_to_config(config, record, avatar_preview=avatar_preview)
+    p2p_manager = current_app.config.get('P2P_MANAGER')
+    connection_manager = getattr(p2p_manager, 'connection_manager', None) if p2p_manager else None
+    if connection_manager:
+        from ..network.invite import meshspace_fingerprint
+
+        connection_manager.local_meshspace_id = str(config.meshspace.meshspace_id or '').strip()
+        connection_manager.local_meshspace_id_aliases = list(getattr(config.meshspace, 'meshspace_id_aliases', []) or [])
+        connection_manager.local_meshspace_name = str(config.meshspace.name or '').strip()
+        connection_manager.local_meshspace_fingerprint = meshspace_fingerprint(
+            connection_manager.local_meshspace_id,
+            connection_manager.local_meshspace_name,
+        )
+        connection_manager.local_meshspace_avatar_b64 = str(getattr(config.meshspace, 'avatar_preview_b64', '') or '').strip()
+        connection_manager.local_meshspace_avatar_mime = str(getattr(config.meshspace, 'avatar_preview_mime', 'image/png') or 'image/png').strip() or 'image/png'
+
+
+def _current_invite_peer_label(
+    db_manager: Any,
+    *,
+    fallback_device_label: str = '',
+) -> str:
+    """Prefer the local owner display name for invite review, then device label."""
+    owner_user_id = ''
+    try:
+        owner_user_id = str(db_manager.get_instance_owner_user_id() or '').strip() if db_manager else ''
+    except Exception:
+        owner_user_id = ''
+    if owner_user_id and db_manager:
+        try:
+            owner = db_manager.get_user(owner_user_id) or {}
+            display_name = str(owner.get('display_name') or owner.get('username') or '').strip()
+            if display_name:
+                return display_name
+        except Exception:
+            pass
+    return str(fallback_device_label or '').strip()
 
 
 def _current_meshspace_default_agent_permissions() -> list[str]:
@@ -513,18 +634,29 @@ def _current_session_meshspace_attention() -> Optional[dict[str, int]]:
     current_user_id = str(session.get('user_id') or '').strip()
     if not current_user_id:
         return None
+    cache = getattr(g, '_current_session_meshspace_attention_cache', None)
+    if isinstance(cache, dict) and current_user_id in cache:
+        cached = cache.get(current_user_id)
+        return dict(cached) if isinstance(cached, dict) else cached
     try:
         db_manager, _, _, _, channel_manager, _, feed_manager, _, _, _, p2p_manager = _get_app_components_any(current_app)
     except Exception:
         return None
 
-    return build_meshspace_notification_summary(
+    attention = build_meshspace_notification_summary(
         db_manager,
         channel_manager,
         feed_manager,
         p2p_manager,
         current_user_id,
     )
+    if isinstance(attention, dict):
+        if not isinstance(cache, dict):
+            cache = {}
+            g._current_session_meshspace_attention_cache = cache
+        cache[current_user_id] = dict(attention)
+        return dict(attention)
+    return attention
 
 
 def _apply_meshspace_attention_overlay(
@@ -1325,6 +1457,10 @@ def create_ui_blueprint() -> Blueprint:
     def _compute_group_id(member_ids: list) -> str:
         """Create a stable group ID from a set of member IDs."""
         return compute_group_id(member_ids)
+
+    def _compute_group_thread_id(member_ids: list, thread_token: str) -> str:
+        """Create a stable group ID for one explicit same-member thread."""
+        return compute_group_thread_id(member_ids, thread_token)
 
     @ui.app_context_processor
     def inject_canopy_version():
@@ -2182,7 +2318,10 @@ def create_ui_blueprint() -> Blueprint:
         if is_group:
             if user_id != sender_id and user_id not in group_members:
                 return None
-            conversation_group = compute_group_id(group_members) if group_members else (raw_group_id or recipient_id)
+            if str(metadata.get('group_thread_id') or '').strip() and raw_group_id:
+                conversation_group = raw_group_id
+            else:
+                conversation_group = compute_group_id(group_members) if group_members else (raw_group_id or recipient_id)
             other_names = [
                 _bookmark_author_label(member_id, db_manager, profile_manager)
                 for member_id in group_members
@@ -3146,6 +3285,25 @@ def create_ui_blueprint() -> Blueprint:
                     """,
                     ('general', user_id),
                 )
+                try:
+                    public_channels = conn.execute(
+                        "SELECT id FROM channels "
+                        "WHERE channel_type = 'public' "
+                        "  AND COALESCE(privacy_mode, 'open') = 'open'"
+                    ).fetchall()
+                except Exception:
+                    # Backward compatibility for legacy schemas without privacy_mode.
+                    public_channels = conn.execute(
+                        "SELECT id FROM channels WHERE channel_type = 'public'"
+                    ).fetchall()
+                for (channel_id,) in public_channels:
+                    conn.execute(
+                        """
+                        INSERT OR IGNORE INTO channel_members (channel_id, user_id, role)
+                        VALUES (?, ?, 'member')
+                        """,
+                        (channel_id, user_id),
+                    )
                 if include_quarantine_admin:
                     conn.execute(
                         """
@@ -4639,15 +4797,22 @@ def create_ui_blueprint() -> Blueprint:
 
         def _group_thread_identity(meta: dict[str, Any], recipient_id: str) -> tuple[Optional[str], Optional[str], list[str], list[str]]:
             raw_group_id = str(meta.get('group_id') or '').strip()
+            group_thread_id = str(meta.get('group_thread_id') or '').strip()
             group_members = _normalize_members(meta.get('group_members'))
             alias_group_ids: list[str] = []
             if raw_group_id:
                 alias_group_ids.append(raw_group_id)
             if recipient_id.startswith('group:') and recipient_id not in alias_group_ids:
                 alias_group_ids.append(recipient_id)
+            if group_thread_id:
+                thread_alias = f"group-thread:{group_thread_id}"
+                if thread_alias not in alias_group_ids:
+                    alias_group_ids.append(thread_alias)
 
             canonical_group_key: Optional[str] = None
-            if group_members:
+            if group_thread_id and raw_group_id:
+                canonical_group_key = raw_group_id
+            elif group_members:
                 canonical_group_key = compute_group_id(group_members)
                 if canonical_group_key not in alias_group_ids:
                     alias_group_ids.append(canonical_group_key)
@@ -4728,6 +4893,26 @@ def create_ui_blueprint() -> Blueprint:
                 right_aliases.add(right_group_id)
             return bool(left_aliases and right_aliases and left_aliases.intersection(right_aliases))
 
+        def _group_thread_alias_tokens(thread: dict[str, Any]) -> list[str]:
+            aliases: list[str] = []
+            for raw in (thread.get('alias_group_ids') or []):
+                token = str(raw or '').strip()
+                if token and token not in aliases:
+                    aliases.append(token)
+            for field in ('group_id', 'canonical_group_key'):
+                token = str(thread.get(field) or '').strip()
+                if token and token not in aliases:
+                    aliases.append(token)
+            return aliases
+
+        def _merge_unique_values(existing: Any, additions: Any) -> list[str]:
+            values: list[str] = []
+            for raw in list(existing or []) + list(additions or []):
+                token = str(raw or '').strip()
+                if token and token not in values:
+                    values.append(token)
+            return values
+
         def _format_thread_title(thread: dict[str, Any]) -> tuple[str, str, list[dict[str, Any]]]:
             if thread.get('kind') == 'direct':
                 other = _user_display(thread.get('user_id')) or {'display_name': thread.get('user_id')}
@@ -4778,11 +4963,18 @@ def create_ui_blueprint() -> Blueprint:
         ]
 
         conversations_by_key: dict[str, dict[str, Any]] = {}
+        group_entry_alias_index: dict[str, str] = {}
         for message in all_dm_messages:
             thread = _classify_thread(message)
             if not thread:
                 continue
             thread_key = str(thread['key'])
+            if thread.get('kind') == 'group':
+                for alias in _group_thread_alias_tokens(thread):
+                    indexed_key = group_entry_alias_index.get(alias)
+                    if indexed_key and indexed_key in conversations_by_key:
+                        thread_key = indexed_key
+                        break
             attachments = (_message_meta(message).get('attachments') or [])
             entry = conversations_by_key.get(thread_key)
             if entry is None:
@@ -4807,6 +4999,26 @@ def create_ui_blueprint() -> Blueprint:
                     'member_ids': thread.get('member_ids') or [],
                 }
                 conversations_by_key[thread_key] = entry
+            elif entry.get('kind') == 'group' and thread.get('kind') == 'group':
+                entry['alias_group_ids'] = _merge_unique_values(
+                    entry.get('alias_group_ids') or [],
+                    thread.get('alias_group_ids') or [],
+                )
+                entry['member_ids'] = _merge_unique_values(
+                    entry.get('member_ids') or [],
+                    thread.get('member_ids') or [],
+                )
+                if not entry.get('group_id') and thread.get('group_id'):
+                    entry['group_id'] = thread.get('group_id')
+                if not entry.get('canonical_group_key') and thread.get('canonical_group_key'):
+                    entry['canonical_group_key'] = thread.get('canonical_group_key')
+                title, subtitle, preview_users = _format_thread_title(entry)
+                entry['title'] = title
+                entry['subtitle'] = subtitle
+                entry['preview_users'] = preview_users
+            if entry.get('kind') == 'group':
+                for alias in _group_thread_alias_tokens(entry):
+                    group_entry_alias_index[alias] = thread_key
             entry['message_count'] += 1
             entry['preview'] = build_dm_preview(getattr(message, 'content', ''), attachments) or 'Attachment'
             if message.created_at >= (entry.get('updated_dt') or datetime.min.replace(tzinfo=timezone.utc)):
@@ -5315,6 +5527,7 @@ def create_ui_blueprint() -> Blueprint:
 
                 display_name = ''
                 label_source = 'fallback'
+
                 if profile_name:
                     display_name = profile_name
                     label_source = 'profile'
@@ -5326,6 +5539,13 @@ def create_ui_blueprint() -> Blueprint:
                     label_source = 'identity'
                 else:
                     display_name = clean_peer_id[:12]
+
+                display_name_source_label = {
+                    'profile': 'Profile label',
+                    'announced': 'Announced label',
+                    'identity': 'Known label',
+                    'fallback': 'Fallback label',
+                }.get(label_source, 'Known label')
 
                 role_label, role_state = _infer_role(profile, public_identity, display_name)
                 endpoint_rows: list[dict[str, Any]] = []
@@ -5372,14 +5592,19 @@ def create_ui_blueprint() -> Blueprint:
                 needs_profile = not profile_name
                 needs_label = label_source == 'fallback'
                 attention_flags: list[str] = []
+
+                def _add_attention_flag(label: str) -> None:
+                    if label and label not in attention_flags:
+                        attention_flags.append(label)
+
                 if needs_profile:
-                    attention_flags.append('Needs profile')
-                if role_state == 'unknown':
-                    attention_flags.append('Role unknown')
+                    _add_attention_flag('Needs profile')
+                if role_state == 'unknown' and not needs_profile:
+                    _add_attention_flag('Role unknown')
                 if connection_state == 'stale':
-                    attention_flags.append('Stale')
+                    _add_attention_flag('Stale')
                 if connection_state in ('stale', 'introduced') and endpoint_count == 0:
-                    attention_flags.append('No endpoints')
+                    _add_attention_flag('No endpoints')
 
                 introduced_by_label = ''
                 if introduced_by:
@@ -5394,20 +5619,124 @@ def create_ui_blueprint() -> Blueprint:
                     except Exception:
                         score_value = 0
                 is_trusted = bool(score_value is not None and score_value >= 50)
+                sync_status: dict[str, Any] = {}
+                if p2p_manager and hasattr(p2p_manager, 'get_peer_sync_status'):
+                    try:
+                        sync_status = dict(p2p_manager.get_peer_sync_status(clean_peer_id) or {})
+                    except Exception:
+                        sync_status = {}
+                sync_preview_only = bool(sync_status.get('preview_only'))
+                sync_effective_scope = str(sync_status.get('effective_scope') or '').strip().lower()
+                sync_explicit_scope = str(sync_status.get('explicit_scope') or '').strip().lower()
+                sync_approved_at = str(sync_status.get('approved_at') or '').strip()
+                inherited_from_peer_id = str(sync_status.get('inherited_from_peer_id') or '').strip()
+                remote_meshspace_id = str(sync_status.get('remote_meshspace_id') or '').strip()
+                remote_meshspace_name = str(sync_status.get('remote_meshspace_name') or '').strip()
+                remote_meshspace_fingerprint = str(sync_status.get('remote_meshspace_fingerprint') or '').strip()
+                cross_mesh_status: dict[str, Any] = {}
+                if p2p_manager and hasattr(p2p_manager, 'get_peer_cross_mesh_status'):
+                    try:
+                        cross_mesh_status = dict(p2p_manager.get_peer_cross_mesh_status(clean_peer_id) or {})
+                    except Exception:
+                        cross_mesh_status = {}
+                mesh_relationship = str(cross_mesh_status.get('mesh_relationship') or 'unknown').strip()
+                mesh_review_required = bool(cross_mesh_status.get('requires_manual_confirmation'))
+                cross_mesh_allowed = bool(cross_mesh_status.get('cross_mesh_allowed'))
+                mesh_relationship_label = {
+                    'same_mesh_confirmed': 'Same mesh',
+                    'same_mesh_alias_confirmed': 'Same mesh alias',
+                    'mesh_mismatch_pending_review': 'Mesh review required',
+                    'cross_mesh_bridge_allowed': 'Cross-mesh bridge',
+                    'unknown': 'Mesh unknown',
+                }.get(mesh_relationship, 'Mesh unknown')
+                sync_scope_label = {
+                    'peer': 'Peer approved',
+                    'mesh': 'Mesh approved',
+                }.get(sync_effective_scope, 'Approval required')
+                mesh_label = remote_meshspace_name or remote_meshspace_id or 'unknown mesh'
+                if sync_preview_only:
+                    sync_status_note = (
+                        f"Preview only. {mesh_label} can be reviewed, but channels and history stay paused until you approve sync."
+                    )
+                elif sync_effective_scope == 'mesh':
+                    sync_status_note = f"Sync is allowed for peers from {mesh_label}."
+                else:
+                    sync_status_note = "Sync is allowed for this peer."
 
                 connection_sort = {'live': 0, 'known': 1, 'introduced': 2, 'stale': 3}.get(connection_state, 4)
+                if profile_name:
+                    identity_status_label = 'Profile verified'
+                    identity_status_note = 'Device profile is available.'
+                    identity_status_class = 'identity-verified'
+                elif needs_label:
+                    identity_status_label = 'Only peer ID available'
+                    identity_status_note = 'No recognizable peer name has been learned yet.'
+                    identity_status_class = 'identity-incomplete'
+                else:
+                    identity_status_label = 'Unverified label'
+                    identity_status_note = f"{display_name_source_label} before trust."
+                    identity_status_class = 'identity-unverified'
+
+                if mesh_review_required:
+                    review_gate_label = 'Mesh review required'
+                    review_gate_note = 'Resolve same-mesh vs bridge before sync.'
+                    review_gate_class = 'review-blocked'
+                elif sync_preview_only:
+                    review_gate_label = 'Sync approval required'
+                    review_gate_note = 'History stays paused until approved.'
+                    review_gate_class = 'review-pending'
+                elif score_value is None:
+                    review_gate_label = 'Assign trust tier'
+                    review_gate_note = 'Choose Safe, Guarded, Restricted, or Quarantine.'
+                    review_gate_class = 'review-pending'
+                else:
+                    review_gate_label = 'Trust tier assigned'
+                    review_gate_note = sync_status_note
+                    review_gate_class = 'review-clear'
+
+                requires_review_attention = bool(
+                    needs_profile
+                    or role_state == 'unknown'
+                    or connection_state == 'stale'
+                    or mesh_review_required
+                    or sync_preview_only
+                )
+                connection_summary_note = active_endpoint or connection_note
+                review_summary = [
+                    {
+                        'label': 'Connection',
+                        'value': connection_label,
+                        'note': connection_summary_note,
+                        'class_name': f'connection-{connection_state}',
+                    },
+                    {
+                        'label': 'Review gate',
+                        'value': review_gate_label,
+                        'note': review_gate_note,
+                        'class_name': review_gate_class,
+                    },
+                    {
+                        'label': 'Identity',
+                        'value': identity_status_label,
+                        'note': identity_status_note,
+                        'class_name': identity_status_class,
+                    },
+                ]
+
                 return {
                     'peer_id': clean_peer_id,
                     'short_id': f'{clean_peer_id[:12]}...',
                     'display_name': display_name,
                     'description': str(_profile_value(profile, 'description', '') or '').strip(),
                     'display_name_source': label_source,
-                    'display_name_source_label': {
-                        'profile': 'Profile label',
-                        'announced': 'Announced label',
-                        'identity': 'Known label',
-                        'fallback': 'Fallback label',
-                    }.get(label_source, 'Known label'),
+                    'display_name_source_label': display_name_source_label,
+                    'identity_status_label': identity_status_label,
+                    'identity_status_note': identity_status_note,
+                    'identity_status_class': identity_status_class,
+                    'review_gate_label': review_gate_label,
+                    'review_gate_note': review_gate_note,
+                    'review_gate_class': review_gate_class,
+                    'review_summary': review_summary,
                     'avatar_b64': _profile_value(profile, 'avatar_b64', ''),
                     'avatar_mime': _profile_value(profile, 'avatar_mime', 'image/png'),
                     'public_avatar_color': str(public_identity.get('avatar_color') or '').strip(),
@@ -5415,7 +5744,11 @@ def create_ui_blueprint() -> Blueprint:
                     'connected': clean_peer_id in connected_set,
                     'can_connect_now': clean_peer_id in introduced_map and endpoint_count > 0,
                     'can_reconnect': bool(endpoint_count) and clean_peer_id not in connected_set,
-                    'can_sync_now': clean_peer_id in connected_set,
+                    'can_sync_now': clean_peer_id in connected_set and not sync_preview_only,
+                    'can_allow_sync': sync_preview_only,
+                    'can_allow_mesh_sync': bool(sync_preview_only and (remote_meshspace_id or remote_meshspace_fingerprint)),
+                    'can_treat_same_mesh': mesh_review_required,
+                    'can_keep_bridge': mesh_review_required and not cross_mesh_allowed,
                     'can_refresh_profile': bool(
                         p2p_manager
                         and hasattr(p2p_manager, 'recover_peer_profile_state')
@@ -5435,10 +5768,27 @@ def create_ui_blueprint() -> Blueprint:
                     'introduced_by_label': introduced_by_label,
                     'needs_profile': needs_profile,
                     'needs_label': needs_label,
+                    'requires_review_attention': requires_review_attention,
                     'attention_flags': attention_flags,
                     'has_profile': bool(profile_name),
                     'is_unverified': bool(public_identity.get('unverified')),
                     'public_identity': public_identity,
+                    'sync_preview_only': sync_preview_only,
+                    'sync_effective_scope': sync_effective_scope,
+                    'sync_explicit_scope': sync_explicit_scope,
+                    'sync_approved_at': sync_approved_at,
+                    'sync_scope_label': sync_scope_label,
+                    'sync_status_note': sync_status_note,
+                    'sync_status_class': 'preview' if sync_preview_only else ('mesh' if sync_effective_scope == 'mesh' else 'peer'),
+                    'remote_meshspace_id': remote_meshspace_id,
+                    'remote_meshspace_name': remote_meshspace_name,
+                    'remote_meshspace_fingerprint': remote_meshspace_fingerprint,
+                    'cross_mesh_status': cross_mesh_status,
+                    'mesh_relationship': mesh_relationship,
+                    'mesh_relationship_label': mesh_relationship_label,
+                    'mesh_review_required': mesh_review_required,
+                    'cross_mesh_allowed': cross_mesh_allowed,
+                    'inherited_from_peer_id': inherited_from_peer_id,
                 }
 
             # Build tiered trust buckets for UI
@@ -5506,7 +5856,7 @@ def create_ui_blueprint() -> Blueprint:
 
             attention_peers = [
                 peer for peer in peer_index.values()
-                if peer.get('needs_profile') or peer.get('role_state') == 'unknown' or peer.get('connection_state') == 'stale'
+                if peer.get('requires_review_attention')
             ]
             attention_peers.sort(key=lambda peer: (peer['connection_sort'], str(peer.get('display_name') or '').lower()))
 
@@ -5533,6 +5883,7 @@ def create_ui_blueprint() -> Blueprint:
                                  connected_peer_cards=connected_peer_cards,
                                  attention_peers=attention_peers,
                                  trust_overview=trust_overview,
+                                 is_admin=_is_admin(),
                                  user_id=get_current_user())
                                  
         except Exception as e:
@@ -5545,6 +5896,8 @@ def create_ui_blueprint() -> Blueprint:
     def trust_update():
         """Update trust score directly (manual tier adjustment)."""
         try:
+            if not _is_admin():
+                return jsonify({'error': 'Only the instance admin can change trust tiers.'}), 403
             _, _, trust_manager, _, _, _, _, _, _, _, p2p_manager = _get_app_components_any(current_app)
             if not trust_manager:
                 return jsonify({'error': 'Trust manager not available'}), 500
@@ -5637,8 +5990,15 @@ def create_ui_blueprint() -> Blueprint:
                         continue
                     host, port, scheme = parsed
                     try:
+                        connect_to_endpoint = getattr(type(p2p_manager), '_connect_to_endpoint', None)
+                        if callable(connect_to_endpoint):
+                            connect_coro = connect_to_endpoint(p2p_manager, peer_id, ep)
+                        else:
+                            connect_coro = connection_manager.connect_to_peer(
+                                peer_id, host, port, scheme=scheme
+                            )
                         future = asyncio.run_coroutine_threadsafe(
-                            connection_manager.connect_to_peer(peer_id, host, port, scheme=scheme),
+                            connect_coro,
                             ev_loop,
                         )
                         connected = future.result(timeout=10.0)
@@ -5659,6 +6019,73 @@ def create_ui_blueprint() -> Blueprint:
                         return True, ep
                 return False, 'Could not connect to any endpoint'
 
+            def _disconnect_peer(detail: str) -> tuple[bool, Optional[str]]:
+                connection_manager = getattr(p2p_manager, 'connection_manager', None)
+                ev_loop = getattr(p2p_manager, '_event_loop', None)
+                if not connection_manager or not hasattr(connection_manager, 'disconnect_peer'):
+                    return False, 'P2P connection manager unavailable'
+                if not ev_loop or ev_loop.is_closed():
+                    return False, 'P2P event loop unavailable'
+                try:
+                    future = asyncio.run_coroutine_threadsafe(
+                        connection_manager.disconnect_peer(peer_id),
+                        ev_loop,
+                    )
+                    future.result(timeout=10.0)
+                    try:
+                        _record_connection_event(
+                            p2p_manager,
+                            peer_id,
+                            status='disconnected',
+                            detail=detail,
+                        )
+                    except Exception:
+                        pass
+                    return True, None
+                except Exception as disconnect_err:
+                    logger.warning("Trust peer action disconnect failed for %s: %s", peer_id, disconnect_err)
+                    return False, str(disconnect_err)
+
+            def _candidate_refresh_endpoints() -> list[str]:
+                endpoints: list[str] = []
+                connection_manager = getattr(p2p_manager, 'connection_manager', None)
+                get_connection = getattr(connection_manager, 'get_connection', None)
+                if callable(get_connection):
+                    try:
+                        conn = get_connection(peer_id)
+                    except Exception:
+                        conn = None
+                    endpoint_uri = str(getattr(conn, 'endpoint_uri', '') or '').strip() if conn else ''
+                    if endpoint_uri:
+                        endpoints.append(endpoint_uri)
+                get_endpoint_diagnostics = getattr(p2p_manager, 'get_peer_endpoint_diagnostics', None)
+                if callable(get_endpoint_diagnostics):
+                    try:
+                        for row in list(get_endpoint_diagnostics(peer_id) or []):
+                            endpoint = str((row or {}).get('endpoint') or '').strip()
+                            if endpoint:
+                                endpoints.append(endpoint)
+                    except Exception:
+                        pass
+                identity_manager = getattr(p2p_manager, 'identity_manager', None)
+                for endpoint in list((getattr(identity_manager, 'peer_endpoints', {}) or {}).get(peer_id, []) or []):
+                    clean = str(endpoint or '').strip()
+                    if clean:
+                        endpoints.append(clean)
+                intro = (getattr(p2p_manager, '_introduced_peers', {}) or {}).get(peer_id) or {}
+                for endpoint in list(intro.get('endpoints') or []):
+                    clean = str(endpoint or '').strip()
+                    if clean:
+                        endpoints.append(clean)
+                deduped: list[str] = []
+                seen: set[str] = set()
+                for endpoint in endpoints:
+                    if endpoint in seen:
+                        continue
+                    seen.add(endpoint)
+                    deduped.append(endpoint)
+                return deduped
+
             if action == 'sync_now':
                 trigger_sync = getattr(p2p_manager, 'trigger_peer_sync', None)
                 if not callable(trigger_sync):
@@ -5667,12 +6094,118 @@ def create_ui_blueprint() -> Blueprint:
                     return jsonify({'error': 'Failed to trigger sync'}), 502
                 return jsonify({'success': True, 'peer_id': peer_id, 'action': action, 'message': 'Peer sync triggered.'})
 
+            if action in {'treat_same_mesh', 'keep_cross_mesh_bridge'}:
+                if not _is_admin():
+                    return jsonify({'error': 'Only the instance admin can resolve mesh identity relationships.'}), 403
+                if action == 'treat_same_mesh':
+                    mark_same = getattr(p2p_manager, 'mark_peer_meshspace_equivalent', None)
+                    if not callable(mark_same):
+                        return jsonify({'error': 'Mesh alias reconciliation unavailable'}), 500
+                    status = dict(mark_same(peer_id) or {})
+                    return jsonify({
+                        'success': True,
+                        'peer_id': peer_id,
+                        'action': action,
+                        'cross_mesh': status,
+                        'message': 'Remote mesh ID saved as a compatibility alias for this mesh.',
+                    })
+                mark_bridge = getattr(p2p_manager, 'mark_peer_cross_mesh_allowed', None)
+                get_status = getattr(p2p_manager, 'get_peer_cross_mesh_status', None)
+                if not callable(mark_bridge):
+                    return jsonify({'error': 'Cross-mesh bridge approval unavailable'}), 500
+                mark_bridge(peer_id, True)
+                status = dict(get_status(peer_id) or {}) if callable(get_status) else {}
+                return jsonify({
+                    'success': True,
+                    'peer_id': peer_id,
+                    'action': action,
+                    'cross_mesh': status,
+                    'message': 'Peer kept as an intentional cross-mesh bridge. No mesh aliases were created.',
+                })
+
+            if action in {'allow_sync', 'allow_mesh_sync'}:
+                if not _is_admin():
+                    return jsonify({'error': 'Only the instance admin can approve peer sync.'}), 403
+                approve_sync = getattr(p2p_manager, 'approve_peer_sync', None)
+                get_sync_status = getattr(p2p_manager, 'get_peer_sync_status', None)
+                trigger_sync = getattr(p2p_manager, 'trigger_peer_sync', None)
+                if not callable(approve_sync) or not callable(get_sync_status):
+                    return jsonify({'error': 'Peer sync approval unavailable'}), 500
+                current_sync_status = dict(get_sync_status(peer_id) or {})
+                if action == 'allow_mesh_sync' and not (
+                    str(current_sync_status.get('remote_meshspace_id') or '').strip()
+                    or str(current_sync_status.get('remote_meshspace_fingerprint') or '').strip()
+                ):
+                    return jsonify({'error': 'This peer has not advertised a stable meshspace identity yet.'}), 400
+                scope = 'mesh' if action == 'allow_mesh_sync' else 'peer'
+                sync_status = dict(approve_sync(peer_id, scope=scope) or {})
+                sync_started = False
+                if callable(trigger_sync):
+                    try:
+                        sync_started = bool(trigger_sync(peer_id))
+                    except Exception:
+                        sync_started = False
+                mesh_name = str(
+                    sync_status.get('remote_meshspace_name')
+                    or sync_status.get('remote_meshspace_id')
+                    or 'that meshspace'
+                ).strip()
+                if scope == 'mesh':
+                    message = f"Sync approved for peers from {mesh_name}."
+                else:
+                    message = 'Sync approved for this peer.'
+                if sync_started:
+                    message += ' Bootstrap sync started.'
+                return jsonify({
+                    'success': True,
+                    'peer_id': peer_id,
+                    'action': action,
+                    'sync_status': sync_status,
+                    'sync_started': sync_started,
+                    'message': message,
+                })
+
             if action == 'refresh_profile':
                 clear_cache = getattr(p2p_manager, 'clear_peer_profile_cache', None)
                 recover = getattr(p2p_manager, 'recover_peer_profile_state', None)
+                get_sync_status = getattr(p2p_manager, 'get_peer_sync_status', None)
                 if not callable(clear_cache) or not callable(recover):
                     return jsonify({'error': 'Profile refresh unavailable'}), 500
                 cache_result = clear_cache(peer_id)
+                sync_status = dict(get_sync_status(peer_id) or {}) if callable(get_sync_status) else {}
+                preview_only = bool(sync_status.get('preview_only'))
+                if preview_only:
+                    endpoints = _candidate_refresh_endpoints()
+                    connection_manager = getattr(p2p_manager, 'connection_manager', None)
+                    get_connection = getattr(connection_manager, 'get_connection', None)
+                    currently_connected = bool(callable(get_connection) and get_connection(peer_id))
+                    if currently_connected:
+                        disconnected, disconnect_error = _disconnect_peer('Preview identity refresh reconnect')
+                        if not disconnected:
+                            return jsonify({'error': str(disconnect_error or 'Could not disconnect peer for preview refresh')}), 502
+                    if not endpoints:
+                        return jsonify({
+                            'success': True,
+                            'peer_id': peer_id,
+                            'action': action,
+                            'cache_result': cache_result,
+                            'preview_only': True,
+                            'profile_recovery': {'ok': True, 'recovered_user_count': 0, 'skipped_untrusted': [peer_id]},
+                            'message': 'Cached identity hints were cleared, but this peer has no reusable endpoint for a preview refresh yet.',
+                        })
+                    refreshed, detail = _connect_via_endpoints(endpoints, 'Preview identity refresh reconnected peer')
+                    if not refreshed:
+                        return jsonify({'error': str(detail or 'Preview identity refresh failed')}), 502
+                    return jsonify({
+                        'success': True,
+                        'peer_id': peer_id,
+                        'action': action,
+                        'cache_result': cache_result,
+                        'preview_only': True,
+                        'endpoint': detail,
+                        'profile_recovery': {'ok': True, 'recovered_user_count': 0, 'skipped_untrusted': [peer_id]},
+                        'message': 'Preview identity refresh requested. The peer was reconnected so fresh label and avatar hints can be learned without approving sync.',
+                    })
                 recovery = recover(peer_id, trigger_sync=True)
                 skipped_untrusted = list((recovery or {}).get('skipped_untrusted') or [])
                 message = 'Profile refresh requested.'
@@ -6669,7 +7202,7 @@ def create_ui_blueprint() -> Blueprint:
     def channels():
         """Slack-style channel interface for real-time messaging."""
         try:
-            db_manager, _, _, _, channel_manager, _, _, _, _, config, p2p_manager = _get_app_components_any(current_app)
+            db_manager, _, trust_manager, _, channel_manager, _, _, _, _, config, p2p_manager = _get_app_components_any(current_app)
             from ..core.polls import poll_edit_window_seconds
             user_id = get_current_user()
             workspace_event_manager = current_app.config.get('WORKSPACE_EVENT_MANAGER')
@@ -6742,15 +7275,35 @@ def create_ui_blueprint() -> Blueprint:
     def settings():
         """Application settings and configuration."""
         try:
-            db_manager, _, _, _, _, _, _, _, _, config, _ = _get_app_components_any(current_app)
+            db_manager, _, _, _, _, _, _, _, profile_manager, config, _ = _get_app_components_any(current_app)
             user_id = get_current_user()
             from .. import __version__ as canopy_version
+            from ..core.device import DEVICE_PROFILE_ICON_CHOICES, get_device_label, get_device_profile
             
             # Get database statistics
             db_stats = db_manager.get_database_stats()
             # Env-only options (read-only in UI; document in Settings)
             auto_approve_raw = (os.getenv('CANOPY_AUTO_APPROVE_AGENTS') or '').strip().lower()
             auto_approve_agents = auto_approve_raw in ('1', 'true', 'yes')
+            device_profile = {}
+            fallback_device_label = str(getattr(config, 'device_label', '') or '').strip()
+            try:
+                device_profile = get_device_profile() or {}
+                if not fallback_device_label:
+                    fallback_device_label = str(get_device_label() or '').strip()
+            except Exception:
+                device_profile = {}
+            current_local_peer_hint = _current_local_peer_hint_payload(
+                db_manager,
+                profile_manager,
+                fallback_device_label=fallback_device_label,
+                device_profile=device_profile,
+            )
+            current_mesh_hint = _current_meshspace_hint_payload()
+            connection_identity_preview = _connection_identity_preview_payload(
+                current_mesh_hint,
+                current_local_peer_hint,
+            )
             return render_template('settings.html',
                                  config=config.to_dict(),
                                  db_stats=db_stats,
@@ -6760,7 +7313,11 @@ def create_ui_blueprint() -> Blueprint:
                                  large_attachment_threshold_mb=int(LARGE_ATTACHMENT_THRESHOLD / 1024 / 1024),
                                  large_attachment_store_root=get_large_attachment_store_root(db_manager),
                                  large_attachment_download_mode=get_large_attachment_download_mode(db_manager),
-                                 is_admin=_is_admin())
+                                 is_admin=_is_admin(),
+                                 device_icon_choices=DEVICE_PROFILE_ICON_CHOICES,
+                                 current_local_peer_hint=current_local_peer_hint,
+                                 current_mesh_hint=current_mesh_hint,
+                                 connection_identity_preview=connection_identity_preview)
                                  
         except Exception as e:
             logger.error(f"Settings error: {e}")
@@ -7152,10 +7709,57 @@ def create_ui_blueprint() -> Blueprint:
         item['launch_env'] = manager.launch_environment(item.get('meshspace_id')) or {}
         item['data_dir_exists'] = Path(str(item.get('data_dir') or '')).exists()
         item['database_exists'] = Path(str(item.get('database_path') or '')).exists()
+        port_status = str(item.get('status') or '').strip().lower()
+        item['can_update_ports'] = bool(
+            not item.get('is_current')
+            and not item.get('live_detected')
+            and port_status in {'defined', 'stopped', 'crashed', 'degraded'}
+        )
+        if item.get('is_current'):
+            item['port_update_blocked_reason'] = 'This is the currently running mesh. Stop or manage it from another supervisor before changing ports.'
+        elif item.get('live_detected'):
+            item['port_update_blocked_reason'] = 'Stop this mesh before changing its port block.'
+        elif port_status not in {'defined', 'stopped', 'crashed', 'degraded'}:
+            item['port_update_blocked_reason'] = f"Ports cannot be changed while this mesh is {port_status or 'in transition'}."
+        else:
+            item['port_update_blocked_reason'] = ''
+        from ..core.device import get_device_label, get_device_profile
+        from ..network.invite import meshspace_fingerprint
+
+        db_manager = current_app.config.get('DB_MANAGER')
+        profile_manager = current_app.config.get('PROFILE_MANAGER')
+        device_profile = {}
+        fallback_device_label = str(getattr(config, 'device_label', '') or '').strip()
+        try:
+            device_profile = get_device_profile() or {}
+            if not fallback_device_label:
+                fallback_device_label = str(get_device_label() or '').strip()
+        except Exception:
+            device_profile = {}
+        current_local_peer_hint = _current_local_peer_hint_payload(
+            db_manager,
+            profile_manager,
+            fallback_device_label=fallback_device_label,
+            device_profile=device_profile,
+        )
+        mesh_hint = {
+            'meshspace_id': str(item.get('meshspace_id') or '').strip(),
+            'meshspace_name': str(item.get('name') or '').strip(),
+            'meshspace_fingerprint': meshspace_fingerprint(
+                str(item.get('meshspace_id') or '').strip(),
+                str(item.get('name') or '').strip(),
+            ),
+            'meshspace_avatar_url': str(item.get('avatar_url') or '').strip(),
+        }
         return render_template(
             'meshspace_detail.html',
             meshspace=item,
             is_admin=True,
+            current_local_peer_hint=current_local_peer_hint,
+            connection_identity_preview=_connection_identity_preview_payload(
+                mesh_hint,
+                current_local_peer_hint,
+            ),
         )
 
     @ui.route('/meshes/<meshspace_id>/open')
@@ -7284,10 +7888,120 @@ def create_ui_blueprint() -> Blueprint:
         config = current_app.config.get('CANOPY_CONFIG')
         current_meshspace_id = str(getattr(getattr(config, 'meshspace', None), 'meshspace_id', '') or '')
         if meshspace_id == current_meshspace_id:
-            config.meshspace.name = str(record.get('name') or config.meshspace.name)
-            config.meshspace.description = str(record.get('description') or '')
+            _refresh_runtime_meshspace_advertisement(record)
             current_app.config['MESHSPACE_RECORD'] = dict(record)
         flash(f"Updated meshspace '{record.get('name')}'.", 'success')
+        return redirect(url_for('ui.meshspace_detail', meshspace_id=meshspace_id))
+
+    @ui.route('/meshes/<meshspace_id>/ports', methods=['POST'])
+    @require_login
+    def meshspace_ports(meshspace_id: str):
+        """Update the stopped meshspace runtime port block."""
+        if not _is_admin():
+            flash('Only the instance admin can change meshspace ports.', 'warning')
+            return redirect(url_for('ui.dashboard'))
+        manager = _get_meshspace_registry_manager()
+        if not manager:
+            flash('Meshspace registry is unavailable.', 'error')
+            return redirect(url_for('ui.meshes_home'))
+        raw_http_port = str(request.form.get('http_port') or '').strip()
+        try:
+            record = manager.update_meshspace_ports(meshspace_id, http_port=raw_http_port)
+        except ValueError as exc:
+            flash(str(exc), 'error')
+            return redirect(url_for('ui.meshspace_detail', meshspace_id=meshspace_id))
+        except Exception as exc:
+            logger.error("Meshspace port update failed for %s: %s", meshspace_id, exc, exc_info=True)
+            flash('Failed to update meshspace ports.', 'error')
+            return redirect(url_for('ui.meshspace_detail', meshspace_id=meshspace_id))
+        if not record:
+            flash('Meshspace not found.', 'error')
+            return redirect(url_for('ui.meshes_home'))
+        flash(
+            f"Updated '{record.get('name')}' to HTTP {record.get('http_port')}, "
+            f"mesh {record.get('mesh_port')}, discovery {record.get('discovery_port')}. "
+            "Restart the meshspace and share a fresh invite with peers that only know the old endpoint.",
+            'success',
+        )
+        return redirect(url_for('ui.meshspace_detail', meshspace_id=meshspace_id))
+
+    @ui.route('/meshes/<meshspace_id>/promote', methods=['POST'])
+    @require_login
+    def meshspace_promote(meshspace_id: str):
+        """Convert the current legacy-default mesh into an explicit stable identity."""
+        if not _is_admin():
+            flash('Only the instance admin can promote the current mesh identity.', 'warning')
+            return redirect(url_for('ui.dashboard'))
+        manager = _get_meshspace_registry_manager()
+        if not manager:
+            flash('Meshspace registry is unavailable.', 'error')
+            return redirect(url_for('ui.meshes_home'))
+        config = current_app.config.get('CANOPY_CONFIG')
+        current_mid = str(getattr(getattr(config, 'meshspace', None), 'meshspace_id', '') or '').strip()
+        if meshspace_id != current_mid:
+            flash('Only the current legacy mesh can be promoted from this page.', 'warning')
+            return redirect(url_for('ui.meshspace_detail', meshspace_id=meshspace_id))
+
+        target_meshspace_id = str(request.form.get('stable_meshspace_id') or '').strip()
+        target_name = str(request.form.get('stable_meshspace_name') or '').strip()
+        try:
+            promoted = manager.promote_legacy_meshspace(
+                meshspace_id,
+                new_meshspace_id=target_meshspace_id,
+                new_name=target_name or None,
+            )
+            if not promoted:
+                flash('Meshspace not found.', 'error')
+                return redirect(url_for('ui.meshes_home'))
+            _refresh_runtime_meshspace_advertisement(promoted)
+            config.meshspace.enabled = True
+            config.meshspace.data_root = str(promoted.get('data_dir') or config.storage.data_dir or '').strip()
+            config.meshspace.registry_root = str(getattr(config.meshspace, 'registry_root', '') or '').strip()
+            env_map = build_runtime_environment_from_config(config)
+            schedule_self_restart(
+                env_map,
+                cwd=str(Path(__file__).resolve().parents[2]),
+                parent_pid=os.getpid(),
+                delay_seconds=0.9,
+            )
+            peer_id = ''
+            p2p_manager = current_app.config.get('P2P_MANAGER')
+            if p2p_manager:
+                try:
+                    peer_id = str(p2p_manager.get_peer_id() or '').strip()
+                except Exception:
+                    peer_id = ''
+            updated = manager.update_runtime_state(
+                str(promoted.get('meshspace_id') or ''),
+                'starting',
+                peer_id=peer_id,
+            ) or promoted
+            _refresh_runtime_meshspace_advertisement(updated)
+            current_app.config['MESHSPACE_RECORD'] = dict(updated)
+
+            def _terminate_current_runtime() -> None:
+                time.sleep(0.45)
+                try:
+                    os.kill(os.getpid(), signal.SIGTERM)
+                except Exception:
+                    logger.warning("Failed to terminate current meshspace process during promotion", exc_info=True)
+
+            threading.Thread(target=_terminate_current_runtime, daemon=True).start()
+            return render_template(
+                'meshspace_restarting.html',
+                meshspace=_meshspace_card_payload(
+                    updated,
+                    str(updated.get('meshspace_id') or ''),
+                    manager,
+                ),
+                target_url=_meshspace_launch_url(updated, str(updated.get('meshspace_id') or '')),
+                is_admin=True,
+            )
+        except ValueError as exc:
+            flash(str(exc), 'error')
+        except Exception as exc:
+            logger.error("Failed to promote meshspace %s: %s", meshspace_id, exc, exc_info=True)
+            flash(f'Failed to promote mesh identity: {exc}', 'error')
         return redirect(url_for('ui.meshspace_detail', meshspace_id=meshspace_id))
 
     @ui.route('/meshes/<meshspace_id>/restart', methods=['POST'])
@@ -7747,18 +8461,51 @@ def create_ui_blueprint() -> Blueprint:
     def connect_page():
         """Peer connection and invite code page."""
         from ..network.invite import generate_invite, get_local_ips
+        from ..core.device import get_device_label, get_device_profile
         try:
-            _, _, _, _, _, _, _, _, _, config, p2p_manager = _get_app_components_any(current_app)
+            db_manager, _, trust_manager, _, channel_manager, _, _, _, profile_manager, config, p2p_manager = _get_app_components_any(current_app)
             user_id = get_current_user()
 
             invite_code = None
             peer_id = None
             endpoints = []
             local_ips = get_local_ips()
+            mesh_cfg = getattr(config, 'meshspace', None)
+            current_mesh_hint = _current_meshspace_hint_payload()
+            current_mesh_name = str(current_mesh_hint.get('meshspace_name') or getattr(mesh_cfg, 'name', '') or '').strip() or 'Default Mesh'
+            current_meshspace_id = str(current_mesh_hint.get('meshspace_id') or getattr(mesh_cfg, 'meshspace_id', '') or '').strip()
+            current_mesh_fingerprint = str(current_mesh_hint.get('meshspace_fingerprint') or '').strip()
+            current_instance_label = str(getattr(config, 'device_label', '') or '').strip()
+            device_profile = {}
+            try:
+                device_profile = get_device_profile() or {}
+                if not current_instance_label:
+                    current_instance_label = str(get_device_label() or '').strip()
+            except Exception:
+                device_profile = {}
+            current_local_peer_hint = _current_local_peer_hint_payload(
+                db_manager,
+                profile_manager,
+                fallback_device_label=current_instance_label,
+                device_profile=device_profile,
+            )
+            current_peer_label = str(current_local_peer_hint.get('peer_label') or '').strip()
+            current_peer_avatar_url = str(current_local_peer_hint.get('peer_avatar_url') or '').strip()
+            current_instance_label = str(current_local_peer_hint.get('instance_label') or '').strip()
 
             if p2p_manager and p2p_manager.identity_manager.local_identity:
                 mesh_port = config.network.mesh_port if config else 7771
-                invite = generate_invite(p2p_manager.identity_manager, mesh_port)
+                invite = generate_invite(
+                    p2p_manager.identity_manager,
+                    mesh_port,
+                    mesh_name=current_mesh_name,
+                    meshspace_id=current_meshspace_id or None,
+                    meshspace_id_aliases=list(current_mesh_hint.get('meshspace_id_aliases') or []) or None,
+                    meshspace_fingerprint_value=current_mesh_fingerprint or None,
+                    peer_label=current_peer_label or None,
+                    instance_label=current_instance_label or None,
+                    generated_at=datetime.now(timezone.utc).isoformat(),
+                )
                 invite_code = invite.encode()
                 peer_id = invite.peer_id
                 endpoints = invite.endpoints
@@ -7792,23 +8539,75 @@ def create_ui_blueprint() -> Blueprint:
                 for pid, identity in im.known_peers.items():
                     if identity.is_local():
                         continue
+                    meshspace_hint = (
+                        im.get_peer_meshspace_hint(pid)
+                        if hasattr(im, 'get_peer_meshspace_hint') else {}
+                    )
+                    cross_mesh_status = (
+                        p2p_manager.get_peer_cross_mesh_status(pid)
+                        if hasattr(p2p_manager, 'get_peer_cross_mesh_status') else {}
+                    )
+                    mesh_relationship = str((cross_mesh_status or {}).get('mesh_relationship') or 'unknown').strip()
+                    mesh_review_required = bool((cross_mesh_status or {}).get('requires_manual_confirmation'))
+                    cross_mesh_warning = ''
+                    if mesh_review_required:
+                        remote_name = str(
+                            (cross_mesh_status or {}).get('remote_meshspace_name')
+                            or (cross_mesh_status or {}).get('remote_meshspace_id')
+                            or (meshspace_hint or {}).get('meshspace_name')
+                            or 'another meshspace'
+                        )
+                        cross_mesh_warning = (
+                            f"This peer advertises meshspace '{remote_name}', "
+                            f"not '{current_mesh_name}'. Keep transport connected only while you review whether this is the same mesh or an intentional bridge."
+                        )
                     connection_type = 'offline'
                     if pid in connected_set:
                         connection_type = 'direct'
                     elif pid in relayed_set:
                         connection_type = 'relayed'
+                    public_identity = {}
+                    if hasattr(p2p_manager, 'get_peer_public_identity'):
+                        try:
+                            public_identity = dict(p2p_manager.get_peer_public_identity(pid) or {})
+                        except Exception:
+                            public_identity = {}
                     known_peers.append({
                         'peer_id': pid,
                         'display_name': im.peer_display_names.get(pid, ''),
+                        'public_identity': public_identity,
                         'endpoints': im.peer_endpoints.get(pid, []),
+                        'meshspace_hint': meshspace_hint,
+                        'cross_mesh_status': cross_mesh_status,
+                        'mesh_relationship': mesh_relationship,
+                        'mesh_review_required': mesh_review_required,
+                        'can_treat_same_mesh': mesh_review_required,
+                        'can_keep_bridge': mesh_review_required and not bool((cross_mesh_status or {}).get('cross_mesh_allowed')),
+                        'cross_mesh_warning': cross_mesh_warning,
                         'connected': connection_type in {'direct', 'relayed'},
                         'connection_type': connection_type,
                         'relay_via': active_relays.get(pid),
                     })
 
             # Device profiles for peer identification
-            _, _, trust_manager, _, channel_manager, _, _, _, _, _, _ = _get_app_components_any(current_app)
             peer_device_profiles = channel_manager.get_all_peer_device_profiles() if channel_manager else {}
+            peer_preview_profiles = {}
+            if peer_device_profiles:
+                for pid, dev in peer_device_profiles.items():
+                    if not pid or not dev:
+                        continue
+                    peer_preview_profiles[pid] = {
+                        'display_name': str(getattr(dev, 'display_name', '') or '').strip(),
+                        'avatar_b64': str(getattr(dev, 'avatar_b64', '') or '').strip(),
+                        'avatar_mime': str(getattr(dev, 'avatar_mime', '') or '').strip(),
+                        'icon': str(
+                            getattr(dev, 'icon', '')
+                            if not isinstance(dev, dict)
+                            else dev.get('icon', '')
+                        ).strip(),
+                    }
+            peer_mesh_hints = {}
+            peer_public_identities = {}
 
             # Trust scores for connected and known peers
             trust_scores = {}
@@ -7845,12 +8644,48 @@ def create_ui_blueprint() -> Blueprint:
                 pid = getattr(peer, 'peer_id', None)
                 if pid and pid not in peer_labels:
                     peer_labels[pid] = pid
+            for dest, relay in active_relays.items():
+                if dest and dest not in peer_labels:
+                    peer_labels[dest] = dest
+                if relay and relay not in peer_labels:
+                    peer_labels[relay] = relay
+            for peer in introduced_peers:
+                introducer = peer.get('introduced_by') if isinstance(peer, dict) else None
+                if introducer and introducer not in peer_labels:
+                    peer_labels[introducer] = introducer
+            if p2p_manager and hasattr(p2p_manager, 'identity_manager'):
+                im = p2p_manager.identity_manager
+                for pid in (set(peer_labels.keys()) | set(peer_preview_profiles.keys())):
+                    if not pid:
+                        continue
+                    if p2p_manager and hasattr(p2p_manager, 'get_peer_public_identity'):
+                        try:
+                            peer_public_identities[pid] = dict(p2p_manager.get_peer_public_identity(pid) or {})
+                        except Exception:
+                            pass
+                    try:
+                        hint = im.get_peer_meshspace_hint(pid) if hasattr(im, 'get_peer_meshspace_hint') else {}
+                    except Exception:
+                        hint = {}
+                    if isinstance(hint, dict) and hint:
+                        peer_mesh_hints[pid] = {
+                            'meshspace_avatar_b64': str(hint.get('meshspace_avatar_b64') or '').strip(),
+                            'meshspace_avatar_mime': str(hint.get('meshspace_avatar_mime') or '').strip(),
+                        }
 
             return render_template('connect.html',
                                  invite_code=invite_code,
                                  peer_id=peer_id,
                                  endpoints=endpoints,
                                  local_ips=local_ips,
+                                 current_mesh_name=current_mesh_name,
+                                 current_meshspace_id=current_meshspace_id,
+                                 current_meshspace_id_aliases=list(current_mesh_hint.get('meshspace_id_aliases') or []),
+                                 current_mesh_fingerprint=current_mesh_fingerprint,
+                                 current_mesh_avatar_url=str(current_mesh_hint.get('meshspace_avatar_url') or '').strip(),
+                                 current_peer_label=current_peer_label,
+                                 current_peer_avatar_url=current_peer_avatar_url,
+                                 current_instance_label=current_instance_label,
                                  mesh_port=config.network.mesh_port if config else 7771,
                                  connected_peers=connected_peers,
                                  discovered_peers=discovered_peers,
@@ -7860,6 +8695,9 @@ def create_ui_blueprint() -> Blueprint:
                                  peer_device_profiles=peer_device_profiles,
                                  trust_scores=trust_scores,
                                  peer_labels=peer_labels,
+                                 peer_preview_profiles=peer_preview_profiles,
+                                 peer_public_identities=peer_public_identities,
+                                 peer_mesh_hints=peer_mesh_hints,
                                  is_admin=_is_admin(),
                                  user_id=user_id)
         except Exception as e:
@@ -8473,6 +9311,11 @@ def create_ui_blueprint() -> Blueprint:
                 metadata['source_layout'] = normalized_source_layout
             if reply_to:
                 metadata['reply_to'] = reply_to
+            force_new_group = bool(
+                data.get('force_new_group')
+                or data.get('new_group_thread')
+                or data.get('start_new_group_thread')
+            )
 
             # Normalize recipients
             recipients_unique = []
@@ -8490,12 +9333,24 @@ def create_ui_blueprint() -> Blueprint:
             # Group DM handling
             if len(recipients_unique) > 1:
                 group_members = sorted({user_id, *recipients_unique})
-                group_id = _compute_group_id(group_members)
+                base_group_id = _compute_group_id(group_members)
+                group_thread_token = ''
+                if force_new_group:
+                    group_thread_token = (
+                        str(data.get('group_thread_id') or '').strip()
+                        or f"gt_{secrets.token_hex(8)}"
+                    )
+                    group_id = _compute_group_thread_id(group_members, group_thread_token)
+                else:
+                    group_id = base_group_id
                 metadata.update({
                     'group_id': group_id,
                     'group_members': group_members,
                     'is_group': True,
                 })
+                if group_thread_token:
+                    metadata['group_thread_id'] = group_thread_token
+                    metadata['base_group_id'] = base_group_id
                 metadata['security'] = build_dm_security_summary(
                     db_manager,
                     p2p_manager,
@@ -8527,6 +9382,8 @@ def create_ui_blueprint() -> Blueprint:
                                         'group_id': group_id,
                                         'group_members': group_members,
                                         'is_group': True,
+                                        'group_thread_id': group_thread_token or None,
+                                        'base_group_id': base_group_id if group_thread_token else None,
                                         'security': metadata.get('security'),
                                     },
                                     message_id=message.id,
@@ -8559,7 +9416,11 @@ def create_ui_blueprint() -> Blueprint:
                         except Exception as bcast_err:
                             logger.warning(f"Failed to broadcast group DM over P2P: {bcast_err}")
 
-                    return jsonify({'success': True, 'message': message.to_dict(), 'group_id': group_id})
+                    response_payload = {'success': True, 'message': message.to_dict(), 'group_id': group_id}
+                    if group_thread_token:
+                        response_payload['group_thread_id'] = group_thread_token
+                        response_payload['base_group_id'] = base_group_id
+                    return jsonify(response_payload)
                 return jsonify({'error': 'Failed to send group message'}), 500
 
             # Single recipient or broadcast
@@ -9294,6 +10155,7 @@ def create_ui_blueprint() -> Blueprint:
                     if not quarantine_ok or not governance_result.get('enabled'):
                         db_manager.set_user_status(user_id, 'pending_approval')
                         return jsonify({'error': 'Failed to apply default agent quarantine'}), 500
+                    _ensure_user_default_channels(db_manager, channel_manager, user_id)
                 return jsonify({'success': True, 'status': 'active'})
             return jsonify({'error': 'User not found or update failed'}), 400
         except Exception as e:
@@ -9377,6 +10239,7 @@ def create_ui_blueprint() -> Blueprint:
                         status=user.get('status'),
                     )
                     return jsonify({'error': 'Failed to apply default agent quarantine'}), 500
+                _ensure_user_default_channels(db_manager, channel_manager, user_id)
                 refreshed = db_manager.get_user(user_id) or refreshed
             payload = {
                 'id': refreshed.get('id'),
@@ -13474,6 +14337,22 @@ def create_ui_blueprint() -> Blueprint:
                     for member_id in (final_metadata.get('group_members') or [])
                     if str(member_id).strip() and str(member_id).strip() != user_id
                 ]
+                if group_members_for_security and not str(final_metadata.get('group_thread_id') or '').strip():
+                    try:
+                        resolved_group_members = message_manager.resolve_group_members(
+                            user_id,
+                            str(final_metadata.get('group_id') or row['recipient_id'] or '').strip(),
+                            [user_id, *group_members_for_security],
+                        )
+                        if resolved_group_members:
+                            final_metadata['group_members'] = resolved_group_members
+                            group_members_for_security = [
+                                member_id
+                                for member_id in resolved_group_members
+                                if member_id != user_id
+                            ]
+                    except Exception:
+                        pass
             target_ids_for_security = group_members_for_security or ([str(row['recipient_id']).strip()] if row['recipient_id'] else [])
             if target_ids_for_security:
                 final_metadata['security'] = build_dm_security_summary(
@@ -13569,6 +14448,10 @@ def create_ui_blueprint() -> Blueprint:
                             payload['group_id'] = final_metadata.get('group_id')
                         if isinstance(final_metadata, dict) and final_metadata.get('group_members'):
                             payload['group_members'] = final_metadata.get('group_members')
+                        if isinstance(final_metadata, dict) and final_metadata.get('group_thread_id'):
+                            payload['group_thread_id'] = final_metadata.get('group_thread_id')
+                        if isinstance(final_metadata, dict) and final_metadata.get('base_group_id'):
+                            payload['base_group_id'] = final_metadata.get('base_group_id')
                         inbox_manager.sync_source_triggers(
                             source_type='dm',
                             source_id=message_id,
@@ -13620,10 +14503,23 @@ def create_ui_blueprint() -> Blueprint:
             meta = original.metadata or {}
             group_members = meta.get('group_members') if isinstance(meta, dict) else None
             group_id = meta.get('group_id') if isinstance(meta, dict) else None
+            group_thread_id = str(meta.get('group_thread_id') or '').strip() if isinstance(meta, dict) else ''
+            base_group_id = str(meta.get('base_group_id') or '').strip() if isinstance(meta, dict) else ''
 
             if group_members:
                 if not group_id:
                     group_id = _compute_group_id(group_members)
+                if group_thread_id:
+                    group_members = sorted({str(member_id).strip() for member_id in group_members if str(member_id).strip()})
+                else:
+                    try:
+                        group_members = message_manager.resolve_group_members(
+                            user_id,
+                            group_id,
+                            group_members,
+                        )
+                    except Exception:
+                        group_members = sorted({str(member_id).strip() for member_id in group_members if str(member_id).strip()})
                 recipients = [member_id for member_id in group_members if member_id and member_id != user_id]
                 if not recipients:
                     return jsonify({'error': 'No other group members to reply to'}), 400
@@ -13634,6 +14530,10 @@ def create_ui_blueprint() -> Blueprint:
                     'group_members': group_members,
                     'is_group': True,
                 }
+                if group_thread_id:
+                    reply_meta['group_thread_id'] = group_thread_id
+                if base_group_id:
+                    reply_meta['base_group_id'] = base_group_id
                 reply_meta['security'] = build_dm_security_summary(
                     db_manager,
                     p2p_manager,
@@ -13667,6 +14567,8 @@ def create_ui_blueprint() -> Blueprint:
                                         'group_id': group_id,
                                         'group_members': group_members,
                                         'is_group': True,
+                                        'group_thread_id': group_thread_id or None,
+                                        'base_group_id': base_group_id or None,
                                         'security': reply_meta.get('security'),
                                     },
                                     message_id=message.id,
@@ -18918,11 +19820,32 @@ def create_ui_blueprint() -> Blueprint:
     def profile():
         """User profile management page."""
         try:
-            db_manager, _, _, _, _, _, _, _, profile_manager, _, _ = _get_app_components_any(current_app)
+            db_manager, _, _, _, _, _, _, _, profile_manager, config, _ = _get_app_components_any(current_app)
             user_id = get_current_user()
             
             # Get or create user profile
             user_profile = profile_manager.ensure_default_profile(user_id, user_id)
+            from ..core.device import get_device_label, get_device_profile
+
+            device_profile = {}
+            fallback_device_label = str(getattr(config, 'device_label', '') or '').strip()
+            try:
+                device_profile = get_device_profile() or {}
+                if not fallback_device_label:
+                    fallback_device_label = str(get_device_label() or '').strip()
+            except Exception:
+                device_profile = {}
+            current_local_peer_hint = _current_local_peer_hint_payload(
+                db_manager,
+                profile_manager,
+                fallback_device_label=fallback_device_label,
+                device_profile=device_profile,
+            )
+            current_mesh_hint = _current_meshspace_hint_payload()
+            connection_identity_preview = _connection_identity_preview_payload(
+                current_mesh_hint,
+                current_local_peer_hint,
+            )
 
             # Build activity stats from actual data (avoid placeholder values).
             stats = {
@@ -18980,7 +19903,11 @@ def create_ui_blueprint() -> Blueprint:
             return render_template('profile.html',
                                  profile=user_profile,
                                  profile_stats=stats,
-                                 user_id=user_id)
+                                 user_id=user_id,
+                                 is_instance_owner=_is_admin(),
+                                 current_local_peer_hint=current_local_peer_hint,
+                                 current_mesh_hint=current_mesh_hint,
+                                 connection_identity_preview=connection_identity_preview)
                                  
         except Exception as e:
             logger.error(f"Profile error: {e}")

--- a/canopy/ui/static/js/canopy-main.js
+++ b/canopy/ui/static/js/canopy-main.js
@@ -50,8 +50,22 @@
             if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago';
             return date.toLocaleString();
         }
+
+        function formatTimestamps(scope) {
+            const root = scope && typeof scope.querySelectorAll === 'function' ? scope : document;
+            root.querySelectorAll('[data-timestamp]').forEach(el => {
+                const timestamp = el.getAttribute('data-timestamp');
+                el.textContent = formatTimestamp(timestamp);
+                const parsed = parseCanopyTimestamp(timestamp);
+                if (parsed) {
+                    el.title = parsed.toLocaleString();
+                }
+            });
+        }
+
         window.parseCanopyTimestamp = parseCanopyTimestamp;
         window.formatCanopyTimestamp = formatTimestamp;
+        window.formatTimestamps = formatTimestamps;
         
         function showAlert(message, type = 'info') {
             const alertDiv = document.createElement('div');
@@ -1086,6 +1100,8 @@
             pollInFlight: false,
             pollHandle: null,
             safetyHandle: null,
+            listenersAttached: false,
+            visibilityFocusDebounceHandle: null,
         };
 
         const canopyAttentionDismissStorageKey = (() => {
@@ -1412,6 +1428,18 @@
                 });
         }
 
+        function _scheduleCanopyVisibilityFocusRefresh() {
+            if (canopySidebarAttentionState.visibilityFocusDebounceHandle) {
+                window.clearTimeout(canopySidebarAttentionState.visibilityFocusDebounceHandle);
+            }
+            canopySidebarAttentionState.visibilityFocusDebounceHandle = window.setTimeout(function() {
+                canopySidebarAttentionState.visibilityFocusDebounceHandle = null;
+                pollCanopyWorkspaceAttentionEvents();
+                requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
+                requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
+            }, 150);
+        }
+
         function startCanopyWorkspaceAttentionPolling() {
             renderSidebarAttentionSummary(canopySidebarAttentionState.summary);
             canopyRenderSidebarDmContacts(canopySidebarDmState.contacts);
@@ -1428,18 +1456,17 @@
                 requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
                 requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
             }, 30000);
-            document.addEventListener('visibilitychange', function() {
-                if (document.visibilityState === 'visible') {
-                    pollCanopyWorkspaceAttentionEvents();
-                    requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
-                    requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
-                }
-            });
-            window.addEventListener('focus', function() {
-                pollCanopyWorkspaceAttentionEvents();
-                requestCanopySidebarAttentionRefresh({ force: false }).catch(() => {});
-                requestCanopySidebarDmRefresh({ force: false }).catch(() => {});
-            });
+            if (!canopySidebarAttentionState.listenersAttached) {
+                canopySidebarAttentionState.listenersAttached = true;
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') {
+                        _scheduleCanopyVisibilityFocusRefresh();
+                    }
+                });
+                window.addEventListener('focus', function() {
+                    _scheduleCanopyVisibilityFocusRefresh();
+                });
+            }
         }
 
         window.requestCanopySidebarAttentionRefresh = requestCanopySidebarAttentionRefresh;
@@ -3138,6 +3165,98 @@
                 return div.innerHTML;
             }
 
+            function hasCanopyMarkdownSyntax(text) {
+                const value = String(text || '');
+                return (
+                    /(^|\n)\s{0,3}#{1,3}\s+\S/.test(value) ||
+                    /(^|\n)\s{0,3}>\s+\S/.test(value) ||
+                    /(^|\n)\s{0,3}(?:[-*+]\s+|\d+\.\s+)\S/.test(value) ||
+                    /(?:\*\*|__)[^\n]+(?:\*\*|__)/.test(value) ||
+                    /(^|[^\*])\*[^\s*][^\n]*[^\s*]\*(?!\*)/.test(value) ||
+                    /~~[^\n]+~~/.test(value) ||
+                    /`[^`\n]+`/.test(value) ||
+                    /\[[^\]\n]+\]\(https?:\/\/[^)\s]+[^\s)]\)/.test(value)
+                );
+            }
+
+            function renderCanopyInlineMarkdown(html) {
+                if (!html) return html;
+                const inlineBlocks = [];
+                const INLINE_PLACEHOLDER = '\x00INLINE_';
+                html = html.replace(/`([^`\n]+)`/g, function(_match, body) {
+                    const idx = inlineBlocks.length;
+                    inlineBlocks.push('<code class="canopy-inline-code no-katex">' + body + '</code>');
+                    return INLINE_PLACEHOLDER + idx + '\x00';
+                });
+                html = html.replace(/(\*\*|__)([^\n]+?)\1/g, '<strong>$2</strong>');
+                html = html.replace(/~~([^\n]+?)~~/g, '<del>$1</del>');
+                html = html.replace(/(^|[^\*])\*([^\s*][^\n]*?[^\s*])\*(?!\*)/g, '$1<em>$2</em>');
+                for (let i = 0; i < inlineBlocks.length; i++) {
+                    html = html.replace(INLINE_PLACEHOLDER + i + '\x00', inlineBlocks[i]);
+                }
+                return html;
+            }
+
+            function renderCanopyBlockMarkdown(html) {
+                if (!html) return html;
+                const lines = String(html).split('\n');
+                const out = [];
+                let listType = null;
+                let listItems = [];
+                let quoteLines = [];
+
+                function flushList() {
+                    if (!listType) return;
+                    out.push('<' + listType + ' class="canopy-md-list">' + listItems.join('') + '</' + listType + '>');
+                    listType = null;
+                    listItems = [];
+                }
+
+                function flushQuote() {
+                    if (!quoteLines.length) return;
+                    out.push('<blockquote class="canopy-md-quote">' + quoteLines.join('<br>') + '</blockquote>');
+                    quoteLines = [];
+                }
+
+                lines.forEach(function(line) {
+                    const heading = line.match(/^\s{0,3}(#{1,3})\s+(.+)$/);
+                    const quote = line.match(/^\s{0,3}>\s?(.*)$/);
+                    const unordered = line.match(/^\s{0,3}[-*+]\s+(.+)$/);
+                    const ordered = line.match(/^\s{0,3}\d+\.\s+(.+)$/);
+
+                    if (heading) {
+                        flushList();
+                        flushQuote();
+                        const levelClass = 'h' + Math.min(3, heading[1].length);
+                        out.push('<div class="canopy-md-heading ' + levelClass + '">' + heading[2] + '</div>');
+                        return;
+                    }
+
+                    if (quote) {
+                        flushList();
+                        quoteLines.push(quote[1] || '&nbsp;');
+                        return;
+                    }
+
+                    if (unordered || ordered) {
+                        flushQuote();
+                        const nextType = unordered ? 'ul' : 'ol';
+                        if (listType && listType !== nextType) flushList();
+                        listType = nextType;
+                        listItems.push('<li>' + (unordered ? unordered[1] : ordered[1]) + '</li>');
+                        return;
+                    }
+
+                    flushList();
+                    flushQuote();
+                    out.push(line);
+                });
+
+                flushList();
+                flushQuote();
+                return out.join('\n');
+            }
+
             const CANOPY_MARKDOWN_PREVIEW_EXTENSIONS = ['.md', '.markdown'];
             const CANOPY_SPREADSHEET_PREVIEW_EXTENSIONS = ['.csv', '.tsv', '.xlsx', '.xlsm'];
             const CANOPY_SPREADSHEET_PREVIEW_MIME_TYPES = new Set([
@@ -4148,6 +4267,8 @@
                 return '<a href="' + safeUrl + '" target="_blank" rel="noopener noreferrer" ' +
                     'style="color:var(--canopy-primary,#22c55e);">' + safeText + '</a>';
             });
+            html = renderCanopyInlineMarkdown(html);
+            html = renderCanopyBlockMarkdown(html);
             html = html.replace(/\n/g, '<br>');
 
             const embedState = collectProviderEmbeds(html);
@@ -4217,7 +4338,7 @@
 
 	            // Wrap in paragraph or div (div if we have block elements like <pre> so markup stays valid)
             if (!html.includes('embed-preview') && !html.includes('embed-grid')) {
-                if (html.includes('<pre') || html.includes('<pre ') || html.includes('<div') || html.includes('<table')) {
+                if (html.includes('<pre') || html.includes('<pre ') || html.includes('<div') || html.includes('<table') || html.includes('<ul') || html.includes('<ol') || html.includes('<blockquote')) {
                     html = '<div class="rich-content">' + html + '</div>';
                 } else {
                     html = '<p class="mb-0">' + html + '</p>';
@@ -4235,7 +4356,7 @@
 		                const rawText = el.textContent.trim();
 		                if (!rawText) return;
 		                // Process if it contains a URL worth embedding, markdown image, or code blocks
-		                var shouldProcess = /https?:\/\//.test(rawText) || /\]\(\/files\//.test(rawText) || /!\[/.test(rawText) || /```/.test(rawText) || containsMathDelimiters(rawText);
+		                var shouldProcess = /https?:\/\//.test(rawText) || /\]\(\/files\//.test(rawText) || /!\[/.test(rawText) || /```/.test(rawText) || hasCanopyMarkdownSyntax(rawText) || containsMathDelimiters(rawText);
 		                if (shouldProcess) {
 		                    const rendered = renderRichContent(rawText);
 		                    if (el.tagName === 'P') {
@@ -5392,19 +5513,13 @@
             }
         })();
 
-        // Auto-refresh timestamps
-        setInterval(() => {
-            document.querySelectorAll('[data-timestamp]').forEach(el => {
-                const timestamp = el.getAttribute('data-timestamp');
-                el.textContent = formatTimestamp(timestamp);
-                if (typeof window.parseCanopyTimestamp === 'function') {
-                    const parsed = window.parseCanopyTimestamp(timestamp);
-                    if (parsed) {
-                        el.title = parsed.toLocaleString();
-                    }
-                }
-            });
-        }, 30000);
+        // Format timestamps immediately and then refresh relative labels.
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => formatTimestamps());
+        } else {
+            formatTimestamps();
+        }
+        setInterval(() => formatTimestamps(), 30000);
 
         // --- Attention center + peer rail ---
         function initCanopyAttentionCenter() {

--- a/canopy/ui/templates/_messages_thread_header.html
+++ b/canopy/ui/templates/_messages_thread_header.html
@@ -24,6 +24,9 @@
             </div>
         </div>
         <div class="dm-thread-actions">
+            <button class="btn btn-sm btn-outline-secondary dm-mobile-sidebar-toggle" type="button" onclick="toggleDmMobileSidebar(true)" aria-controls="dm-sidebar" aria-expanded="false">
+                <i class="bi bi-list"></i><span class="dm-btn-label">Chats</span>
+            </button>
             {% if active_thread.security %}
                 {% set thread_sec_mode = active_thread.security.get('mode') %}
                 {% set thread_sec_state = active_thread.security.get('state') %}
@@ -36,6 +39,11 @@
                     <i class="bi bi-{% if thread_sec_mode == 'peer_e2e_v1' %}shield-lock-fill{% elif thread_sec_mode == 'local_only' %}pc-display{% elif thread_sec_state == 'decrypt_failed' %}shield-x{% else %}shield-exclamation{% endif %}"></i>
                     <span class="visually-hidden security-text">{{ active_thread.security.get('label') }}</span>
                 </span>
+            {% endif %}
+            {% if active_thread.kind == 'group' %}
+            <button class="btn btn-sm btn-outline-secondary" type="button" onclick="startFreshGroupDiscussion()" title="Start a separate group DM with these same participants">
+                <i class="bi bi-chat-square-plus"></i><span class="dm-btn-label">Fresh thread</span>
+            </button>
             {% endif %}
             <button class="btn btn-sm btn-outline-secondary" type="button" onclick="startNewConversation()">
                 <i class="bi bi-pencil-square"></i><span class="dm-btn-label">New</span>

--- a/canopy/ui/templates/base.html
+++ b/canopy/ui/templates/base.html
@@ -38,6 +38,66 @@
             margin: 0.5rem 0;
             padding-bottom: 0.125rem;
         }
+        .rich-content .canopy-md-heading,
+        .message-content .canopy-md-heading,
+        .post-content .canopy-md-heading,
+        .dm-bubble-copy .canopy-md-heading {
+            font-weight: 750;
+            letter-spacing: -0.015em;
+            color: var(--canopy-text-primary);
+            margin: 0.35rem 0 0.25rem;
+            line-height: 1.2;
+        }
+        .rich-content .canopy-md-heading.h1,
+        .message-content .canopy-md-heading.h1,
+        .post-content .canopy-md-heading.h1,
+        .dm-bubble-copy .canopy-md-heading.h1 {
+            font-size: 1.14rem;
+        }
+        .rich-content .canopy-md-heading.h2,
+        .message-content .canopy-md-heading.h2,
+        .post-content .canopy-md-heading.h2,
+        .dm-bubble-copy .canopy-md-heading.h2 {
+            font-size: 1.04rem;
+        }
+        .rich-content .canopy-md-heading.h3,
+        .message-content .canopy-md-heading.h3,
+        .post-content .canopy-md-heading.h3,
+        .dm-bubble-copy .canopy-md-heading.h3 {
+            font-size: 0.98rem;
+        }
+        .rich-content .canopy-md-list,
+        .message-content .canopy-md-list,
+        .post-content .canopy-md-list,
+        .dm-bubble-copy .canopy-md-list {
+            margin: 0.25rem 0 0.45rem;
+            padding-left: 1.25rem;
+        }
+        .rich-content .canopy-md-list li,
+        .message-content .canopy-md-list li,
+        .post-content .canopy-md-list li,
+        .dm-bubble-copy .canopy-md-list li {
+            margin: 0.08rem 0;
+        }
+        .rich-content .canopy-md-quote,
+        .message-content .canopy-md-quote,
+        .post-content .canopy-md-quote,
+        .dm-bubble-copy .canopy-md-quote {
+            margin: 0.4rem 0;
+            padding: 0.5rem 0.75rem;
+            border-left: 3px solid var(--canopy-primary);
+            border-radius: 0 10px 10px 0;
+            background: color-mix(in srgb, var(--canopy-bg-tertiary) 82%, transparent);
+            color: var(--canopy-text-secondary);
+        }
+        .canopy-inline-code {
+            border: 1px solid var(--canopy-border);
+            background: var(--canopy-bg-tertiary);
+            border-radius: 6px;
+            padding: 0.08rem 0.28rem;
+            color: var(--canopy-text-primary);
+            font-size: 0.92em;
+        }
     </style>
     
     <style>
@@ -6078,6 +6138,7 @@
             height: 100%;
             object-fit: cover;
             display: block;
+            image-orientation: from-image;
             transition: transform 0.2s ease;
         }
         .media-grid .mg-cell:hover img {

--- a/canopy/ui/templates/channels.html
+++ b/canopy/ui/templates/channels.html
@@ -2124,11 +2124,18 @@
             gap: 0.15rem;
             flex: 0 0 auto;
         }
+        .channel-header-search-toggle {
+            display: inline-flex !important;
+        }
         .channel-header-search {
             order: 3;
             flex: 1 1 100%;
             min-width: 0;
             max-width: none;
+            display: none;
+        }
+        .channel-header-search.mobile-open {
+            display: flex;
         }
         #channel-search-bar {
             width: 100% !important;
@@ -5698,6 +5705,21 @@ function scheduleChannelNameOverflowSync() {
     requestAnimationFrame(() => {
         channelNameOverflowSyncQueued = false;
         syncAllChannelNameOverflowStates();
+    });
+}
+
+// Deduplicate viewport-sync work so that both window.resize and
+// visualViewport.resize (which both fire on mobile soft-keyboard open/close)
+// collapse into a single rAF flush per frame.
+let channelViewportSyncQueued = false;
+function scheduleChannelViewportSync() {
+    if (channelViewportSyncQueued) return;
+    channelViewportSyncQueued = true;
+    requestAnimationFrame(() => {
+        channelViewportSyncQueued = false;
+        syncChannelViewportMetrics();
+        scheduleChannelNameOverflowSync();
+        syncChannelHeaderSearchUI();
     });
 }
 
@@ -15262,7 +15284,7 @@ function rerunActiveChannelSearch(options = {}) {
 }
 
 function isNarrowMobileChannelLayout() {
-    return window.innerWidth <= 575;
+    return window.innerWidth <= 767;
 }
 
 function syncChannelHeaderSearchUI(forceOpen) {
@@ -15316,22 +15338,10 @@ document.addEventListener('DOMContentLoaded', function() {
         updateCurrentChannelIdUI(currentChannelId);
         syncChannelViewportMetrics();
         syncChannelHeaderSearchUI(false);
-        window.addEventListener('resize', () => {
-            syncChannelViewportMetrics();
-            scheduleChannelNameOverflowSync();
-            syncChannelHeaderSearchUI();
-        });
-        window.addEventListener('orientationchange', () => setTimeout(() => {
-            syncChannelViewportMetrics();
-            scheduleChannelNameOverflowSync();
-            syncChannelHeaderSearchUI();
-        }, 120));
+        window.addEventListener('resize', scheduleChannelViewportSync);
+        window.addEventListener('orientationchange', () => setTimeout(scheduleChannelViewportSync, 120));
         if (window.visualViewport) {
-            window.visualViewport.addEventListener('resize', () => {
-                syncChannelViewportMetrics();
-                scheduleChannelNameOverflowSync();
-                syncChannelHeaderSearchUI();
-            });
+            window.visualViewport.addEventListener('resize', scheduleChannelViewportSync);
         }
         const navbarCollapse = document.getElementById('navbarNav');
         if (navbarCollapse) {

--- a/canopy/ui/templates/connect.html
+++ b/canopy/ui/templates/connect.html
@@ -174,6 +174,121 @@
         word-break: break-word;
     }
 
+    .invite-preview-card {
+        border: 1px solid var(--canopy-border);
+        background:
+            radial-gradient(circle at top left, rgba(34, 197, 94, 0.12), transparent 34%),
+            color-mix(in srgb, var(--canopy-bg-tertiary) 82%, transparent);
+        border-radius: 16px;
+        padding: 0.85rem;
+    }
+    .invite-preview-card.invite-preview-warning {
+        border-color: rgba(245, 158, 11, 0.45);
+        background:
+            radial-gradient(circle at top left, rgba(245, 158, 11, 0.12), transparent 34%),
+            color-mix(in srgb, var(--canopy-bg-tertiary) 82%, transparent);
+    }
+    .invite-preview-card.invite-preview-error {
+        border-color: rgba(239, 68, 68, 0.5);
+        background:
+            radial-gradient(circle at top left, rgba(239, 68, 68, 0.12), transparent 34%),
+            color-mix(in srgb, var(--canopy-bg-tertiary) 82%, transparent);
+    }
+    .invite-preview-title {
+        color: var(--canopy-text-primary);
+        font-weight: 700;
+    }
+    .invite-preview-peer-head {
+        display: flex;
+        align-items: center;
+        gap: 0.65rem;
+        min-width: 0;
+    }
+    .invite-preview-peer-avatar {
+        width: 38px;
+        height: 38px;
+        border-radius: 50%;
+        object-fit: cover;
+        border: 1px solid color-mix(in srgb, var(--canopy-border) 75%, transparent);
+        flex-shrink: 0;
+    }
+    .invite-preview-peer-initials {
+        width: 38px;
+        height: 38px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #fff;
+        background: #334155;
+        flex-shrink: 0;
+    }
+    .invite-preview-subtitle {
+        color: var(--canopy-text-secondary);
+        font-size: 0.8rem;
+    }
+    .invite-preview-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 0.55rem;
+        margin-top: 0.75rem;
+    }
+    .invite-preview-fact {
+        border: 1px solid color-mix(in srgb, var(--canopy-border) 75%, transparent);
+        border-radius: 12px;
+        padding: 0.55rem 0.6rem;
+        min-width: 0;
+    }
+    .invite-preview-label {
+        color: var(--canopy-text-secondary);
+        font-size: 0.68rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        margin-bottom: 0.15rem;
+    }
+    .invite-preview-value {
+        color: var(--canopy-text-primary);
+        font-weight: 650;
+        overflow-wrap: anywhere;
+    }
+    .invite-warning-list {
+        margin: 0.65rem 0 0;
+        padding-left: 1rem;
+        color: #b45309;
+        font-size: 0.82rem;
+    }
+    [data-bs-theme="dark"] .invite-warning-list {
+        color: #fbbf24;
+    }
+    .invite-preview-actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    }
+    .mesh-hint-avatar,
+    .invite-preview-mesh-avatar {
+        width: 28px;
+        height: 28px;
+        border-radius: 10px;
+        object-fit: cover;
+        border: 1px solid color-mix(in srgb, var(--canopy-border) 75%, transparent);
+        flex-shrink: 0;
+    }
+    .invite-preview-mesh-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.55rem;
+        min-width: 0;
+    }
+    .invite-preview-mesh-meta {
+        min-width: 0;
+    }
+    .invite-preview-mesh-meta .invite-preview-label {
+        margin-bottom: 0.05rem;
+    }
+
     .connect-page .card-header .d-flex {
         min-width: 0;
     }
@@ -327,6 +442,42 @@
                 </div>
 
                 <div class="mb-3">
+                    <label class="form-label small text-muted">Invite identity hints</label>
+                    <div class="d-flex flex-wrap gap-2">
+                        <span class="badge bg-success-subtle text-success-emphasis border">
+                            {% if current_mesh_avatar_url %}
+                            <img src="{{ current_mesh_avatar_url }}" alt="" class="mesh-hint-avatar me-1">
+                            {% else %}
+                            <i class="bi bi-diagram-3"></i> {{ current_mesh_name or 'Default Mesh' }}
+                            {% endif %}
+                            {% if current_mesh_avatar_url %}
+                            {{ current_mesh_name or 'Default Mesh' }}
+                            {% endif %}
+                        </span>
+                        {% if current_mesh_fingerprint %}
+                        <span class="badge bg-warning-subtle text-warning-emphasis border" title="{{ current_meshspace_id }}">
+                            Mesh check {{ current_mesh_fingerprint }}
+                        </span>
+                        {% endif %}
+                        {% if current_peer_label %}
+                        <span class="badge bg-info-subtle text-info-emphasis border">
+                            {% if current_peer_avatar_url %}
+                            <img src="{{ current_peer_avatar_url }}" alt="" style="width:18px; height:18px; border-radius:50%; object-fit:cover; border:1px solid color-mix(in srgb, var(--canopy-border) 75%, transparent);" class="me-1">
+                            {% else %}
+                            <i class="bi bi-person-circle"></i>
+                            {% endif %}
+                            {{ current_peer_label }}
+                        </span>
+                        {% endif %}
+                        {% if current_instance_label %}
+                        <span class="badge bg-secondary-subtle text-secondary-emphasis border">
+                            <i class="bi bi-pc-display"></i> Node hint {{ current_instance_label }}
+                        </span>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="mb-3">
                     <label class="form-label small text-muted">Reachable at</label>
                     <div>
                         {% for ep in endpoints %}
@@ -388,7 +539,7 @@
                 <h5 class="mb-0"><i class="bi bi-box-arrow-in-down"></i> Import Friend's Invite</h5>
             </div>
             <div class="card-body">
-                <p class="text-muted small">Paste an invite code from another Canopy user to connect.</p>
+                <p class="text-muted small">Paste an invite code, review the peer and mesh hints, then confirm the connection.</p>
 
                 <div class="mb-3">
                     <label class="form-label small text-muted">Invite code</label>
@@ -396,9 +547,16 @@
                               placeholder="canopy:eyJ2Ij..." style="font-size: 0.8rem;"></textarea>
                 </div>
 
-                <button class="btn btn-success w-100" onclick="importInvite()" id="importBtn">
-                    <i class="bi bi-plug"></i> Connect
-                </button>
+                <div class="invite-preview-actions">
+                    <button class="btn btn-outline-primary flex-fill" onclick="previewInvite(true)" id="previewInviteBtn">
+                        <i class="bi bi-card-checklist"></i> Review Invite
+                    </button>
+                    <button class="btn btn-success flex-fill" onclick="connectPreviewedInvite()" id="importBtn" disabled>
+                        <i class="bi bi-plug"></i> Connect to this peer
+                    </button>
+                </div>
+
+                <div id="invitePreview" class="mt-3" style="display:none;" aria-live="polite"></div>
 
                 <div id="importResult" class="mt-3" style="display:none;"></div>
             </div>
@@ -425,11 +583,17 @@
                 <ul class="list-group list-group-flush">
                     {% for pid in connected_peers %}
                     {% set dev = peer_device_profiles.get(pid) if peer_device_profiles else None %}
+                    {% set pub = peer_public_identities.get(pid) if peer_public_identities else {} %}
                     <li class="list-group-item d-flex align-items-start peer-row" data-peer-id="{{ pid }}" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
                         <span class="peer-status-dot"></span>
                         {% if dev and dev.avatar_b64 and dev.avatar_mime %}
                         <img src="data:{{ dev.avatar_mime }};base64,{{ dev.avatar_b64 }}"
                              alt="" style="width:32px; height:32px; border-radius:50%; margin:0 10px; object-fit:cover;">
+                        {% elif pub and pub.avatar_initials %}
+                        <span class="d-inline-flex align-items-center justify-content-center fw-semibold"
+                              style="width:32px; height:32px; border-radius:50%; margin:0 10px; color:#fff; background:{{ pub.avatar_color or 'var(--canopy-accent)' }}; font-size:0.78rem;">
+                            {{ pub.avatar_initials }}
+                        </span>
                         {% else %}
                         <i class="bi bi-pc-display-horizontal me-2" style="font-size:1.2rem; opacity:0.5; margin:0 10px 0 6px;"></i>
                         {% endif %}
@@ -440,6 +604,12 @@
                             {% if dev.description %}
                             <small class="text-muted d-block" style="font-size:0.7rem; opacity:0.7;">{{ dev.description }}</small>
                             {% endif %}
+                            {% elif pub and pub.node_name %}
+                            <div class="peer-title">{{ pub.node_name }}</div>
+                            {% if pub.source and pub.source != 'fallback' %}
+                            <small class="text-muted d-block" style="font-size:0.68rem;">Unverified {{ pub.source }} label</small>
+                            {% endif %}
+                            <small class="text-muted d-block" style="font-size:0.75rem;">{{ pid[:16] }}...</small>
                             {% else %}
                             <code>{{ pid }}</code>
                             {% endif %}
@@ -474,17 +644,30 @@
                     {% for dest, relay in relay_status.active_relays.items() %}
                     {% set rdev = peer_device_profiles.get(dest) if peer_device_profiles else None %}
                     {% set viadev = peer_device_profiles.get(relay) if peer_device_profiles else None %}
+                    {% set rpub = peer_public_identities.get(dest) if peer_public_identities else {} %}
+                    {% set viapub = peer_public_identities.get(relay) if peer_public_identities else {} %}
                     <li class="list-group-item d-flex align-items-start peer-row" data-peer-id="{{ dest }}" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
                         <span class="peer-status-dot relay"></span>
                         {% if rdev and rdev.avatar_b64 and rdev.avatar_mime %}
                         <img src="data:{{ rdev.avatar_mime }};base64,{{ rdev.avatar_b64 }}"
                              alt="" style="width:32px; height:32px; border-radius:50%; margin:0 10px; object-fit:cover;">
+                        {% elif rpub and rpub.avatar_initials %}
+                        <span class="d-inline-flex align-items-center justify-content-center fw-semibold"
+                              style="width:32px; height:32px; border-radius:50%; margin:0 10px; color:#fff; background:{{ rpub.avatar_color or 'var(--canopy-accent)' }}; font-size:0.78rem;">
+                            {{ rpub.avatar_initials }}
+                        </span>
                         {% else %}
                         <i class="bi bi-pc-display-horizontal me-2" style="font-size:1.2rem; opacity:0.5; margin:0 10px 0 6px;"></i>
                         {% endif %}
                         <div class="peer-meta">
                             {% if rdev and rdev.display_name %}
                             <div class="peer-title">{{ rdev.display_name }}</div>
+                            <small class="text-muted d-block" style="font-size:0.75rem;">{{ dest[:16] }}...</small>
+                            {% elif rpub and rpub.node_name %}
+                            <div class="peer-title">{{ rpub.node_name }}</div>
+                            {% if rpub.source and rpub.source != 'fallback' %}
+                            <small class="text-muted d-block" style="font-size:0.68rem;">Unverified {{ rpub.source }} label</small>
+                            {% endif %}
                             <small class="text-muted d-block" style="font-size:0.75rem;">{{ dest[:16] }}...</small>
                             {% else %}
                             <code>{{ dest[:16] }}...</code>
@@ -493,8 +676,8 @@
                             <small class="peer-activity d-block" data-peer-last>Last activity: —</small>
                         </div>
                         <div class="ms-auto peer-actions">
-                            <span class="badge bg-info" title="Relayed via {{ (viadev.display_name if viadev and viadev.display_name else relay[:12]) }}">
-                                <i class="bi bi-arrow-left-right"></i> Via {{ (viadev.display_name if viadev and viadev.display_name else relay[:12]) }}
+                            <span class="badge bg-info" title="Relayed via {{ (viadev.display_name if viadev and viadev.display_name else (viapub.node_name if viapub and viapub.node_name else relay[:12])) }}">
+                                <i class="bi bi-arrow-left-right"></i> Via {{ (viadev.display_name if viadev and viadev.display_name else (viapub.node_name if viapub and viapub.node_name else relay[:12])) }}
                             </span>
                             <button class="btn btn-sm btn-outline-success ms-1" title="Attempt direct connection"
                                     onclick="promoteDirect('{{ dest }}', this); return false;">
@@ -531,15 +714,27 @@
                 <ul class="list-group list-group-flush">
                     {% for peer in discovered_peers %}
                     {% set ddev = peer_device_profiles.get(peer.peer_id) if peer_device_profiles else None %}
+                    {% set dpub = peer_public_identities.get(peer.peer_id) if peer_public_identities else {} %}
                     <li class="list-group-item d-flex justify-content-between align-items-center" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
                         <div class="d-flex align-items-center">
                             {% if ddev and ddev.avatar_b64 and ddev.avatar_mime %}
                             <img src="data:{{ ddev.avatar_mime }};base64,{{ ddev.avatar_b64 }}"
                                  alt="" style="width:28px; height:28px; border-radius:50%; margin-right:8px; object-fit:cover;">
+                            {% elif dpub and dpub.avatar_initials %}
+                            <span class="d-inline-flex align-items-center justify-content-center fw-semibold"
+                                  style="width:28px; height:28px; border-radius:50%; margin-right:8px; color:#fff; background:{{ dpub.avatar_color or 'var(--canopy-accent)' }}; font-size:0.72rem;">
+                                {{ dpub.avatar_initials }}
+                            </span>
                             {% endif %}
                             <div>
                                 {% if ddev and ddev.display_name %}
                                 <strong>{{ ddev.display_name }}</strong>
+                                <small class="text-muted d-block" style="font-size:0.75rem;">{{ peer.peer_id[:16] }} &middot; {{ peer.address }}:{{ peer.port }}</small>
+                                {% elif dpub and dpub.node_name %}
+                                <strong>{{ dpub.node_name }}</strong>
+                                {% if dpub.source and dpub.source != 'fallback' %}
+                                <small class="text-muted d-block" style="font-size:0.68rem;">Unverified {{ dpub.source }} label</small>
+                                {% endif %}
                                 <small class="text-muted d-block" style="font-size:0.75rem;">{{ peer.peer_id[:16] }} &middot; {{ peer.address }}:{{ peer.port }}</small>
                                 {% else %}
                                 <code>{{ peer.peer_id }}</code>
@@ -586,6 +781,7 @@
                             {% set idev = peer_device_profiles.get(peer.peer_id) if peer_device_profiles else None %}
                             {% set ibydev = peer_device_profiles.get(peer.introduced_by) if peer_device_profiles else None %}
                             {% set pub = peer.public_identity if peer.public_identity else None %}
+                            {% set bypub = peer_public_identities.get(peer.introduced_by) if peer_public_identities else {} %}
                             <tr>
                                 <td>
                                     <div class="d-flex align-items-center">
@@ -635,6 +831,11 @@
                                 <td>
                                     {% if ibydev and ibydev.display_name %}
                                     <strong>{{ ibydev.display_name }}</strong>
+                                    {% elif bypub and bypub.node_name %}
+                                    <strong>{{ bypub.node_name }}</strong>
+                                    {% if bypub.source and bypub.source != 'fallback' %}
+                                    <small class="text-muted d-block" style="font-size:0.68rem;">Unverified {{ bypub.source }} label</small>
+                                    {% endif %}
                                     {% else %}
                                     <code>{{ peer.introduced_by[:12] }}...</code>
                                     {% endif %}
@@ -667,23 +868,32 @@
                     <h5 class="mb-0"><i class="bi bi-journal-bookmark"></i> Known Peers</h5>
                     <div class="d-flex align-items-center gap-2">
                         <button class="btn btn-sm btn-outline-primary" onclick="reconnectAllPeers()">
-                            <i class="bi bi-arrow-repeat"></i> Reconnect All
+                            <i class="bi bi-arrow-repeat"></i> Reconnect Same-Mesh
                         </button>
                     </div>
                 </div>
             </div>
             <div class="card-body connect-scroll-list">
-                <p class="text-muted small">Previously connected peers. Click <strong>Reconnect</strong> to try reaching them again.</p>
+                <p class="text-muted small">Previously connected peers. Reconnect-all skips peers that last advertised a different mesh unless you reconnect that peer explicitly.</p>
                 <ul class="list-group list-group-flush">
                     {% for peer in known_peers %}
                     {% set kdev = peer_device_profiles.get(peer.peer_id) if peer_device_profiles else None %}
                     {% set relaydev = peer_device_profiles.get(peer.relay_via) if (peer_device_profiles and peer.relay_via) else None %}
+                    {% set pubid = peer.public_identity if peer.public_identity else {} %}
                     <li class="list-group-item d-flex align-items-start peer-row" data-peer-id="{{ peer.peer_id }}" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
                         <span class="peer-status-dot {% if peer.connection_type == 'relayed' %}relay{% elif not peer.connected %}offline{% endif %}"></span>
                         <div class="d-flex align-items-center">
                             {% if kdev and kdev.avatar_b64 and kdev.avatar_mime %}
                             <img src="data:{{ kdev.avatar_mime }};base64,{{ kdev.avatar_b64 }}"
                                  alt="" style="width:32px; height:32px; border-radius:50%; margin:0 10px; object-fit:cover;">
+                            {% elif pubid.avatar_b64 and pubid.avatar_mime %}
+                            <img src="data:{{ pubid.avatar_mime }};base64,{{ pubid.avatar_b64 }}"
+                                 alt="" style="width:32px; height:32px; border-radius:50%; margin:0 10px; object-fit:cover;">
+                            {% elif pubid.avatar_initials %}
+                            <span class="d-inline-flex align-items-center justify-content-center fw-semibold"
+                                  style="width:32px; height:32px; border-radius:50%; margin:0 10px; color:#fff; background:{{ pubid.avatar_color or 'var(--canopy-accent)' }}; font-size:0.78rem;">
+                                {{ pubid.avatar_initials }}
+                            </span>
                             {% else %}
                             <i class="bi bi-pc-display-horizontal me-2" style="font-size:1.3rem; opacity:0.4; margin:0 10px 0 6px;"></i>
                             {% endif %}
@@ -692,10 +902,38 @@
                                 <div class="peer-title">{{ kdev.display_name }}</div>
                                 {% elif peer.display_name %}
                                 <div class="peer-title">{{ peer.display_name }}</div>
+                                {% elif pubid.node_name %}
+                                <div class="peer-title">{{ pubid.node_name }}</div>
+                                {% endif %}
+                                {% if pubid.source and pubid.source != 'fallback' %}
+                                <small class="text-muted d-block" style="font-size:0.68rem;">Unverified {{ pubid.source }} label</small>
                                 {% endif %}
                                 <small class="text-muted d-block" style="font-size:0.75rem;">{{ peer.peer_id[:16] }}...</small>
                                 {% if kdev and kdev.description %}
                                 <small class="text-muted d-block" style="font-size:0.7rem; opacity:0.7;">{{ kdev.description }}</small>
+                                {% endif %}
+                                {% if peer.meshspace_hint %}
+                                <span class="badge {% if peer.cross_mesh_warning %}bg-warning-subtle text-warning-emphasis{% else %}bg-success-subtle text-success-emphasis{% endif %} border me-1 d-inline-flex align-items-center gap-1" style="font-size:0.65rem;"
+                                      title="{{ peer.meshspace_hint.meshspace_id or '' }}">
+                                    {% if peer.meshspace_hint.meshspace_avatar_b64 and peer.meshspace_hint.meshspace_avatar_mime %}
+                                    <img src="data:{{ peer.meshspace_hint.meshspace_avatar_mime }};base64,{{ peer.meshspace_hint.meshspace_avatar_b64 }}"
+                                         alt="" class="mesh-hint-avatar" style="width:18px; height:18px; border-radius:6px;">
+                                    {% endif %}
+                                    Mesh {{ peer.meshspace_hint.meshspace_fingerprint or peer.meshspace_hint.meshspace_name or peer.meshspace_hint.meshspace_id or 'hint' }}
+                                </span>
+                                {% endif %}
+                                {% if peer.cross_mesh_warning %}
+                                <small class="text-warning d-block" style="font-size:0.72rem;">
+                                    <i class="bi bi-exclamation-triangle"></i> {{ peer.cross_mesh_warning }}
+                                </small>
+                                {% elif peer.mesh_relationship == 'cross_mesh_bridge_allowed' %}
+                                <small class="text-info d-block" style="font-size:0.72rem;">
+                                    <i class="bi bi-link-45deg"></i> Intentional cross-mesh bridge
+                                </small>
+                                {% elif peer.mesh_relationship == 'same_mesh_alias_confirmed' %}
+                                <small class="text-success d-block" style="font-size:0.72rem;">
+                                    <i class="bi bi-check-circle"></i> Same mesh alias confirmed
+                                </small>
                                 {% endif %}
                                 {% for ep in peer.endpoints %}
                                 <span class="badge bg-secondary me-1" style="font-size:0.65rem;">{{ ep }}</span>
@@ -706,6 +944,16 @@
                         <div class="ms-auto peer-actions">
                             {% if peer.connection_type == 'direct' %}
                             <span class="badge bg-success">Connected</span>
+                            {% if peer.can_treat_same_mesh %}
+                            <button class="btn btn-sm btn-outline-success" onclick="reviewPeerMesh('{{ peer.peer_id }}', 'same_mesh_alias', this)">
+                                <i class="bi bi-check2-circle"></i> Treat as Same Mesh
+                            </button>
+                            {% endif %}
+                            {% if peer.can_keep_bridge %}
+                            <button class="btn btn-sm btn-outline-warning" onclick="reviewPeerMesh('{{ peer.peer_id }}', 'cross_mesh_bridge', this)">
+                                <i class="bi bi-link-45deg"></i> Keep Bridge
+                            </button>
+                            {% endif %}
                             <button class="btn btn-sm btn-outline-secondary" onclick="disconnectPeer('{{ peer.peer_id }}')">
                                 <i class="bi bi-plug"></i> Disconnect
                             </button>
@@ -713,12 +961,33 @@
                             <span class="badge bg-info" title="Relayed via {{ (relaydev.display_name if relaydev and relaydev.display_name else (peer.relay_via[:12] if peer.relay_via else 'relay')) }}">
                                 <i class="bi bi-arrow-left-right"></i> Via {{ (relaydev.display_name if relaydev and relaydev.display_name else (peer.relay_via[:12] if peer.relay_via else 'relay')) }}
                             </span>
+                            {% if peer.can_treat_same_mesh %}
+                            <button class="btn btn-sm btn-outline-success" onclick="reviewPeerMesh('{{ peer.peer_id }}', 'same_mesh_alias', this)">
+                                <i class="bi bi-check2-circle"></i> Treat as Same Mesh
+                            </button>
+                            {% endif %}
+                            {% if peer.can_keep_bridge %}
+                            <button class="btn btn-sm btn-outline-warning" onclick="reviewPeerMesh('{{ peer.peer_id }}', 'cross_mesh_bridge', this)">
+                                <i class="bi bi-link-45deg"></i> Keep Bridge
+                            </button>
+                            {% endif %}
                             <button class="btn btn-sm btn-outline-success" onclick="promoteDirect('{{ peer.peer_id }}', this)">
                                 <i class="bi bi-lightning-charge"></i> Go Direct
                             </button>
                             {% else %}
+                            {% if peer.can_treat_same_mesh %}
+                            <button class="btn btn-sm btn-outline-success" onclick="reviewPeerMesh('{{ peer.peer_id }}', 'same_mesh_alias', this)">
+                                <i class="bi bi-check2-circle"></i> Treat as Same Mesh
+                            </button>
+                            {% endif %}
+                            {% if peer.can_keep_bridge %}
+                            <button class="btn btn-sm btn-outline-warning" onclick="reviewPeerMesh('{{ peer.peer_id }}', 'cross_mesh_bridge', this)">
+                                <i class="bi bi-link-45deg"></i> Keep Bridge
+                            </button>
+                            {% endif %}
                             {% if peer.endpoints %}
                             <button class="btn btn-sm btn-outline-primary"
+                                    data-cross-mesh-warning="{{ peer.cross_mesh_warning or '' }}"
                                     onclick="reconnectPeer('{{ peer.peer_id }}', this)">
                                 <i class="bi bi-arrow-repeat"></i> Reconnect
                             </button>
@@ -983,9 +1252,54 @@
 
 <script>
 const PEER_LABELS = {{ peer_labels | tojson }};
+const PEER_PREVIEW_PROFILES = {{ (peer_preview_profiles or {}) | tojson }};
+const PEER_MESH_HINTS = {{ (peer_mesh_hints or {}) | tojson }};
+const CURRENT_MESH_NAME = {{ (current_mesh_name or 'Default Mesh') | tojson }};
+const CURRENT_MESHSPACE_ID = {{ (current_meshspace_id or '') | tojson }};
+const CURRENT_MESHSPACE_ID_ALIASES = {{ (current_meshspace_id_aliases or []) | tojson }};
+const CURRENT_MESH_FINGERPRINT = {{ (current_mesh_fingerprint or '') | tojson }};
+const CURRENT_PEER_ID = {{ (peer_id or '') | tojson }};
 const USER_IS_ADMIN = {{ 'true' if is_admin else 'false' }};
+const DEVICE_ICON_CHOICES = new Set([
+    'bi-pc-display-horizontal',
+    'bi-laptop',
+    'bi-phone',
+    'bi-tablet',
+    'bi-cpu',
+    'bi-hdd-network',
+    'bi-router',
+    'bi-server',
+]);
 const connectionEvents = new Map();
 const CSRF_TOKEN = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+let currentInvitePreview = null;
+let invitePreviewTimer = null;
+let invitePreviewFetchSequence = 0;
+
+function meshIdsMatch(remoteId, remoteAliases) {
+    const localIds = new Set([String(CURRENT_MESHSPACE_ID || '').trim(), ...((CURRENT_MESHSPACE_ID_ALIASES || []).map((value) => String(value || '').trim()))]);
+    const remoteIds = new Set([String(remoteId || '').trim(), ...((remoteAliases || []).map((value) => String(value || '').trim()))]);
+    localIds.delete('');
+    remoteIds.delete('');
+    if (!localIds.size || !remoteIds.size) return false;
+    for (const value of remoteIds) {
+        if (localIds.has(value)) return true;
+    }
+    return false;
+}
+
+function peerInitials(label) {
+    const text = String(label || '').trim();
+    if (!text) return '?';
+    const parts = text.split(/\s+/).filter(Boolean).slice(0, 2);
+    const initials = parts.map((part) => part[0]).join('');
+    return (initials || text.slice(0, 2)).toUpperCase();
+}
+
+function normalizePeerIcon(icon) {
+    const clean = String(icon || '').trim();
+    return DEVICE_ICON_CHOICES.has(clean) ? clean : 'bi-pc-display-horizontal';
+}
 
 function apiJsonFetch(url, options = {}) {
     const method = (options.method || 'GET').toUpperCase();
@@ -1015,14 +1329,30 @@ function apiJsonFetch(url, options = {}) {
             if (response.status === 401 && !usingKey && /api key required|authentication required/i.test(message)) {
                 message = 'Authentication required. Your session may have expired. Reload and sign in again.';
             }
-            throw new Error(message);
+            const err = new Error(message);
+            err.status = response.status;
+            if (data && data.diagnostic_code) err.diagnosticCode = data.diagnostic_code;
+            throw err;
         }
         return data || {};
     });
 }
 
 function buildConnectErrorMessage(err) {
-    const text = String((err && err.message) ? err.message : (err || 'Unknown error'));
+    const code = err?.diagnosticCode;
+    if (code === 'cross_mesh_admin_required') {
+        return 'Instance admin permission is required to connect to a peer from a different meshspace.';
+    }
+    if (code === 'mesh_identity_admin_required') {
+        return 'Instance admin permission is required to review a peer whose mesh identity differs from this workspace.';
+    }
+    if (code === 'cross_mesh_confirmation_required') {
+        return 'This invite is for a different meshspace. Review the invite again before requesting a cross-mesh connection.';
+    }
+    if (code === 'cross_mesh_reconnect_confirmation_required') {
+        return 'This peer is from a different meshspace. Reload the page to review the current mesh warning and confirm explicitly.';
+    }
+    const text = String(err?.message ?? (err ?? 'Unknown error'));
     if (/session may have expired|authentication required|api key required/i.test(text)) {
         return 'Authentication required for this action. Please reload the page and sign in again. ' +
                'If you are using a script/CLI, include X-API-Key.';
@@ -1069,11 +1399,338 @@ function regenerateInvite() {
     });
 }
 
-function importInvite() {
+function decodeInvitePreview(code) {
+    let text = String(code || '').trim();
+    if (!text) {
+        throw new Error('Paste an invite code first.');
+    }
+    if (!text.trim().startsWith('{') && !text.toLowerCase().startsWith('canopy:')) {
+        const token = text.match(/canopy:[A-Za-z0-9_-]+/);
+        if (token) text = token[0];
+    }
+    if (text.toLowerCase().startsWith('canopy:')) {
+        text = text.slice('canopy:'.length);
+    }
+
+    let raw = text;
+    if (!text.trim().startsWith('{')) {
+        try {
+            const padded = text + '='.repeat((4 - (text.length % 4)) % 4);
+            const binary = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+            const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+            if (typeof TextDecoder !== 'undefined') {
+                raw = new TextDecoder('utf-8').decode(bytes);
+            } else {
+                raw = binary;
+            }
+        } catch (_) {
+            raw = text;
+        }
+    }
+
+    let data;
+    try {
+        data = JSON.parse(raw);
+    } catch (_) {
+        throw new Error('This does not look like a valid Canopy invite.');
+    }
+    if (!data || !data.pid || !data.epk || !data.xpk) {
+        throw new Error('Invite is missing required peer identity fields.');
+    }
+
+    const endpoints = Array.isArray(data.ep)
+        ? data.ep.map((value) => String(value || '').trim()).filter(Boolean)
+        : [];
+    return {
+        code: String(code || '').trim(),
+        version: data.v || 1,
+        peerId: String(data.pid || ''),
+        meshName: String(data.mn || '').trim(),
+        meshspaceId: String(data.mid || '').trim(),
+        meshspaceIdAliases: Array.isArray(data.mia)
+            ? data.mia.map((value) => String(value || '').trim()).filter(Boolean)
+            : [],
+        meshFingerprint: String(data.mf || '').trim(),
+        meshAvatarB64: String(data.mab || '').trim(),
+        meshAvatarMime: String(data.mam || '').trim(),
+        peerLabel: String(data.pl || '').trim(),
+        instanceLabel: String(data.il || '').trim(),
+        peerIcon: normalizePeerIcon(data.pi || ''),
+        generatedAt: String(data.ts || '').trim(),
+        endpoints,
+    };
+}
+
+function invitePreviewAgeLabel(generatedAt) {
+    if (!generatedAt) return '';
+    const parsed = Date.parse(generatedAt);
+    if (!Number.isFinite(parsed)) return '';
+    const deltaSeconds = Math.max(0, Math.floor((Date.now() - parsed) / 1000));
+    return formatRelativeTime(deltaSeconds);
+}
+
+function mergeRemoteInvitePreview(preview, remote) {
+    const merged = { ...(preview || {}) };
+    if (!remote || typeof remote !== 'object') {
+        return merged;
+    }
+    if (remote.meshspace_name) merged.meshName = String(remote.meshspace_name || '').trim();
+    if (remote.meshspace_id) merged.meshspaceId = String(remote.meshspace_id || '').trim();
+    if (Array.isArray(remote.meshspace_id_aliases)) {
+        merged.meshspaceIdAliases = remote.meshspace_id_aliases.map((value) => String(value || '').trim()).filter(Boolean);
+    }
+    if (remote.meshspace_fingerprint) merged.meshFingerprint = String(remote.meshspace_fingerprint || '').trim();
+    if (remote.meshspace_avatar_b64) merged.meshAvatarB64 = String(remote.meshspace_avatar_b64 || '').trim();
+    if (remote.meshspace_avatar_mime) merged.meshAvatarMime = String(remote.meshspace_avatar_mime || '').trim();
+    if (remote.peer_label) merged.peerLabel = String(remote.peer_label || '').trim();
+    if (remote.peer_avatar_b64) merged.peerAvatarB64 = String(remote.peer_avatar_b64 || '').trim();
+    if (remote.peer_avatar_mime) merged.peerAvatarMime = String(remote.peer_avatar_mime || '').trim();
+    if (remote.instance_label) merged.instanceLabel = String(remote.instance_label || '').trim();
+    if (remote.peer_icon) merged.peerIcon = normalizePeerIcon(remote.peer_icon || '');
+    if (remote.source_endpoint) merged.remotePreviewSourceEndpoint = String(remote.source_endpoint || '').trim();
+    if (remote.source_url) merged.remotePreviewSourceUrl = String(remote.source_url || '').trim();
+    if (remote.version) merged.remotePreviewVersion = String(remote.version || '').trim();
+    merged.remotePreviewState = remote.ok ? 'fetched' : String(remote.status || '').trim() || 'unavailable';
+    return merged;
+}
+
+function enrichInvitePreview(preview, sequence) {
+    if (!preview || !preview.code || !Array.isArray(preview.endpoints) || !preview.endpoints.length) {
+        return Promise.resolve(null);
+    }
+    return apiJsonFetch('/api/v1/p2p/invite/preview', {
+        method: 'POST',
+        body: JSON.stringify({ invite_code: preview.code })
+    })
+    .then((data) => {
+        if (sequence !== invitePreviewFetchSequence) return null;
+        if (!currentInvitePreview || currentInvitePreview.code !== preview.code) return null;
+        currentInvitePreview = mergeRemoteInvitePreview(currentInvitePreview, data || {});
+        renderInvitePreview(currentInvitePreview);
+        return currentInvitePreview;
+    })
+    .catch(() => null);
+}
+
+function invitePreviewWarnings(preview) {
+    const warnings = [];
+    if (CURRENT_PEER_ID && preview.peerId === CURRENT_PEER_ID) {
+        warnings.push('This invite appears to point back to your own local peer.');
+    }
+    if (preview.meshspaceId && CURRENT_MESHSPACE_ID && !meshIdsMatch(preview.meshspaceId, preview.meshspaceIdAliases)) {
+        warnings.push(`Meshspace ID differs from this workspace (${CURRENT_MESHSPACE_ID}). The peer can connect for review, but sync stays paused until an admin treats it as the same mesh or keeps a bridge.`);
+        if (!USER_IS_ADMIN) {
+            warnings.push('Mesh identity review requires instance admin approval on this workspace.');
+        }
+    }
+    if (preview.meshName && CURRENT_MESH_NAME && preview.meshName !== CURRENT_MESH_NAME) {
+        warnings.push(`Mesh hint differs from this workspace (${CURRENT_MESH_NAME}). Confirm you are importing into the intended meshspace.`);
+    }
+    if (!preview.endpoints.length) {
+        warnings.push('No direct endpoints are advertised. Canopy can register the peer, but direct connection may require broker/relay help.');
+    }
+    const knownLabel = PEER_LABELS[preview.peerId] || '';
+    if (knownLabel && preview.peerLabel && knownLabel !== preview.peerLabel) {
+        warnings.push(`This peer is already known locally as "${knownLabel}". The invite label says "${preview.peerLabel}".`);
+    }
+    if (preview.generatedAt) {
+        const parsed = Date.parse(preview.generatedAt);
+        if (Number.isFinite(parsed) && Date.now() - parsed > 1000 * 60 * 60 * 24 * 14) {
+            warnings.push('This invite is more than two weeks old. Ask for a fresh code if endpoints fail.');
+        }
+    }
+    return warnings;
+}
+
+function renderInvitePreview(preview, error) {
+    const container = document.getElementById('invitePreview');
+    const importBtn = document.getElementById('importBtn');
+    if (!container || !importBtn) return;
+
+    if (error) {
+        currentInvitePreview = null;
+        importBtn.disabled = true;
+        importBtn.innerHTML = '<i class="bi bi-plug"></i> Connect to this peer';
+        container.style.display = 'block';
+        container.innerHTML = `
+            <div class="invite-preview-card invite-preview-error">
+                <div class="invite-preview-title"><i class="bi bi-x-circle"></i> Invite could not be previewed</div>
+                <div class="invite-preview-subtitle">${_escapeHtml(error.message || error)}</div>
+            </div>`;
+        return;
+    }
+
+    if (!preview) {
+        currentInvitePreview = null;
+        importBtn.disabled = true;
+        importBtn.innerHTML = '<i class="bi bi-plug"></i> Connect to this peer';
+        container.style.display = 'none';
+        container.innerHTML = '';
+        return;
+    }
+
+    currentInvitePreview = preview;
+    const warnings = invitePreviewWarnings(preview);
+    const knownLabel = PEER_LABELS[preview.peerId] || '';
+    const knownProfile = PEER_PREVIEW_PROFILES[preview.peerId] || {};
+    const knownMeshHint = PEER_MESH_HINTS[preview.peerId] || {};
+    const title = knownProfile.display_name || preview.peerLabel || knownLabel || preview.instanceLabel || preview.peerId.slice(0, 12);
+    const nodeIcon = normalizePeerIcon(knownProfile.icon || preview.peerIcon || '');
+    const meshLabel = preview.meshName || 'Not specified';
+    const endpointLabel = preview.endpoints.length
+        ? `${preview.endpoints.length} direct ${preview.endpoints.length === 1 ? 'endpoint' : 'endpoints'}`
+        : 'No direct endpoints';
+    const endpointPreview = preview.endpoints.slice(0, 3)
+        .map((ep) => `<code>${_escapeHtml(ep)}</code>`)
+        .join('<br>');
+    const ageLabel = invitePreviewAgeLabel(preview.generatedAt);
+    const knownBadge = knownLabel
+        ? '<span class="badge bg-info-subtle text-info-emphasis border">Known peer</span>'
+        : '<span class="badge bg-success-subtle text-success-emphasis border">New peer</span>';
+    const hasMeshInfo = Boolean(preview.meshspaceId || preview.meshName);
+    const meshMatches = preview.meshspaceId && CURRENT_MESHSPACE_ID
+        ? meshIdsMatch(preview.meshspaceId, preview.meshspaceIdAliases)
+        : (preview.meshName && preview.meshName === CURRENT_MESH_NAME);
+    const meshBadge = !hasMeshInfo
+        ? '<span class="badge bg-secondary-subtle text-secondary-emphasis border">No mesh hint</span>'
+        : meshMatches
+            ? '<span class="badge bg-success-subtle text-success-emphasis border">Current mesh hint</span>'
+            : '<span class="badge bg-warning-subtle text-warning-emphasis border">Check mesh hint</span>';
+    const meshAvatarB64 = preview.meshAvatarB64 || knownMeshHint.meshspace_avatar_b64 || '';
+    const meshAvatarMime = preview.meshAvatarMime || knownMeshHint.meshspace_avatar_mime || '';
+    const meshAvatarHtml = (meshAvatarB64 && meshAvatarMime)
+        ? `<img src="data:${_escapeHtml(meshAvatarMime)};base64,${_escapeHtml(meshAvatarB64)}" alt="" class="invite-preview-mesh-avatar">`
+        : '';
+    const peerAvatarB64 = knownProfile.avatar_b64 || preview.peerAvatarB64 || '';
+    const peerAvatarMime = knownProfile.avatar_mime || preview.peerAvatarMime || '';
+    const peerAvatarHtml = (peerAvatarB64 && peerAvatarMime)
+        ? `<img src="data:${_escapeHtml(peerAvatarMime)};base64,${_escapeHtml(peerAvatarB64)}" alt="" class="invite-preview-peer-avatar">`
+        : `<span class="invite-preview-peer-initials">${_escapeHtml(peerInitials(title))}</span>`;
+    const warningHtml = warnings.length
+        ? `<ul class="invite-warning-list">${warnings.map((warning) => `<li>${_escapeHtml(warning)}</li>`).join('')}</ul>`
+        : '';
+    const remotePreviewHtml = preview.remotePreviewSourceEndpoint
+        ? `<div class="invite-preview-subtitle mt-2">Remote preview refreshed from <code>${_escapeHtml(preview.remotePreviewSourceEndpoint)}</code>${preview.remotePreviewSourceUrl ? ' via <code>' + _escapeHtml(preview.remotePreviewSourceUrl) + '</code>' : ''}${preview.remotePreviewVersion ? ' · v' + _escapeHtml(preview.remotePreviewVersion) : ''}</div>`
+        : '';
+
+    container.style.display = 'block';
+    container.innerHTML = `
+        <div class="invite-preview-card ${warnings.length ? 'invite-preview-warning' : ''}">
+            <div class="d-flex align-items-start justify-content-between gap-2 flex-wrap">
+                <div class="invite-preview-peer-head">
+                    ${peerAvatarHtml}
+                    <div>
+                        <div class="invite-preview-title"><i class="bi bi-person-check"></i> ${_escapeHtml(title)}</div>
+                        <div class="invite-preview-subtitle">Review before connecting. Labels are sender-provided hints; peer keys are verified when imported.</div>
+                    </div>
+                </div>
+                <div class="d-flex gap-1 flex-wrap">${knownBadge}${meshBadge}</div>
+            </div>
+            <div class="invite-preview-grid">
+                <div class="invite-preview-fact">
+                    <div class="invite-preview-label">Peer ID</div>
+                    <div class="invite-preview-value"><code>${_escapeHtml(preview.peerId)}</code></div>
+                </div>
+                <div class="invite-preview-fact">
+                    <div class="invite-preview-label">Mesh hint</div>
+                    <div class="invite-preview-value invite-preview-mesh-badge">
+                        ${meshAvatarHtml}
+                        <span class="invite-preview-mesh-meta">${_escapeHtml(meshLabel)}${preview.meshFingerprint ? ' · <code>' + _escapeHtml(preview.meshFingerprint) + '</code>' : ''}</span>
+                    </div>
+                </div>
+                <div class="invite-preview-fact">
+                    <div class="invite-preview-label">Meshspace ID</div>
+                    <div class="invite-preview-value"><code>${_escapeHtml(preview.meshspaceId || 'Not specified')}</code></div>
+                </div>
+                <div class="invite-preview-fact">
+                    <div class="invite-preview-label">Node hint</div>
+                    <div class="invite-preview-value d-inline-flex align-items-center gap-2">
+                        <i class="bi ${_escapeHtml(nodeIcon)} text-muted"></i>
+                        <span>${_escapeHtml(preview.instanceLabel || preview.peerLabel || 'Not specified')}</span>
+                    </div>
+                </div>
+                <div class="invite-preview-fact">
+                    <div class="invite-preview-label">Reachability</div>
+                    <div class="invite-preview-value">${_escapeHtml(endpointLabel)}</div>
+                </div>
+                ${ageLabel ? `
+                <div class="invite-preview-fact">
+                    <div class="invite-preview-label">Generated</div>
+                    <div class="invite-preview-value">${_escapeHtml(ageLabel)}</div>
+                </div>` : ''}
+            </div>
+            ${endpointPreview ? `<div class="invite-preview-subtitle mt-2">${endpointPreview}</div>` : ''}
+            ${remotePreviewHtml}
+            ${warningHtml}
+        </div>`;
+    const isCrossMeshBlocked = Boolean(
+        preview.meshspaceId && CURRENT_MESHSPACE_ID && !meshIdsMatch(preview.meshspaceId, preview.meshspaceIdAliases) && !USER_IS_ADMIN
+    );
+    if (isCrossMeshBlocked) {
+        importBtn.disabled = true;
+        importBtn.title = 'Instance admin permission is required to connect to a peer from a different meshspace.';
+        importBtn.innerHTML = '<i class="bi bi-lock"></i> Admin required';
+    } else {
+        importBtn.disabled = false;
+        importBtn.title = '';
+        importBtn.innerHTML = preview.endpoints.length
+            ? '<i class="bi bi-plug"></i> Connect to this peer'
+            : '<i class="bi bi-box-arrow-in-down"></i> Import peer';
+    }
+}
+
+function previewInvite(force) {
+    const code = document.getElementById('importCode').value.trim();
+    if (!code) {
+        invitePreviewFetchSequence += 1;
+        renderInvitePreview(null);
+        if (force) alert('Paste an invite code first.');
+        return null;
+    }
+    try {
+        const preview = decodeInvitePreview(code);
+        renderInvitePreview(preview);
+        const sequence = ++invitePreviewFetchSequence;
+        enrichInvitePreview(preview, sequence);
+        return preview;
+    } catch (err) {
+        invitePreviewFetchSequence += 1;
+        renderInvitePreview(null, err);
+        return null;
+    }
+}
+
+function scheduleInvitePreview() {
+    if (invitePreviewTimer) clearTimeout(invitePreviewTimer);
+    invitePreviewTimer = setTimeout(() => previewInvite(false), 180);
+}
+
+function connectPreviewedInvite() {
     const code = document.getElementById('importCode').value.trim();
     if (!code) {
         alert('Paste an invite code first.');
         return;
+    }
+    if (!currentInvitePreview || currentInvitePreview.code !== code) {
+        const preview = previewInvite(true);
+        if (!preview) return;
+    }
+    const preview = currentInvitePreview;
+    const isCrossMesh = Boolean(
+        preview && preview.meshspaceId && CURRENT_MESHSPACE_ID && !meshIdsMatch(preview.meshspaceId, preview.meshspaceIdAliases)
+    );
+    if (isCrossMesh) {
+        if (!USER_IS_ADMIN) {
+            alert('Only the instance admin can connect and review a peer from a different meshspace.');
+            return;
+        }
+        const remoteMesh = preview.meshName || preview.meshspaceId;
+        const ok = confirm(
+            `This invite is for a different meshspace: ${remoteMesh} (${preview.meshspaceId}).\n\n` +
+            `Current meshspace: ${CURRENT_MESH_NAME} (${CURRENT_MESHSPACE_ID}).\n\n` +
+            'Connect for review? Sync will stay paused until you choose "Treat as same mesh" or "Keep bridge".'
+        );
+        if (!ok) return;
     }
     const btn = document.getElementById('importBtn');
     btn.disabled = true;
@@ -1081,7 +1738,7 @@ function importInvite() {
 
     apiJsonFetch('/api/v1/p2p/invite/import', {
         method: 'POST',
-        body: JSON.stringify({invite_code: code})
+        body: JSON.stringify({invite_code: code, allow_cross_mesh: false})
     })
     .then(data => {
         const res = document.getElementById('importResult');
@@ -1089,7 +1746,15 @@ function importInvite() {
         const safePeerId = _escapeHtml(data.peer_id || '');
         const safeEndpoint = _escapeHtml(data.connected_endpoint || '');
         const safeError = _escapeHtml(data.error || '');
-        if (data.status === 'connected') {
+        if (data.status === 'connected_mesh_review_required') {
+            res.className = 'mt-3 alert alert-warning';
+            res.innerHTML = '<i class="bi bi-exclamation-triangle-fill"></i> Connected to <code>' + safePeerId + '</code>, but mesh identity needs admin review before sync. ' +
+                '<div class="mt-2 d-flex flex-wrap gap-2">' +
+                '<button type="button" class="btn btn-sm btn-outline-success" onclick="reviewPeerMesh(\'' + safePeerId + '\', \'same_mesh_alias\', this)">Treat as same mesh</button>' +
+                '<button type="button" class="btn btn-sm btn-outline-warning" onclick="reviewPeerMesh(\'' + safePeerId + '\', \'cross_mesh_bridge\', this)">Keep bridge</button>' +
+                '<button type="button" class="btn btn-sm btn-outline-danger" onclick="forgetPeer(\'' + safePeerId + '\')">Disconnect / forget</button>' +
+                '</div>';
+        } else if (data.status === 'connected') {
             res.className = 'mt-3 alert alert-success';
             res.innerHTML = '<i class="bi bi-check-circle-fill"></i> Connected to <code>' + safePeerId + '</code> via <code>' + safeEndpoint + '</code>!';
         } else if (data.status === 'imported_not_connected') {
@@ -1111,9 +1776,26 @@ function importInvite() {
         res.innerHTML = '<i class="bi bi-x-circle-fill"></i> ' + _escapeHtml(buildConnectErrorMessage(err));
     })
     .finally(() => {
-        btn.disabled = false;
-        btn.innerHTML = '<i class="bi bi-plug"></i> Connect';
+        const p = currentInvitePreview;
+        const blocked = Boolean(
+            p && p.meshspaceId && CURRENT_MESHSPACE_ID && !meshIdsMatch(p.meshspaceId, p.meshspaceIdAliases) && !USER_IS_ADMIN
+        );
+        if (blocked) {
+            btn.disabled = true;
+            btn.title = 'Instance admin permission is required to connect to a peer from a different meshspace.';
+            btn.innerHTML = '<i class="bi bi-lock"></i> Admin required';
+        } else {
+            btn.disabled = false;
+            btn.title = '';
+            btn.innerHTML = p && p.endpoints && p.endpoints.length
+                ? '<i class="bi bi-plug"></i> Connect to this peer'
+                : '<i class="bi bi-box-arrow-in-down"></i> Import peer';
+        }
     });
+}
+
+function importInvite() {
+    return connectPreviewedInvite();
 }
 
 function connectToIntroduced(peerId, buttonEl) {
@@ -1215,14 +1897,57 @@ function checkBrokeredConnection(peerId, btn, attempt) {
     });
 }
 
+function reviewPeerMesh(peerId, action, buttonEl) {
+    const cleanPeerId = String(peerId || '').trim();
+    const cleanAction = String(action || '').trim();
+    if (!cleanPeerId || !cleanAction) return;
+    if (!USER_IS_ADMIN) {
+        alert('Only the instance admin can resolve mesh identity relationships.');
+        return;
+    }
+    const label = cleanAction === 'same_mesh_alias' ? 'treat this peer as the same mesh' : 'keep this peer as a cross-mesh bridge';
+    if (!confirm(`Confirm that you want to ${label}?`)) return;
+    const btn = buttonEl || (typeof event !== 'undefined' ? event.target.closest('button') : null);
+    const originalHtml = btn ? btn.innerHTML : '';
+    if (btn) {
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+    }
+    apiJsonFetch('/api/v1/p2p/mesh_relationship', {
+        method: 'POST',
+        body: JSON.stringify({peer_id: cleanPeerId, action: cleanAction})
+    })
+    .then(data => {
+        showAlert(data.message || 'Mesh relationship updated.', 'success');
+        setTimeout(() => window.location.reload(), 900);
+    })
+    .catch(err => {
+        showAlert('Mesh review failed: ' + buildConnectErrorMessage(err), 'danger');
+        if (btn) {
+            btn.disabled = false;
+            btn.innerHTML = originalHtml;
+        }
+    });
+}
+
 function reconnectPeer(peerId, buttonEl) {
     const btn = buttonEl || (typeof event !== 'undefined' ? event.target.closest('button') : null);
     if (!btn) return;
+    const crossMeshWarning = String(btn.dataset.crossMeshWarning || '').trim();
+    const allowCrossMesh = false;
+    if (crossMeshWarning) {
+        if (!USER_IS_ADMIN) {
+            alert('Only the instance admin can approve a cross-mesh reconnect from this workspace.');
+            return;
+        }
+        alert(`${crossMeshWarning}\n\nResolve this peer as "Treat as same mesh" or "Keep bridge" before reconnecting.`);
+        return;
+    }
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
     apiJsonFetch('/api/v1/p2p/reconnect', {
         method: 'POST',
-        body: JSON.stringify({peer_id: peerId})
+        body: JSON.stringify({peer_id: peerId, allow_cross_mesh: allowCrossMesh})
     })
     .then(data => {
         if (data.status === 'connected') {
@@ -1257,7 +1982,7 @@ function reconnectAllPeers() {
     apiJsonFetch('/api/v1/p2p/reconnect_all', {method: 'POST'})
         .then(data => {
             if (data.status === 'scheduled') {
-                showAlert('Reconnect scheduled for all known peers.', 'success');
+                showAlert('Reconnect scheduled for same-mesh known peers. Cross-mesh peers require explicit per-peer confirmation.', 'success');
                 setTimeout(refreshConnectPage, 1500);
             } else {
                 showAlert(data.message || 'Reconnect failed', 'danger');
@@ -1267,7 +1992,7 @@ function reconnectAllPeers() {
         .finally(() => {
             btns.forEach(btn => {
                 btn.disabled = false;
-                btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> Reconnect All';
+                btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> Reconnect Same-Mesh';
             });
         });
 }
@@ -1712,6 +2437,13 @@ document.addEventListener('DOMContentLoaded', function() {
     setInterval(pollMeshDiagnostics, 12000);
     pollConnectionDiagnostics();
     setInterval(pollConnectionDiagnostics, 15000);
+
+    const importCode = document.getElementById('importCode');
+    if (importCode) {
+        importCode.addEventListener('input', scheduleInvitePreview);
+        importCode.addEventListener('paste', () => setTimeout(() => previewInvite(false), 0));
+        if (importCode.value.trim()) previewInvite(false);
+    }
 
     // Animate chevron for troubleshooting panel
     const panel = document.getElementById('troubleshootingPanel');

--- a/canopy/ui/templates/feed.html
+++ b/canopy/ui/templates/feed.html
@@ -25,7 +25,13 @@
             <i class="bi bi-plus-circle"></i>
             <span class="fw-semibold">Create a post</span>
         </div>
-        <small class="text-muted">P2P</small>
+        <div class="d-flex align-items-center gap-2">
+            <small class="text-muted">P2P</small>
+            <button type="button" class="btn btn-sm btn-outline-secondary feed-mobile-composer-toggle" id="feed-mobile-composer-toggle" onclick="toggleFeedComposer()" aria-expanded="false" aria-controls="post-composer">
+                <i class="bi bi-chevron-down"></i>
+                <span class="visually-hidden">Toggle post composer</span>
+            </button>
+        </div>
     </div>
     <div class="card-body">
         <form id="createPostForm" onsubmit="event.preventDefault(); createPost();">
@@ -2514,6 +2520,10 @@
     gap: 0.5rem;
 }
 
+.feed-mobile-composer-toggle {
+    display: none;
+}
+
 .composer-action-row {
     gap: 0.5rem;
 }
@@ -2540,13 +2550,32 @@
     .feed-page-header {
         align-items: flex-start !important;
         gap: 0.45rem;
+        margin-bottom: 0.85rem !important;
     }
     .feed-page-actions {
         width: 100%;
         justify-content: flex-start;
+        gap: 0.4rem;
     }
     .feed-page-actions .btn {
         min-height: 40px;
+    }
+    #post-composer {
+        margin-bottom: 0.9rem !important;
+    }
+    #post-composer.mobile-collapsed .card-body {
+        display: none;
+    }
+    #post-composer.mobile-collapsed .card-header {
+        border-bottom: 0;
+    }
+    .feed-mobile-composer-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 2rem;
+        min-width: 2rem;
+        border-radius: 999px;
     }
     .composer-action-row {
         align-items: stretch !important;
@@ -4243,8 +4272,17 @@
 }
 @media (max-width: 576px) {
     .icon-action-btn { font-size: 0.78rem; }
+    .feed-page-actions {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: stretch;
+    }
     .feed-page-actions .btn {
         width: 100%;
+    }
+    .feed-page-actions .btn-outline-primary {
+        width: auto;
+        min-width: 2.6rem;
     }
     .composer-action-tools .btn,
     .composer-submit-row .btn {
@@ -4298,11 +4336,75 @@
 	    function openComposer() {
 	        const composer = document.getElementById('post-composer');
 	        if (!composer) return;
+            syncFeedComposerLayout({ forceExpand: true });
 	        composer.scrollIntoView({ behavior: 'smooth', block: 'start' });
 	        const textarea = document.getElementById('postContent');
 	        if (textarea) textarea.focus();
 	        loadTagSuggestionsOnce();
 	    }
+
+        function isFeedCompactViewport() {
+            return window.matchMedia('(max-width: 768px)').matches;
+        }
+
+        // rAF gate: prevents rapid resize events from thrashing the composer
+        // layout on each pixel change during a window resize or soft-keyboard
+        // transition.
+        let _feedComposerSyncQueued = false;
+        function scheduleFeedComposerSync() {
+            if (_feedComposerSyncQueued) return;
+            _feedComposerSyncQueued = true;
+            requestAnimationFrame(() => {
+                _feedComposerSyncQueued = false;
+                syncFeedComposerLayout();
+            });
+        }
+
+        function syncFeedComposerLayout(options = {}) {
+            const composer = document.getElementById('post-composer');
+            const toggle = document.getElementById('feed-mobile-composer-toggle');
+            const textarea = document.getElementById('postContent');
+            if (!composer) return;
+
+            if (!isFeedCompactViewport()) {
+                composer.classList.remove('mobile-collapsed');
+                composer.dataset.mobileExpanded = 'true';
+            } else {
+                if (options.forceExpand) {
+                    composer.dataset.mobileExpanded = 'true';
+                } else if (options.forceCollapse) {
+                    composer.dataset.mobileExpanded = 'false';
+                } else if (!Object.prototype.hasOwnProperty.call(composer.dataset, 'mobileExpanded')) {
+                    const hasDraft = !!String(textarea?.value || '').trim() || (Array.isArray(selectedPostFiles) && selectedPostFiles.length > 0);
+                    composer.dataset.mobileExpanded = hasDraft ? 'true' : 'false';
+                }
+                composer.classList.toggle('mobile-collapsed', composer.dataset.mobileExpanded !== 'true');
+            }
+
+            if (toggle) {
+                const expanded = !composer.classList.contains('mobile-collapsed');
+                toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+                toggle.setAttribute('aria-label', expanded ? 'Collapse post composer' : 'Expand post composer');
+                toggle.innerHTML = expanded
+                    ? '<i class="bi bi-chevron-up"></i><span class="visually-hidden">Collapse post composer</span>'
+                    : '<i class="bi bi-chevron-down"></i><span class="visually-hidden">Expand post composer</span>';
+            }
+        }
+
+        function toggleFeedComposer(forceOpen) {
+            const composer = document.getElementById('post-composer');
+            if (!composer) return;
+            const nextExpanded = typeof forceOpen === 'boolean'
+                ? forceOpen
+                : composer.classList.contains('mobile-collapsed');
+            syncFeedComposerLayout({ forceExpand: nextExpanded, forceCollapse: !nextExpanded });
+            if (nextExpanded) {
+                const textarea = document.getElementById('postContent');
+                if (textarea) {
+                    requestAnimationFrame(() => textarea.focus());
+                }
+            }
+        }
 
         function getMentionContext(textarea) {
             if (!textarea) return null;
@@ -7271,6 +7373,8 @@
 	        formatTimestamps();
 	        updateUserAvatars(); // Load user avatars
 	        loadTagSuggestionsOnce();
+            syncFeedComposerLayout();
+            window.addEventListener('resize', scheduleFeedComposerSync);
 	        focusPostFromQuery();
 	        handleExpiryChange();
 	        updateExpiryBadges();
@@ -7306,6 +7410,7 @@
 	        });
             const postContent = document.getElementById('postContent');
             if (postContent) {
+                postContent.addEventListener('focus', () => syncFeedComposerLayout({ forceExpand: true }));
                 function updateCharCounter() {
                     const charCounter = document.getElementById('charCounter');
                     const charWarning = document.getElementById('charWarning');

--- a/canopy/ui/templates/meshspace_detail.html
+++ b/canopy/ui/templates/meshspace_detail.html
@@ -224,6 +224,42 @@
         color: rgba(254, 240, 138, 0.94);
     }
 
+    .mesh-port-preview {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 10px;
+        margin: 0.65rem 0 0;
+    }
+
+    .mesh-port-chip {
+        padding: 0.72rem 0.78rem;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.14);
+    }
+
+    .mesh-port-chip strong {
+        display: block;
+        font-size: 0.68rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.92);
+        margin-bottom: 0.22rem;
+    }
+
+    .mesh-port-chip span {
+        font-family: 'IBM Plex Mono', ui-monospace, monospace;
+        font-weight: 700;
+        color: #dbeafe;
+    }
+
+    .mesh-port-warning {
+        margin-top: 0.8rem;
+        color: rgba(226, 232, 240, 0.74);
+        font-size: 0.9rem;
+        line-height: 1.45;
+    }
+
     .mesh-avatar-panel {
         display: flex;
         align-items: center;
@@ -282,6 +318,10 @@
         }
 
         .mesh-health-grid {
+            grid-template-columns: minmax(0, 1fr);
+        }
+
+        .mesh-port-preview {
             grid-template-columns: minmax(0, 1fr);
         }
 
@@ -345,6 +385,28 @@
             fallbackCopy(text, markDone);
         }
     };
+
+    function updatePortPreview() {
+        var input = document.getElementById('mesh-http-port-input');
+        if (!input) return;
+        var base = parseInt(input.value, 10);
+        var http = document.querySelector('[data-derived-http-port]');
+        var mesh = document.querySelector('[data-derived-mesh-port]');
+        var discovery = document.querySelector('[data-derived-discovery-port]');
+        var invalid = document.querySelector('[data-port-invalid]');
+        var valid = Number.isFinite(base) && base >= 1024 && base <= 65533;
+        if (http) http.textContent = valid ? String(base) : '-';
+        if (mesh) mesh.textContent = valid ? String(base + 1) : '-';
+        if (discovery) discovery.textContent = valid ? String(base + 2) : '-';
+        if (invalid) invalid.classList.toggle('d-none', valid);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var input = document.getElementById('mesh-http-port-input');
+        if (!input) return;
+        input.addEventListener('input', updatePortPreview);
+        updatePortPreview();
+    });
 })();
 </script>
 {% endblock %}
@@ -461,6 +523,69 @@
                 </section>
 
                 <section class="mesh-detail-panel">
+                    <h2>Port Block</h2>
+                    <p>Move this meshspace to a different local runtime port block when another process already owns the current ports.</p>
+                    {% if not meshspace.can_update_ports %}
+                    <div class="mesh-detail-callout mb-3">
+                        <i class="bi bi-lock me-1"></i>{{ meshspace.port_update_blocked_reason or 'Stop this mesh before changing ports.' }}
+                    </div>
+                    {% endif %}
+                    <form class="mesh-detail-form" method="POST" action="{{ url_for('ui.meshspace_ports', meshspace_id=meshspace.meshspace_id) }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <div class="mesh-detail-form-grid">
+                            <div>
+                                <label class="form-label" for="mesh-http-port-input">Base HTTP port</label>
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    id="mesh-http-port-input"
+                                    name="http_port"
+                                    min="1024"
+                                    max="65533"
+                                    step="1"
+                                    value="{{ meshspace.http_port }}"
+                                    {% if not meshspace.can_update_ports %}disabled{% endif %}
+                                    required
+                                >
+                            </div>
+                            <div>
+                                <label class="form-label">Derived block</label>
+                                <div class="mesh-port-preview">
+                                    <div class="mesh-port-chip">
+                                        <strong>HTTP</strong>
+                                        <span data-derived-http-port>{{ meshspace.http_port }}</span>
+                                    </div>
+                                    <div class="mesh-port-chip">
+                                        <strong>Mesh</strong>
+                                        <span data-derived-mesh-port>{{ (meshspace.http_port|int) + 1 }}</span>
+                                    </div>
+                                    <div class="mesh-port-chip">
+                                        <strong>Discovery</strong>
+                                        <span data-derived-discovery-port>{{ (meshspace.http_port|int) + 2 }}</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mesh-detail-callout d-none" data-port-invalid>
+                            Choose a base HTTP port between 1024 and 65533 so Canopy can reserve HTTP, mesh, and discovery ports as one block.
+                        </div>
+                        <div class="mesh-port-warning">
+                            Changing ports does not move data, change the mesh ID, rotate peer keys, or alter trust. It does change local launch URLs and the mesh websocket endpoint; peers that only remember the old endpoint may need a fresh invite after restart.
+                        </div>
+                        <div class="d-flex flex-wrap gap-2">
+                            <button type="submit" class="btn btn-outline-info" {% if not meshspace.can_update_ports %}disabled{% endif %}>
+                                <i class="bi bi-ethernet me-2"></i>Save port block
+                            </button>
+                            {% if meshspace.can_update_ports %}
+                            <span class="btn btn-outline-secondary disabled">
+                                Restart after saving
+                            </span>
+                            {% endif %}
+                        </div>
+                    </form>
+                </section>
+
+                <section class="mesh-detail-panel">
                     <h2>Launch</h2>
                     <p>Use this only if you want to run the mesh manually from a terminal.</p>
                     <div class="mesh-code" id="launch-cmd">{{ meshspace.launch_command }}</div>
@@ -496,7 +621,51 @@
                         This runtime is the default meshspace on this machine. Its channels, trust, users, files, and peer identity are still exactly where they were before. Only the shell label is provisional. Rename it now before you create additional meshspaces.
                     </div>
                     {% endif %}
-                    <p>Update the label, look, and avatar for this mesh. Storage, ports, and peer identity stay unchanged.</p>
+                    <p>Update the mesh name, avatar, and review-facing mesh hints here. Storage, ports, and the device-level peer identity stay unchanged.</p>
+                    <div class="mesh-detail-callout mb-3">
+                        Mesh name, mesh image, and mesh ID are the mesh hints shown during connection review. The peer name/avatar come from the device profile in Settings, and any extra node hint still comes from that same device profile.
+                    </div>
+                    <div class="card border-0 bg-transparent mb-3">
+                        <div class="card-body px-0 pt-0">
+                            <div class="text-uppercase small text-muted mb-2">Connection Hint Preview</div>
+                            <div class="d-flex align-items-center gap-3 mb-3">
+                                <div class="rounded-circle overflow-hidden border d-flex align-items-center justify-content-center" style="width:56px; height:56px; flex-shrink:0; background: rgba(255,255,255,0.04);">
+                                    {% if connection_identity_preview.peer_avatar_url %}
+                                    <img src="{{ connection_identity_preview.peer_avatar_url }}" alt="" style="width:100%; height:100%; object-fit:cover;">
+                                    {% else %}
+                                    <i class="bi {{ connection_identity_preview.peer_icon or 'bi-pc-display-horizontal' }} fs-4"></i>
+                                    {% endif %}
+                                </div>
+                                <div>
+                                    <div class="text-uppercase small text-muted">Peer identity</div>
+                                    <div class="fw-semibold">{{ connection_identity_preview.peer_label or 'Set in Settings' }}</div>
+                                </div>
+                            </div>
+                            <div class="d-flex align-items-center gap-3 mb-3">
+                                <div class="rounded-4 overflow-hidden border d-flex align-items-center justify-content-center" style="width:56px; height:56px; flex-shrink:0; background: rgba(255,255,255,0.04);">
+                                    {% if connection_identity_preview.mesh_avatar_url %}
+                                    <img src="{{ connection_identity_preview.mesh_avatar_url }}" alt="" style="width:100%; height:100%; object-fit:cover;">
+                                    {% else %}
+                                    <i class="bi bi-diagram-3 fs-4"></i>
+                                    {% endif %}
+                                </div>
+                                <div>
+                                    <div class="text-uppercase small text-muted">Mesh identity</div>
+                                    <div class="fw-semibold">{{ connection_identity_preview.mesh_name }}</div>
+                                    <div class="small text-muted">{{ connection_identity_preview.meshspace_id or 'Mesh ID pending' }}</div>
+                                </div>
+                            </div>
+                            <div class="d-flex align-items-center gap-3">
+                                <div class="rounded-4 border d-flex align-items-center justify-content-center" style="width:56px; height:56px; flex-shrink:0; background: rgba(255,255,255,0.04);">
+                                    <i class="bi {{ connection_identity_preview.instance_icon or 'bi-pc-display-horizontal' }} fs-4"></i>
+                                </div>
+                                <div>
+                                    <div class="text-uppercase small text-muted">Node hint</div>
+                                    <div class="fw-semibold">{{ connection_identity_preview.instance_label or 'Set in Settings' }}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     <form class="mesh-detail-form" method="POST" action="{{ url_for('ui.meshspace_edit', meshspace_id=meshspace.meshspace_id) }}" enctype="multipart/form-data">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <div class="mesh-avatar-panel">
@@ -553,6 +722,37 @@
                         </div>
                     </form>
                 </section>
+
+                {% if meshspace.is_current and meshspace.runtime_mode == 'legacy-default' %}
+                <section class="mesh-detail-panel">
+                    <h2>Promote Legacy Mesh ID</h2>
+                    <div class="mesh-detail-callout mb-3">
+                        This converts the current legacy/default mesh into a stable explicit mesh ID. Canopy will keep the same data, trust graph, peer keys, channels, and files, but it will restart and begin advertising the new mesh identity. Older remembered hints remain as transition aliases so reconnect warnings stay sensible.
+                    </div>
+                    <p>This is admin-only and requires a restart. Existing peers may briefly see the new mesh as a different mesh hint until they reconnect.</p>
+                    <form class="mesh-detail-form" method="POST" action="{{ url_for('ui.meshspace_promote', meshspace_id=meshspace.meshspace_id) }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <div class="mesh-detail-form-grid">
+                            <div>
+                                <label class="form-label">Stable mesh ID</label>
+                                <input type="text" class="form-control" name="stable_meshspace_id" value="{{ meshspace.name|lower|replace(' ', '-') }}" placeholder="family-hq" pattern="[A-Za-z0-9._-]+" required>
+                            </div>
+                            <div>
+                                <label class="form-label">Advertised mesh name</label>
+                                <input type="text" class="form-control" name="stable_meshspace_name" value="{{ meshspace.name }}" required>
+                            </div>
+                        </div>
+                        <div class="mesh-avatar-sub">
+                            The previous legacy ID will be kept as a compatibility alias for diagnostics and reconnect review.
+                        </div>
+                        <div class="d-flex flex-wrap gap-2">
+                            <button type="submit" class="btn btn-outline-warning">
+                                <i class="bi bi-arrow-repeat me-2"></i>Promote and restart
+                            </button>
+                        </div>
+                    </form>
+                </section>
+                {% endif %}
             </div>
 
             <aside class="mesh-detail-side">

--- a/canopy/ui/templates/messages.html
+++ b/canopy/ui/templates/messages.html
@@ -71,6 +71,7 @@
         min-height: 0;
         height: 100%;
         align-items: stretch;
+        position: relative;
     }
 
     .dm-sidebar,
@@ -90,6 +91,30 @@
         gap: 0.7rem;
         overflow: hidden;
         background: linear-gradient(180deg, rgba(14, 24, 39, 0.96), rgba(9, 17, 29, 0.96));
+    }
+
+    .dm-sidebar-mobile-header,
+    .dm-mobile-sidebar-backdrop,
+    .dm-mobile-sidebar-toggle {
+        display: none;
+    }
+
+    .dm-sidebar-mobile-header {
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding-bottom: 0.25rem;
+    }
+
+    .dm-sidebar-mobile-header strong {
+        display: block;
+        font-size: 0.9rem;
+        letter-spacing: -0.01em;
+    }
+
+    .dm-sidebar-mobile-header small {
+        color: var(--canopy-text-secondary);
+        font-size: 0.75rem;
     }
 
     .dm-sidebar-search {
@@ -651,6 +676,8 @@
     .dm-bubble-copy {
         word-break: break-word;
         overflow-wrap: anywhere;
+        white-space: pre-wrap;
+        line-height: 1.45;
     }
 
     .dm-bubble-copy p:last-child {
@@ -1140,6 +1167,20 @@
             min-height: 42px;
         }
 
+        .messages-page.has-active-thread {
+            gap: 0;
+        }
+
+        .messages-page.has-active-thread .messages-topbar {
+            display: none;
+        }
+
+        .messages-page.has-active-thread .messages-shell {
+            grid-template-rows: minmax(0, 1fr);
+            gap: 0;
+            overflow: hidden;
+        }
+
         .dm-thread-header,
         .dm-thread-scroll,
         .dm-composer,
@@ -1153,6 +1194,55 @@
             padding-bottom: 0.68rem;
             max-height: 23vh;
             border-radius: 18px;
+        }
+
+        .messages-page.has-active-thread .dm-sidebar {
+            position: absolute;
+            inset: 0 auto 0 0;
+            width: min(88vw, 340px);
+            max-width: calc(100% - 2.5rem);
+            height: 100%;
+            max-height: none;
+            z-index: 30;
+            padding-top: 0.78rem;
+            padding-bottom: 0.78rem;
+            box-shadow: 0 22px 48px rgba(3, 10, 22, 0.36);
+            transform: translateX(calc(-100% - 1rem));
+            opacity: 0;
+            pointer-events: none;
+            transition: transform 0.22s ease, opacity 0.18s ease;
+        }
+
+        .messages-page.has-active-thread.dm-mobile-sidebar-open .dm-sidebar {
+            transform: translateX(0);
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        .messages-page.has-active-thread .dm-sidebar-mobile-header {
+            display: flex;
+        }
+
+        .messages-page.has-active-thread .dm-sidebar-search {
+            position: static;
+        }
+
+        .messages-page.has-active-thread .dm-mobile-sidebar-backdrop {
+            display: block;
+            position: absolute;
+            inset: 0;
+            z-index: 20;
+            border: 0;
+            padding: 0;
+            background: rgba(3, 10, 22, 0.52);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.18s ease;
+        }
+
+        .messages-page.has-active-thread.dm-mobile-sidebar-open .dm-mobile-sidebar-backdrop {
+            opacity: 1;
+            pointer-events: auto;
         }
 
         .dm-sidebar-scroll {
@@ -1211,6 +1301,16 @@
             gap: 0.3rem;
             width: 100%;
             justify-content: flex-end;
+        }
+
+        .messages-page.has-active-thread .dm-thread-actions {
+            width: auto;
+            margin-left: auto;
+            flex-wrap: nowrap;
+        }
+
+        .messages-page.has-active-thread .dm-mobile-sidebar-toggle {
+            display: inline-flex;
         }
 
         .dm-thread-actions .btn {
@@ -1278,6 +1378,10 @@
             gap: 0.5rem;
         }
 
+        .messages-page.has-active-thread #dm-composer:not(.dm-composer-recipient-mode) .dm-composer-topline {
+            display: none;
+        }
+
         .dm-composer-topline {
             gap: 0.55rem;
         }
@@ -1330,6 +1434,10 @@
             font-size: 0.72rem;
         }
 
+        .messages-page.has-active-thread #dm-composer:not(.dm-composer-recipient-mode) .dm-composer-actions-left .text-muted {
+            display: none;
+        }
+
         .dm-composer-actions-right {
             justify-content: flex-end;
         }
@@ -1362,6 +1470,11 @@
             display: none;
         }
 
+        .messages-page.has-active-thread .dm-sidebar {
+            width: min(90vw, 320px);
+            max-width: calc(100% - 1.8rem);
+        }
+
         .dm-avatar {
             width: 30px;
             height: 30px;
@@ -1385,7 +1498,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="messages-page">
+<div class="messages-page {% if active_thread and not search_query %}has-active-thread{% else %}no-active-thread{% endif %}">
     <div class="messages-topbar">
         <div class="messages-topbar-copy">
             <h1><i class="bi bi-chat-dots"></i> Direct Messages</h1>
@@ -1402,7 +1515,16 @@
     </div>
 
     <div class="messages-shell">
-        <aside class="dm-sidebar">
+        <aside class="dm-sidebar" id="dm-sidebar">
+            <div class="dm-sidebar-mobile-header">
+                <div>
+                    <strong>Chats</strong>
+                    <small>Direct and group conversations</small>
+                </div>
+                <button class="btn btn-sm btn-outline-secondary" type="button" onclick="toggleDmMobileSidebar(false)" aria-label="Close chats list">
+                    <i class="bi bi-x-lg"></i>
+                </button>
+            </div>
             <div class="dm-sidebar-search">
                 <form onsubmit="searchMessages(); return false;">
                     <div class="dm-search-input-wrap">
@@ -1418,6 +1540,7 @@
                 </div>
             </div>
         </aside>
+        <button type="button" class="dm-mobile-sidebar-backdrop" onclick="toggleDmMobileSidebar(false)" aria-label="Close chats list" aria-hidden="true"></button>
 
         <section class="dm-thread-pane">
             <div class="dm-thread-header" id="dm-thread-header">
@@ -1520,6 +1643,7 @@
     let dmChannelHighlightIndex = 0;
     let activeReplyContext = null;
     let composerUsesActiveThread = !!ACTIVE_THREAD;
+    let composerForceNewGroupThread = false;
     const dmInlineEditStates = {};
     let dmSnapshotSerial = 0;
     let dmEventCursor = {{ workspace_event_cursor|tojson }};
@@ -1660,6 +1784,7 @@
         updateComposerTarget();
         applyDmRichContent();
         restoreThreadScrollState(previousScroll, opts);
+        syncDmMobileLayoutState();
 
         if (opts.pushHistory && typeof opts.targetUrl === 'string' && opts.targetUrl) {
             window.history.replaceState({}, '', opts.targetUrl);
@@ -1844,11 +1969,37 @@
 
     function startNewConversation() {
         composerUsesActiveThread = false;
+        composerForceNewGroupThread = false;
         selectedRecipients = [];
         updateRecipientChips();
         clearRecipientInput();
         toggleRecipientEditor(true);
         clearReplyContext();
+        updateComposerTarget();
+        const textarea = document.getElementById('messageContent');
+        if (textarea) {
+            textarea.focus();
+        }
+    }
+
+    function startFreshGroupDiscussion() {
+        if (!ACTIVE_THREAD || ACTIVE_THREAD.kind !== 'group') {
+            startNewConversation();
+            return;
+        }
+        const recipients = Array.isArray(INITIAL_RECIPIENTS) ? [...INITIAL_RECIPIENTS] : [];
+        if (recipients.length < 2) {
+            showAlert('A fresh thread needs at least two other group participants.', 'warning');
+            return;
+        }
+        composerUsesActiveThread = false;
+        composerForceNewGroupThread = true;
+        selectedRecipients = recipients;
+        updateRecipientChips();
+        clearRecipientInput();
+        clearReplyContext();
+        const panel = document.getElementById('composer-recipient-panel');
+        if (panel) panel.style.display = 'none';
         updateComposerTarget();
         const textarea = document.getElementById('messageContent');
         if (textarea) {
@@ -1878,6 +2029,11 @@
         const title = document.getElementById('composer-target-title');
         const subtitle = document.getElementById('composer-target-subtitle');
         const panel = document.getElementById('composer-recipient-panel');
+        const composer = document.getElementById('dm-composer');
+        if (composer) {
+            composer.classList.toggle('dm-composer-recipient-mode', !composerUsesActiveThread || !ACTIVE_THREAD);
+            composer.classList.toggle('dm-composer-fresh-group-thread', !!composerForceNewGroupThread);
+        }
         if (!title || !subtitle) return;
 
         if (composerUsesActiveThread && ACTIVE_THREAD) {
@@ -1892,10 +2048,73 @@
         if (selectedRecipients.length) {
             const names = selectedRecipients.map(rec => rec.display_name || rec.username || rec.user_id);
             title.textContent = names.join(', ');
-            subtitle.textContent = selectedRecipients.length > 1 ? `New group DM with ${selectedRecipients.length} recipients` : 'New direct message';
+            if (composerForceNewGroupThread && selectedRecipients.length > 1) {
+                subtitle.textContent = `Fresh group thread with ${selectedRecipients.length} recipients`;
+            } else {
+                subtitle.textContent = selectedRecipients.length > 1 ? `New group DM with ${selectedRecipients.length} recipients` : 'New direct message';
+            }
         } else {
             title.textContent = 'New conversation';
             subtitle.textContent = 'Select one or more recipients to begin';
+        }
+    }
+
+    function isCompactDmViewport() {
+        return window.matchMedia('(max-width: 767.98px)').matches;
+    }
+
+    // rAF gate: collapses rapid resize events (e.g. desktop window drag or
+    // mobile keyboard transition) into a single layout sync per frame.
+    let _dmLayoutSyncQueued = false;
+    function scheduleDmMobileLayoutSync() {
+        if (_dmLayoutSyncQueued) return;
+        _dmLayoutSyncQueued = true;
+        requestAnimationFrame(() => {
+            _dmLayoutSyncQueued = false;
+            syncDmMobileLayoutState({ keepSidebarOpen: true });
+        });
+    }
+
+    function syncDmMobileLayoutState(options) {
+        const opts = options || {};
+        const page = document.querySelector('.messages-page');
+        if (!page) return;
+        const hasActiveThread = !!ACTIVE_THREAD && !isDmSearchActive();
+        page.classList.toggle('has-active-thread', hasActiveThread);
+        page.classList.toggle('no-active-thread', !hasActiveThread);
+        if (!isCompactDmViewport() || !hasActiveThread) {
+            page.classList.remove('dm-mobile-sidebar-open');
+        } else if (!opts.keepSidebarOpen) {
+            page.classList.remove('dm-mobile-sidebar-open');
+        }
+        const isSidebarOpen = page.classList.contains('dm-mobile-sidebar-open');
+        document.querySelectorAll('.dm-mobile-sidebar-toggle').forEach((button) => {
+            button.setAttribute('aria-expanded', isSidebarOpen ? 'true' : 'false');
+        });
+        const backdrop = document.querySelector('.dm-mobile-sidebar-backdrop');
+        if (backdrop) {
+            backdrop.setAttribute('aria-hidden', isSidebarOpen ? 'false' : 'true');
+        }
+        if (!isCompactDmViewport() || !hasActiveThread) {
+            return;
+        }
+    }
+
+    function toggleDmMobileSidebar(forceOpen) {
+        const page = document.querySelector('.messages-page');
+        if (!page || !isCompactDmViewport() || !ACTIVE_THREAD || isDmSearchActive()) {
+            return;
+        }
+        const shouldOpen = typeof forceOpen === 'boolean'
+            ? forceOpen
+            : !page.classList.contains('dm-mobile-sidebar-open');
+        page.classList.toggle('dm-mobile-sidebar-open', shouldOpen);
+        document.querySelectorAll('.dm-mobile-sidebar-toggle').forEach((button) => {
+            button.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+        });
+        const backdrop = document.querySelector('.dm-mobile-sidebar-backdrop');
+        if (backdrop) {
+            backdrop.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
         }
     }
 
@@ -2828,6 +3047,9 @@
 
         if (recipients.length > 1) payload.recipient_ids = recipients;
         else payload.recipient_id = recipients[0];
+        if (composerForceNewGroupThread && recipients.length > 1) {
+            payload.force_new_group = true;
+        }
 
         if (activeReplyContext && activeReplyContext.messageId) {
             payload.reply_to = activeReplyContext.messageId;
@@ -2855,6 +3077,7 @@
             updateMessageFilePreview();
             clearReplyContext();
             composerUsesActiveThread = true;
+            composerForceNewGroupThread = false;
             const appended = appendOptimisticDmMessage((data && data.message) || null, {
                 targetUrl,
                 replyPreview,
@@ -3087,6 +3310,7 @@
         }
         if (textEl) {
             textEl.textContent = content || '';
+            applyDmRichContentInScope(msgEl);
         }
         const footer = msgEl.querySelector('.dm-bubble-footer');
         if (footer) {
@@ -3135,11 +3359,6 @@
             );
             cancelInlineMessageEdit(messageId, true);
             showAlert('Message updated successfully', 'success');
-            loadDmSnapshot({
-                forceBottom: false,
-                allowDeferred: false,
-                hardFallback: false,
-            }).catch(err => showAlert('Failed to refresh message thread: ' + (err.message || err), 'danger'));
         })
         .catch(err => showAlert('Failed to update message: ' + (err.message || err), 'danger'))
         .finally(() => {
@@ -3183,6 +3402,7 @@
     document.addEventListener('DOMContentLoaded', function() {
         updateRecipientChips();
         updateComposerTarget();
+        syncDmMobileLayoutState();
         setupMessageFileUpload();
         setupMessagePasteHandler();
         setupMessageDropzone();
@@ -3234,14 +3454,17 @@
             scrollThreadToBottom();
         }
         startDmPolling();
+        window.addEventListener('resize', scheduleDmMobileLayoutSync);
+        window.addEventListener('focus', () => syncDmMobileLayoutState({ keepSidebarOpen: true }));
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                toggleDmMobileSidebar(false);
+            }
+        });
         document.addEventListener('visibilitychange', () => {
             if (!document.hidden && !isDmSearchActive()) {
+                syncDmMobileLayoutState({ keepSidebarOpen: true });
                 pollDmEvents();
-                loadDmSnapshot({
-                    allowDeferred: true,
-                    forceBottom: false,
-                    hardFallback: false,
-                }).catch(() => {});
             }
         });
     });

--- a/canopy/ui/templates/profile.html
+++ b/canopy/ui/templates/profile.html
@@ -278,6 +278,17 @@
         </div>
     </div>
 
+    {% if is_instance_owner %}
+    <div class="alert alert-info border-0 shadow-sm">
+        <strong>Connection review model:</strong> Connect cards now use the device profile for the peer name and peer avatar,
+        while the mesh image/name come from the active mesh. This account profile remains your in-app user identity.
+    </div>
+    {% else %}
+    <div class="alert alert-secondary border-0 shadow-sm">
+        This account profile is for in-app identity. Connect cards and invite review now use the device profile for the peer identity instead.
+    </div>
+    {% endif %}
+
     <div class="row">
         <div class="col-lg-8">
             <!-- Profile Information Form -->
@@ -309,7 +320,13 @@
                                        value="{{ profile.display_name or '' }}" 
                                        placeholder="How others see your name"
                                        maxlength="100">
-                                <div class="form-text text-muted">This is the name shown to other users (optional)</div>
+                                <div class="form-text text-muted">
+                                    {% if is_instance_owner %}
+                                    This is your account display name inside Canopy. The peer name on Connect cards now comes from <code>Settings &gt; Device Profile</code>.
+                                    {% else %}
+                                    This is your in-app profile name.
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                         
@@ -382,6 +399,56 @@
         </div>
 
         <div class="col-lg-4">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <i class="bi bi-person-badge me-2"></i>
+                    Connection Hint Preview
+                </div>
+                <div class="card-body">
+                    <p class="text-muted small mb-3">
+                        This is the identity bundle remote users review before connecting.
+                    </p>
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-circle overflow-hidden border d-flex align-items-center justify-content-center bg-body-tertiary" style="width:56px; height:56px; flex-shrink:0;">
+                            {% if connection_identity_preview.peer_avatar_url %}
+                            <img src="{{ connection_identity_preview.peer_avatar_url }}" alt="" style="width:100%; height:100%; object-fit:cover;">
+                            {% else %}
+                            <i class="bi {{ connection_identity_preview.peer_icon or 'bi-pc-display-horizontal' }} fs-3 text-muted"></i>
+                            {% endif %}
+                        </div>
+                        <div class="min-w-0">
+                            <div class="text-uppercase small text-muted">Peer identity</div>
+                            <div class="fw-semibold">{{ connection_identity_preview.peer_label or 'Set in Settings > Device Profile' }}</div>
+                            <div class="small text-muted">Instance/device identity from <code>Settings &gt; Device Profile</code>.</div>
+                        </div>
+                    </div>
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="rounded-4 overflow-hidden border d-flex align-items-center justify-content-center bg-body-tertiary" style="width:56px; height:56px; flex-shrink:0;">
+                            {% if connection_identity_preview.mesh_avatar_url %}
+                            <img src="{{ connection_identity_preview.mesh_avatar_url }}" alt="" style="width:100%; height:100%; object-fit:cover;">
+                            {% else %}
+                            <i class="bi bi-diagram-3 fs-4 text-muted"></i>
+                            {% endif %}
+                        </div>
+                        <div class="min-w-0">
+                            <div class="text-uppercase small text-muted">Mesh identity</div>
+                            <div class="fw-semibold">{{ connection_identity_preview.mesh_name }}</div>
+                            <div class="small text-muted">{{ connection_identity_preview.meshspace_id or 'Mesh ID pending' }}</div>
+                        </div>
+                    </div>
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="rounded-4 border d-flex align-items-center justify-content-center bg-body-tertiary" style="width:56px; height:56px; flex-shrink:0;">
+                            <i class="bi {{ connection_identity_preview.instance_icon or 'bi-pc-display-horizontal' }} fs-4 text-muted"></i>
+                        </div>
+                        <div class="min-w-0">
+                            <div class="text-uppercase small text-muted">Node hint</div>
+                            <div class="fw-semibold">{{ connection_identity_preview.instance_label or 'Set a device name in Settings' }}</div>
+                            <div class="small text-muted">Additional machine hint from <code>Settings &gt; Device Profile</code>.</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Change Password -->
             <div class="card mb-4">
                 <div class="card-header">
@@ -426,6 +493,9 @@
                     <p class="text-muted small mb-2">
                         <i class="bi bi-info-circle"></i> 
                         <strong>Two ways to upload:</strong> Click the box below or drag and drop an image file onto it.
+                        {% if is_instance_owner %}
+                        This avatar stays with your user profile inside Canopy. The peer image shown during connection review now comes from <code>Settings &gt; Device Profile</code>.
+                        {% endif %}
                     </p>
                     <div class="file-drop-zone" id="avatar-drop-zone">
                         <i class="bi bi-cloud-upload fs-2 text-muted mb-2"></i>

--- a/canopy/ui/templates/settings.html
+++ b/canopy/ui/templates/settings.html
@@ -106,10 +106,57 @@
             </div>
             <div class="card-body">
                 <p class="text-muted small mb-3">
-                    Give this device a unique identity that other peers will see in the network.
-                    Channels and content originating from this device will be tagged with this profile.
-                    This helps identify which of your devices created content when you run Canopy on multiple machines.
+                    Give this machine the peer identity shown during connection review.
+                    The peer name/avatar now come from this device profile, while the mesh name/avatar come from the active mesh.
+                    Use it to help people recognize which instance or node sent the invite.
                 </p>
+                {% if is_admin %}
+                <div class="alert alert-info small">
+                    <strong>Identity split:</strong> <code>Device Profile</code> controls the peer identity, <code>Mesh</code> controls the mesh hint,
+                    and <code>Profile</code> remains your in-app user account identity.
+                </div>
+                <div class="card border-0 bg-body-tertiary mb-3">
+                    <div class="card-body">
+                        <div class="text-uppercase small text-muted mb-2">Connection Hint Preview</div>
+                        <div class="d-flex align-items-center gap-3 mb-3">
+                            <div class="rounded-circle overflow-hidden border d-flex align-items-center justify-content-center bg-body" style="width:52px; height:52px; flex-shrink:0;">
+                                {% if connection_identity_preview.peer_avatar_url %}
+                                <img src="{{ connection_identity_preview.peer_avatar_url }}" alt="" style="width:100%; height:100%; object-fit:cover;">
+                                {% else %}
+                                <i class="bi {{ connection_identity_preview.peer_icon or 'bi-pc-display-horizontal' }} fs-4 text-muted"></i>
+                                {% endif %}
+                            </div>
+                            <div>
+                                <div class="text-uppercase small text-muted">Peer identity</div>
+                                <div class="fw-semibold">{{ connection_identity_preview.peer_label or 'Set below' }}</div>
+                            </div>
+                        </div>
+                        <div class="d-flex align-items-center gap-3 mb-3">
+                            <div class="rounded-4 overflow-hidden border d-flex align-items-center justify-content-center bg-body" style="width:52px; height:52px; flex-shrink:0;">
+                                {% if connection_identity_preview.mesh_avatar_url %}
+                                <img src="{{ connection_identity_preview.mesh_avatar_url }}" alt="" style="width:100%; height:100%; object-fit:cover;">
+                                {% else %}
+                                <i class="bi bi-diagram-3 fs-5 text-muted"></i>
+                                {% endif %}
+                            </div>
+                            <div>
+                                <div class="text-uppercase small text-muted">Mesh identity</div>
+                                <div class="fw-semibold">{{ connection_identity_preview.mesh_name }}</div>
+                                <div class="small text-muted">{{ connection_identity_preview.meshspace_id or 'Mesh ID pending' }}</div>
+                            </div>
+                        </div>
+                        <div class="d-flex align-items-center gap-3">
+                            <div class="rounded-4 border d-flex align-items-center justify-content-center bg-body" style="width:52px; height:52px; flex-shrink:0;">
+                                <i class="bi {{ connection_identity_preview.instance_icon or 'bi-pc-display-horizontal' }} fs-5 text-muted"></i>
+                            </div>
+                            <div>
+                                <div class="text-uppercase small text-muted">Node hint</div>
+                                <div class="fw-semibold">{{ connection_identity_preview.instance_label or 'Set below' }}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
                 <div class="row settings-device-row">
                     <div class="col-md-3 text-center mb-3">
                         <div id="device-avatar-preview" style="width:100px; height:100px; border-radius:50%; margin:0 auto; background:var(--canopy-bg-card); border:2px dashed var(--canopy-border); display:flex; align-items:center; justify-content:center; overflow:hidden;">
@@ -131,6 +178,17 @@
                             <label for="device-description" class="form-label">Description</label>
                             <textarea class="form-control" id="device-description" rows="2"
                                       placeholder="Brief description of this device"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="device-icon" class="form-label">Node Hint Icon</label>
+                            <select class="form-select" id="device-icon" onchange="updateDeviceIconPreview()">
+                                {% for choice in device_icon_choices %}
+                                <option value="{{ choice.value }}">{{ choice.label }}</option>
+                                {% endfor %}
+                            </select>
+                            <div class="form-text">
+                                Shared in the invite as a compact fallback when avatar images are missing or remote preview fetches fail.
+                            </div>
                         </div>
                         <button class="btn btn-primary btn-sm" onclick="saveDeviceProfile()">
                             <i class="bi bi-check-lg"></i> Save Device Profile
@@ -709,6 +767,18 @@
         status.style.color = cssVar || 'var(--bs-secondary)';
     }
 
+    function selectedDeviceIcon() {
+        return document.getElementById('device-icon')?.value || 'bi-pc-display-horizontal';
+    }
+
+    function updateDeviceIconPreview() {
+        const placeholder = document.getElementById('device-avatar-placeholder');
+        if (!placeholder) return;
+        placeholder.className = 'bi ' + selectedDeviceIcon();
+        placeholder.style.fontSize = '2rem';
+        placeholder.style.opacity = '0.4';
+    }
+
     function loadDeviceProfile() {
         fetch('/api/v1/device/profile')
             .then(r => r.json())
@@ -719,6 +789,9 @@
                 if (data.description) {
                     document.getElementById('device-description').value = data.description;
                 }
+                if (data.icon) {
+                    document.getElementById('device-icon').value = data.icon;
+                }
                 if (data.avatar_b64 && data.avatar_mime) {
                     _deviceAvatarB64 = data.avatar_b64;
                     _deviceAvatarMime = data.avatar_mime;
@@ -727,6 +800,7 @@
                     img.style.display = 'block';
                     document.getElementById('device-avatar-placeholder').style.display = 'none';
                 }
+                updateDeviceIconPreview();
             })
             .catch(() => {});
     }
@@ -801,6 +875,7 @@
         const body = {
             display_name: document.getElementById('device-display-name').value,
             description: document.getElementById('device-description').value,
+            icon: selectedDeviceIcon(),
         };
         if (_deviceAvatarB64) {
             body.avatar_b64 = _deviceAvatarB64;

--- a/canopy/ui/templates/trust.html
+++ b/canopy/ui/templates/trust.html
@@ -378,6 +378,69 @@
         gap: 8px;
     }
 
+    .trust-peer-summary {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 8px;
+    }
+
+    .trust-summary-item {
+        min-width: 0;
+        padding: 10px 11px;
+        border-radius: 14px;
+        background: rgba(15, 23, 42, 0.5);
+        border: 1px solid rgba(148, 163, 184, 0.13);
+    }
+
+    .trust-summary-label {
+        display: block;
+        font-size: 0.62rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.9);
+        margin-bottom: 4px;
+    }
+
+    .trust-summary-value {
+        display: block;
+        color: rgba(248, 250, 252, 0.94);
+        font-size: 0.84rem;
+        font-weight: 700;
+        line-height: 1.25;
+        overflow-wrap: anywhere;
+    }
+
+    .trust-summary-note {
+        display: block;
+        margin-top: 3px;
+        color: rgba(203, 213, 225, 0.72);
+        font-size: 0.72rem;
+        line-height: 1.35;
+        overflow-wrap: anywhere;
+    }
+
+    .trust-summary-item.connection-live,
+    .trust-summary-item.review-clear,
+    .trust-summary-item.identity-verified {
+        border-color: rgba(52, 211, 153, 0.24);
+        background: rgba(5, 46, 22, 0.28);
+    }
+
+    .trust-summary-item.connection-known,
+    .trust-summary-item.connection-introduced,
+    .trust-summary-item.review-pending,
+    .trust-summary-item.identity-unverified {
+        border-color: rgba(250, 204, 21, 0.24);
+        background: rgba(113, 63, 18, 0.24);
+    }
+
+    .trust-summary-item.connection-stale,
+    .trust-summary-item.review-blocked,
+    .trust-summary-item.identity-incomplete {
+        border-color: rgba(248, 113, 113, 0.24);
+        background: rgba(127, 29, 29, 0.22);
+    }
+
     .trust-badge {
         padding: 4px 9px;
         border-radius: 999px;
@@ -438,6 +501,24 @@
     .trust-badge.source-fallback {
         color: #fda4af;
         border-color: rgba(251, 113, 133, 0.24);
+    }
+
+    .trust-badge.sync-preview {
+        color: #facc15;
+        border-color: rgba(250, 204, 21, 0.24);
+        background: rgba(113, 63, 18, 0.34);
+    }
+
+    .trust-badge.sync-peer {
+        color: #93c5fd;
+        border-color: rgba(96, 165, 250, 0.24);
+        background: rgba(30, 58, 138, 0.34);
+    }
+
+    .trust-badge.sync-mesh {
+        color: #34d399;
+        border-color: rgba(52, 211, 153, 0.28);
+        background: rgba(5, 46, 22, 0.5);
     }
 
     .trust-peer-details {
@@ -621,7 +702,8 @@
         }
 
         .trust-zone-list,
-        .trust-peer-details {
+        .trust-peer-details,
+        .trust-peer-summary {
             grid-template-columns: 1fr;
         }
 
@@ -675,6 +757,18 @@
             {% if allow_actions %}
                 <div class="trust-brief-actions">
                     <a class="btn btn-outline-light btn-sm" href="#trust-peer-{{ peer.peer_id }}">Open card</a>
+                    {% if is_admin and peer.can_allow_sync %}
+                        <button type="button" class="btn btn-warning btn-sm" onclick="runTrustPeerAction('{{ peer.peer_id }}', 'allow_sync', this)">Allow peer sync</button>
+                    {% endif %}
+                    {% if is_admin and peer.can_allow_mesh_sync %}
+                        <button type="button" class="btn btn-outline-warning btn-sm" onclick="runTrustPeerAction('{{ peer.peer_id }}', 'allow_mesh_sync', this)">Allow mesh sync</button>
+                    {% endif %}
+                    {% if is_admin and peer.can_treat_same_mesh %}
+                        <button type="button" class="btn btn-outline-success btn-sm" onclick="runTrustPeerAction('{{ peer.peer_id }}', 'treat_same_mesh', this)">Treat as same mesh</button>
+                    {% endif %}
+                    {% if is_admin and peer.can_keep_bridge %}
+                        <button type="button" class="btn btn-outline-warning btn-sm" onclick="runTrustPeerAction('{{ peer.peer_id }}', 'keep_cross_mesh_bridge', this)">Keep bridge</button>
+                    {% endif %}
                     {% if peer.can_connect_now %}
                         <button type="button" class="btn btn-outline-primary btn-sm" onclick="runTrustPeerAction('{{ peer.peer_id }}', 'connect_introduced', this)">Connect</button>
                     {% elif peer.can_reconnect %}
@@ -694,7 +788,7 @@
 
 {% macro render_peer_card(peer, tier='potential') %}
     {% set peer_id = peer.peer_id %}
-    <div class="trust-peer-card trust-node" id="trust-peer-{{ peer.peer_id }}" draggable="true" data-peer-id="{{ peer.peer_id }}" data-tier="{{ tier }}">
+    <div class="trust-peer-card trust-node" id="trust-peer-{{ peer.peer_id }}" draggable="true" data-peer-id="{{ peer.peer_id }}" data-tier="{{ tier }}" data-needs-review="{{ 1 if peer.requires_review_attention else 0 }}">
         <div class="trust-peer-top">
             {{ render_peer_avatar(peer) }}
             <div class="trust-peer-main">
@@ -704,9 +798,11 @@
                 <div class="trust-peer-sub">
                     <span class="trust-peer-id">{{ peer.short_id }}</span>
                     <span>·</span>
-                    <span>{{ peer.display_name_source_label }}</span>
+                    <span>{{ peer.identity_status_label }}</span>
                 </div>
-                <p class="trust-peer-desc">{{ peer.description or peer.connection_note }}</p>
+                {% if peer.description %}
+                <p class="trust-peer-desc">{{ peer.description }}</p>
+                {% endif %}
             </div>
             <div class="trust-score-pill">
                 <span class="trust-score-label">Trust</span>
@@ -714,14 +810,23 @@
             </div>
         </div>
 
-        <div class="trust-peer-badges">
-            <span class="trust-badge connection-{{ peer.connection_state }}">{{ peer.connection_label }}</span>
-            <span class="trust-badge role-{{ peer.role_state }}">{{ peer.role_label }}</span>
-            <span class="trust-badge source-{{ 'fallback' if peer.display_name_source == 'fallback' else 'profile' }}">{{ peer.display_name_source_label }}</span>
+        <div class="trust-peer-summary" aria-label="Peer review summary">
+            {% for item in peer.review_summary %}
+                <div class="trust-summary-item {{ item.class_name }}">
+                    <span class="trust-summary-label">{{ item.label }}</span>
+                    <span class="trust-summary-value">{{ item.value }}</span>
+                    <span class="trust-summary-note">{{ item.note }}</span>
+                </div>
+            {% endfor %}
+        </div>
+
+        {% if peer.attention_flags %}
+        <div class="trust-peer-badges" aria-label="Outstanding peer warnings">
             {% for flag in peer.attention_flags %}
                 <span class="trust-badge needs-attention">{{ flag }}</span>
             {% endfor %}
         </div>
+        {% endif %}
 
         <div class="trust-peer-details">
             <div class="trust-detail">
@@ -746,10 +851,28 @@
                 <span class="trust-detail-label">Introduced By</span>
                 <span class="trust-detail-value">{{ peer.introduced_by_label or 'Direct / unknown' }}</span>
             </div>
+            <div class="trust-detail">
+                <span class="trust-detail-label">Sync Boundary</span>
+                <span class="trust-detail-value">{{ peer.sync_status_note }}</span>
+            </div>
+            <div class="trust-detail">
+                <span class="trust-detail-label">Mesh Preview</span>
+                <span class="trust-detail-value">
+                    {% if peer.remote_meshspace_name or peer.remote_meshspace_id %}
+                        {{ peer.remote_meshspace_name or peer.remote_meshspace_id }}
+                    {% else %}
+                        No mesh hint yet
+                    {% endif %}
+                </span>
+            </div>
+            <div class="trust-detail">
+                <span class="trust-detail-label">Mesh Relationship</span>
+                <span class="trust-detail-value">{{ peer.mesh_relationship_label }}</span>
+            </div>
         </div>
 
         <div class="trust-peer-footer">
-            <select class="trust-tier-select" data-peer-id="{{ peer.peer_id }}">
+            <select class="trust-tier-select" data-peer-id="{{ peer.peer_id }}" {% if not is_admin %}disabled title="Only the instance admin can change trust tiers."{% endif %}>
                 {% if tier == 'potential' %}
                     <option value="" selected disabled>Assign tier...</option>
                 {% endif %}
@@ -759,6 +882,26 @@
                 <option value="quarantine" {% if tier == 'quarantine' %}selected{% endif %}>Quarantine</option>
             </select>
             <div class="trust-peer-actions">
+                {% if is_admin and peer.can_allow_sync %}
+                    <button type="button" class="btn btn-warning btn-sm" onclick="runTrustPeerAction('{{ peer_id }}', 'allow_sync', this)">
+                        Allow peer sync
+                    </button>
+                {% endif %}
+                {% if is_admin and peer.can_allow_mesh_sync %}
+                    <button type="button" class="btn btn-outline-warning btn-sm" onclick="runTrustPeerAction('{{ peer_id }}', 'allow_mesh_sync', this)">
+                        Allow mesh sync
+                    </button>
+                {% endif %}
+                {% if is_admin and peer.can_treat_same_mesh %}
+                    <button type="button" class="btn btn-outline-success btn-sm" onclick="runTrustPeerAction('{{ peer_id }}', 'treat_same_mesh', this)">
+                        Treat as same mesh
+                    </button>
+                {% endif %}
+                {% if is_admin and peer.can_keep_bridge %}
+                    <button type="button" class="btn btn-outline-warning btn-sm" onclick="runTrustPeerAction('{{ peer_id }}', 'keep_cross_mesh_bridge', this)">
+                        Keep bridge
+                    </button>
+                {% endif %}
                 {% if peer.can_connect_now %}
                     <button type="button" class="btn btn-outline-primary btn-sm" onclick="runTrustPeerAction('{{ peer_id }}', 'connect_introduced', this)">
                         Connect
@@ -802,7 +945,7 @@
                 <p class="trust-subtitle">
                     Review live peers, stale records, pending introductions, and trust assignments from one place.
                     This view is designed to answer the operational questions that matter: who is actually connected,
-                    who is only partially identified, and who should be isolated or forgotten.
+                    who is only partially identified, and which peers are still preview-only until you approve sync.
                 </p>
                 <div class="trust-actions">
                     <button class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#deleteSignalModal">
@@ -951,12 +1094,15 @@
 
                 <div class="trust-panel trust-side-card">
                     <h3 class="trust-side-title">Needs Review</h3>
-                    <p class="trust-side-sub">Peers that are stale, missing a real device label, or still have an unknown role classification.</p>
+                    <p class="trust-side-sub">Peers that are preview-only, blocked on mesh review, stale, or still missing enough identity context for a safe human decision.</p>
                     <div class="trust-side-list">
                         {% if attention_peers %}
                             {% for peer in attention_peers[:8] %}
                                 {{ render_peer_brief(peer, True) }}
                             {% endfor %}
+                            {% if attention_peers|length > 8 %}
+                                <div class="trust-zone-empty">Showing 8 of {{ attention_peers|length }} peers that still need review.</div>
+                            {% endif %}
                         {% else %}
                             <div class="trust-zone-empty">No obvious trust hygiene issues right now.</div>
                         {% endif %}
@@ -1127,7 +1273,7 @@
         })
         .then(data => {
             showAlert(data.message || 'Peer action completed.', 'success');
-            if (cleanAction === 'connect_introduced' || cleanAction === 'reconnect' || cleanAction === 'sync_now' || cleanAction === 'refresh_profile') {
+            if (cleanAction === 'connect_introduced' || cleanAction === 'reconnect' || cleanAction === 'sync_now' || cleanAction === 'refresh_profile' || cleanAction === 'allow_sync' || cleanAction === 'allow_mesh_sync' || cleanAction === 'treat_same_mesh' || cleanAction === 'keep_cross_mesh_bridge') {
                 setTimeout(refreshTrust, 900);
             }
         })
@@ -1176,9 +1322,11 @@
         const restrictedCount = document.querySelector('.trust-zone.restricted')?.querySelectorAll('.trust-node').length || 0;
         const quarantineCount = document.querySelector('.trust-zone.quarantine')?.querySelectorAll('.trust-node').length || 0;
         const potentialCount = document.querySelector('[data-potential-list]')?.querySelectorAll('.trust-node').length || 0;
-        const attentionCount = document.querySelectorAll('.trust-badge.needs-attention').length
-            ? new Set(Array.from(document.querySelectorAll('.trust-node')).filter(node => node.querySelector('.trust-badge.needs-attention')).map(node => node.getAttribute('data-peer-id'))).size
-            : 0;
+        const attentionCount = new Set(
+            Array.from(document.querySelectorAll('.trust-node[data-needs-review="1"]'))
+                .map(node => node.getAttribute('data-peer-id'))
+                .filter(Boolean)
+        ).size;
 
         const safeStat = document.querySelector('[data-stat-safe]');
         if (safeStat) safeStat.textContent = safeCount;

--- a/docs/CONNECT_FAQ.md
+++ b/docs/CONNECT_FAQ.md
@@ -1,6 +1,6 @@
 # Connect Page FAQ and Feature Reference
 
-This document explains exactly what each section/button on the **Connect** page does, and clarifies common confusion around endpoint addresses, public IP usage, and authentication errors.
+This document explains exactly what each section/button on the **Connect** page does, and clarifies common confusion around endpoint addresses, preview-only peers, mesh review, public IP usage, and authentication errors.
 
 ---
 
@@ -9,9 +9,10 @@ This document explains exactly what each section/button on the **Connect** page 
 The Connect page is the operational control center for:
 
 - generating shareable invite codes,
-- importing and connecting to peer invites,
+- reviewing, importing, and connecting to peer invites,
 - monitoring peer connectivity state,
 - reconnect/disconnect/forget workflows,
+- sending first-contact peers into Trust for review,
 - mesh diagnostics and connection history.
 
 It is intentionally action-first. The important value is whether you can connect, reconnect, relay, and diagnose peers from one place, not how many decorative counters fit at the top of the page.
@@ -27,6 +28,7 @@ What it shows:
 - **Peer ID**: your local cryptographic identity.
 - **Reachable at**: one or more `ws://host:port` endpoint candidates included in your invite.
 - **Invite code**: compact `canopy:...` payload containing identity + endpoint list.
+- **Peer-facing identity hints**: the remote side will see the peer name/avatar/node hint built from **Settings -> Device Profile** plus the active mesh hint.
 
 Buttons/actions:
 
@@ -37,6 +39,7 @@ Why this makes sense:
 
 - Invite codes need both identity and reachability hints.
 - Including multiple endpoint candidates increases the chance another peer can connect.
+- Keeping the human-facing peer identity in **Device Profile** helps people recognize the machine or node they are being asked to trust.
 
 ---
 
@@ -44,18 +47,52 @@ Why this makes sense:
 
 Action:
 
-- Paste a `canopy:...` invite and click **Connect**.
+- Paste a `canopy:...` invite, click **Review Invite**, then click **Connect to this peer** if the review looks right.
 
 Behavior:
 
-- Registers the remote peer identity locally.
+- Decodes the invite locally so you can review:
+  - **Peer identity**
+  - **Mesh hint**
+  - **Meshspace ID**
+  - **Node hint**
+  - **Reachability**
+- Can enrich the preview with a safe remote fetch of mesh/peer art when the remote node is reachable.
+- Registers the remote peer identity locally when imported.
 - Attempts to connect to each endpoint in the invite.
 - Returns either connected status or imported-but-not-connected state.
+- If transport succeeds on first contact, the peer may still remain **preview-only** until an admin approves sync.
 
 Why this makes sense:
 
-- Import succeeds independently of immediate network success.
-- This allows later reconnect when endpoint/network conditions improve.
+- Import and transport review are separated from trust/sync approval.
+- This lets operators verify who they are connecting to before history and channels begin syncing.
+- Import succeeds independently of immediate network success, so later reconnect is still possible when endpoint/network conditions improve.
+
+### What "preview-only" means
+
+`preview-only` means the peer connection is real enough to review, but Canopy is still pausing channel/history sync until an admin approves it in **Trust**.
+
+While a peer is preview-only:
+
+- transport can be connected
+- human-readable peer labels and node hints can still appear
+- mesh hints can still be compared
+- channel sync, history catch-up, and wider mesh expansion stay paused
+
+This is intentional. It prevents a first-contact mistake from immediately contaminating the workspace with the wrong peer or wrong mesh.
+
+---
+
+### What the Trust actions mean
+
+When a peer shows up in **Trust**, the common actions are:
+
+- **Allow peer sync**: trust this specific peer enough to exchange channels, history, and other workspace content with it.
+- **Allow mesh sync**: trust that peer's mesh as part of the same shared workspace, so future peers from that mesh do not stay stuck in review-only state.
+- **Treat as same mesh**: confirm that a mismatched mesh name/ID is really just another identifier for the same workspace.
+- **Keep bridge**: keep the connection between two different meshes without treating them as one shared workspace.
+- **Refresh profile**: clear stale preview identity hints and reconnect so Canopy can relearn the current name/avatar without automatically approving sync.
 
 ---
 
@@ -75,6 +112,7 @@ Why this makes sense:
 
 - `Disconnect` is temporary.
 - `Forget` is persistent cleanup and should be a deliberate choice.
+- A peer can appear here even while still preview-only. Connected does not automatically mean approved for sync.
 
 ---
 
@@ -117,6 +155,15 @@ Actions:
 Why this makes sense:
 
 - Persisted peer memory enables recovery after restarts/network interruptions.
+
+### Cross-mesh review
+
+If the invite preview or Trust page says the remote peer advertises a different mesh identity:
+
+- **Treat as same mesh** when the remote mesh ID/name is just a compatibility mismatch or alias for the same real workspace.
+- **Keep bridge** when the peer should stay connected as an intentional cross-mesh bridge, not as part of the same workspace.
+
+This decision belongs on the **Trust** page because it affects sync scope, not just transport reachability.
 
 ---
 
@@ -174,6 +221,33 @@ Fix:
 3. Retry action.
 
 For scripts/CLI/integrations, include `X-API-Key`.
+
+### Why does the invite review show a peer name/avatar that is different from the local user profile?
+
+That is expected. Canopy now separates:
+
+- **Device Profile**: what remote peers see during connection review
+- **Profile**: your in-app user/account identity
+- **Mesh**: the active workspace identity
+
+If you want other operators to recognize this machine during invite review, update **Settings -> Device Profile**.
+
+### What should I do if the peer label or avatar looks stale?
+
+Open **Trust** and use **Refresh profile** on that peer.
+
+For preview-only peers, this clears cached preview identity and safely reconnects so Canopy can relearn fresh label and avatar hints without approving sync. For trusted peers, it can also recover richer profile state.
+
+### When should I leave a peer preview-only?
+
+Leave a peer preview-only when:
+
+- the peer name or avatar is missing or suspicious
+- the mesh hint is unexpected
+- the peer was introduced through another contact and you want to confirm it first
+- the operator has not yet decided whether this is the same mesh or a bridge
+
+Approve sync only when the human-facing identity and mesh context are good enough for that workspace.
 
 ### If I'm behind NAT/router, can I still connect?
 

--- a/docs/PEER_CONNECT_GUIDE.md
+++ b/docs/PEER_CONNECT_GUIDE.md
@@ -2,18 +2,28 @@
 
 This guide is for an AI agent (or human) setting up a **second Canopy instance** on a different machine and connecting it to an existing instance via invite codes.
 
+Version scope: this guide is aligned to Canopy `0.6.27`.
+
 ---
 
 ## Overview
 
 Canopy is a local-first, P2P encrypted communication tool. Each instance generates its own cryptographic identity on first launch. Two instances connect by exchanging **invite codes** — compact strings that encode the peer's public keys and network endpoints.
 
+In current Canopy, first contact is a **review flow**, not just a blind import:
+
+- the sender's **Device Profile** provides the peer-facing machine identity
+- the receiver reviews **peer hint**, **mesh hint**, **meshspace ID**, **node hint**, and **reachability**
+- the connection can succeed while remaining **preview-only** until an admin approves sync in **Trust**
+- cross-mesh peers can be reviewed and then kept as either the same mesh or an intentional bridge
+
 **What you'll do:**
 1. Clone the repo and install dependencies
 2. Launch Canopy on the new machine
-3. Get an invite code from the existing instance (Machine A)
-4. Import it on the new instance (Machine B) — or vice versa
-5. Verify the connection
+3. Set the **Device Profile** the remote side should recognize
+4. Get an invite code from the existing instance (Machine A)
+5. Review and import it on the new instance (Machine B) — or vice versa
+6. Verify the connection and resolve any preview-only review in **Trust**
 
 ---
 
@@ -81,7 +91,19 @@ On first visit you'll be asked to create a username and password — this is loc
 
 ---
 
-## 4. Connect Two Instances (Same LAN)
+## 4. Set the peer-facing identity before sharing invites
+
+Before you share an invite, open **Settings -> Device Profile** on each machine and set:
+
+- a recognizable device name
+- an avatar or node hint icon
+- an optional short description
+
+This matters because the invite review card shows the **machine/node identity** from Device Profile, not the local in-app user profile. If operators only see a raw peer ID or an old machine label, it becomes much harder to decide what to trust.
+
+---
+
+## 5. Connect Two Instances (Same LAN)
 
 If both machines are on the same WiFi/LAN, **mDNS discovery should find them automatically**. Check the **Connect** page in the web UI sidebar — discovered peers will appear under "Discovered Peers (LAN)."
 
@@ -113,7 +135,9 @@ This returns:
 **Option 1 — Web UI:**  
 1. Click **Connect** in the sidebar
 2. Paste Machine A's invite code in "Import Friend's Invite"
-3. Click **Connect**
+3. Click **Review Invite**
+4. Verify the peer identity, mesh hint, node hint, and endpoints
+5. Click **Connect to this peer**
 
 **Option 2 — API:**
 ```bash
@@ -133,6 +157,8 @@ curl -X POST http://localhost:7770/api/v1/p2p/invite/import \
 }
 ```
 
+If this is first contact, a successful transport connection can still remain **preview-only** until an admin approves sync in **Trust**.
+
 **Expected response (peer not reachable):**
 ```json
 {
@@ -143,13 +169,28 @@ curl -X POST http://localhost:7770/api/v1/p2p/invite/import \
 }
 ```
 
-### Then do the reverse!
+### Then do the reverse
 
 For bidirectional communication, Machine A should also import Machine B's invite code. Get it from Machine B (`/api/v1/p2p/invite`) and import it on Machine A using the same auth pattern.
 
 ---
 
-## 5. Connect Two Instances (Different Networks / Over the Internet)
+## 6. What to do after first contact
+
+After transport connects, use the following decision model:
+
+- If the peer and mesh hints look correct, open **Trust** and approve **peer sync** so that specific peer can exchange workspace content.
+- If this peer is the first trusted representative of a remote mesh you intend to share with, approve **mesh sync** so that mesh is treated as part of the same shared workspace.
+- If the peer connected but the label/avatar hints look stale, use **Refresh profile** in **Trust** to relearn fresh preview identity hints without approving sync.
+- If the remote mesh identity differs from the current workspace, an admin should decide whether to:
+  - **Treat as same mesh** when the remote mesh name/ID is really the same workspace under a different label
+  - **Keep bridge** when the connection should stay between separate meshes without merging them
+
+This keeps mistaken imports from immediately syncing history or channels into the wrong workspace.
+
+---
+
+## 7. Connect Two Instances (Different Networks / Over the Internet)
 
 When machines are on different networks (e.g. different houses), you have three main options: **VPN** (easiest), **port forwarding**, or a **tunnel endpoint** such as ngrok.
 
@@ -228,7 +269,7 @@ Canopy preserves the explicit `ws://` or `wss://` scheme from the invite during 
 
 ---
 
-## 6. Send a Message Between Peers
+## 8. Send a Message Between Peers
 
 Once connected, you can send P2P messages:
 
@@ -255,7 +296,7 @@ Use the Messages page — select a recipient or broadcast to all.
 
 ---
 
-## 7. Useful API Endpoints
+## 9. Useful API Endpoints
 
 For CLI and automation clients, include `X-API-Key` on authenticated endpoints.
 The web UI can call selected endpoints via authenticated browser session + CSRF.
@@ -274,7 +315,7 @@ The web UI can call selected endpoints via authenticated browser session + CSRF.
 
 ---
 
-## 8. Mesh Relay & Brokering (Connecting Unreachable Peers)
+## 10. Mesh Relay & Brokering (Connecting Unreachable Peers)
 
 When two peers can't reach each other directly (e.g. Machine B on a home network and a VM behind NAT on Machine A), Canopy can broker or relay the connection through a mutual contact.
 
@@ -356,7 +397,7 @@ Response includes:
 
 ---
 
-## 9. Profile Sync & Peer Discovery
+## 11. Profile Sync, preview-only review, and peer discovery
 
 ### Profile Sync
 
@@ -364,9 +405,28 @@ When two peers connect, they automatically exchange profile cards containing:
 - Display name, bio, and avatar thumbnail (user profile)
 - Device name, description, and avatar (device profile)
 
+Recent Canopy builds treat these differently during first contact:
+
+- **Device Profile** drives the machine identity shown during connection review
+- **Profile** remains the in-app user identity
+- Untrusted or preview-only peers can still share compact identity hints for human recognition
+- Full sync remains paused until approved
+
 Profiles propagate through the mesh: if Machine A is connected to both B and a VM, and B's profile arrives at A, it is re-broadcast to the VM. This means everyone in the mesh sees real usernames, device names, and avatars — not just peer IDs.
 
-**Device profiles** are configured in **Settings → Device Profile**. They help identify which machine is which in the Connect page and channel list (remote channels show the originating device).
+**Device profiles** are configured in **Settings -> Device Profile**. They help identify which machine is which in invite review, the Connect page, and channel lists.
+
+### Preview-only review
+
+Preview-only means the peer is connected enough to inspect, but not yet approved to sync workspace content.
+
+This is where the **Trust** page matters:
+
+- approve **peer sync** for just that peer
+- approve **mesh sync** for peers from that mesh
+- keep the peer pending while you verify identity
+- refresh stale label/avatar hints without approving sync
+- resolve a mesh mismatch as **same mesh** or **bridge**
 
 ### Peer Announcements
 
@@ -394,7 +454,7 @@ curl -X POST http://localhost:7770/api/v1/p2p/reconnect \
 
 ---
 
-## 10. Troubleshooting
+## 12. Troubleshooting
 
 **"Could not connect to any endpoint"**  
 - Is the other machine's Canopy actually running?
@@ -427,13 +487,22 @@ curl -X POST http://localhost:7770/api/v1/p2p/reconnect \
 **Import says "Peer ID does not match public key"**  
 - The invite code may be corrupted (truncated when copying). Make sure you copy the full `canopy:eyJ2...` string
 
+**Peer connected but still shows preview-only**  
+- This is expected until an admin approves sync in **Trust**
+- Review the peer identity, mesh hint, and review gate there
+- Use **Refresh profile** if the preview label/avatar looks stale
+
+**Wrong person or wrong machine is showing on the invite card**  
+- Update **Settings -> Device Profile** on the sending machine
+- That page controls the peer-facing machine name/avatar shown during connection review
+
 **Connection works but messages don't arrive**  
 - Both sides need to import each other's invites for bidirectional messaging
 - Check that the API key has `WRITE_MESSAGES` permission
 
 ---
 
-## 11. Security Notes
+## 13. Security Notes
 
 - **All P2P messages are end-to-end encrypted** using ChaCha20-Poly1305 with ECDH key agreement (X25519)
 - **Peer identities are cryptographically verified** — the invite code contains the peer's public keys, and the peer ID is derived from them

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,7 +1,7 @@
 # Canopy Quick Start
 
 This guide is the primary technical first-run path for Canopy. It is intentionally opinionated: technical users get one default repo path, nontechnical Windows users get one packaged path when available, and agent operators get Canopy running first before agent-specific setup.
-Version scope: this quick start is aligned to the Canopy `0.6.0` release line.
+Version scope: this quick start is aligned to Canopy `0.6.27`.
 
 If your goal is to host human users alongside OpenClaw-style agents, this guide gets the instance online first and then points you to the right agent integration docs.
 
@@ -180,11 +180,13 @@ For **manifest fields, station surface semantics, and bounded actions** (integra
 1. Create your local user account in the web UI.
 2. Open `#general` and post a test message.
 3. Go to **API Keys** and create a key for scripts/agents.
-4. Go to **Connect** and copy your invite code.
-5. Import a second instance's invite code to establish a mesh link.
-6. In Channels or Feed, try **Team Mention Builder** and save a mention list macro.
-7. If you use private channels, note that current Canopy supports E2E-encrypted private/confidential channels with reconnect-time membership/key recovery.
-8. If you plan to run OpenClaw-style agents, continue with [AGENT_ONBOARDING.md](AGENT_ONBOARDING.md) or [MCP_QUICKSTART.md](MCP_QUICKSTART.md) after initial setup.
+4. Go to **Settings -> Device Profile** and set the name/avatar other peers should recognize during connection review.
+5. Go to **Connect** and copy your invite code.
+6. Import a second instance's invite code, review the peer and mesh hints, then connect.
+7. If the peer stays preview-only, go to **Trust** and decide whether to allow peer sync, allow mesh sync, keep a bridge, or refresh stale identity hints.
+8. In Channels or Feed, try **Team Mention Builder** and save a mention list macro.
+9. If you use private channels, note that current Canopy supports E2E-encrypted private/confidential channels with reconnect-time membership/key recovery.
+10. If you plan to run OpenClaw-style agents, continue with [AGENT_ONBOARDING.md](AGENT_ONBOARDING.md) or [MCP_QUICKSTART.md](MCP_QUICKSTART.md) after initial setup.
 
 ---
 
@@ -215,12 +217,18 @@ Full button-by-button reference: [CONNECT_FAQ.md](CONNECT_FAQ.md)
 Quick interpretation:
 
 - **Your Invite Code**
-  - Shows current peer ID and endpoint candidates (`ws://...`).
+  - Shows current peer ID, endpoint candidates (`ws://...`), and the peer-facing identity learned from **Settings -> Device Profile**.
   - **Copy** copies your full `canopy:...` invite.
   - **Regenerate** with public IP/hostname prepends a public endpoint for remote peers.
 
 - **Import Friend's Invite**
-  - Paste `canopy:...` and click **Connect**.
+  - Paste `canopy:...`, use **Review Invite** to inspect the peer hint, mesh hint, node hint, and reachability, then click **Connect to this peer**.
+  - A peer can connect for review while remaining **preview-only** until sync is approved.
+
+- **Trust**
+  - This is where admins finish first-contact review after transport connects.
+  - Use it to approve peer sync, approve mesh-wide sync, treat a peer as the same mesh, keep a cross-mesh bridge, or refresh stale preview identity hints.
+  - In plain language: `peer sync` trusts one peer to exchange workspace content, `mesh sync` trusts that peer's mesh as part of the same workspace, `same mesh` resolves a naming/ID mismatch as one real workspace, `bridge` keeps separate meshes connected without merging them, and `Refresh profile` relearns the peer's current label/avatar without approving sync.
 
 - **Connected Peers / Known Peers / Introduced Peers**
   - `Reconnect`, `Reconnect All`, `Disconnect`, and `Forget` manage peer state/endpoints.
@@ -341,6 +349,16 @@ python -m canopy
 - Wrong or stale endpoint
 - Firewall/NAT blocked mesh port
 - Missing port-forward/public endpoint for internet path
+
+### Peer connected but still looks preview-only
+
+This is expected on first contact. Canopy can keep transport connected for review while leaving channels and history paused.
+
+What to do:
+1. Open **Trust**.
+2. Review the peer identity, mesh hint, and review gate.
+3. Approve peer sync, approve mesh sync, or keep the peer pending until you are satisfied.
+4. If the name/avatar hints look stale, use **Refresh profile** to relearn them without approving sync.
 
 ### Remote history appears incomplete
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canopy"
-version = "0.6.2"
+version = "0.6.27"
 description = "Local-first peer-to-peer collaboration for humans and AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_agent_quarantine_admin_approve.py
+++ b/tests/test_agent_quarantine_admin_approve.py
@@ -1,6 +1,7 @@
 """Regression coverage for admin approval applying agent quarantine."""
 
 import os
+import sqlite3
 import sys
 import types
 import unittest
@@ -28,6 +29,39 @@ from canopy.ui.routes import create_ui_blueprint
 
 class _FakeDbManager:
     def __init__(self) -> None:
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.row_factory = sqlite3.Row
+        self.conn.executescript(
+            """
+            CREATE TABLE channels (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                channel_type TEXT NOT NULL,
+                created_by TEXT NOT NULL,
+                description TEXT,
+                privacy_mode TEXT
+            );
+
+            CREATE TABLE channel_members (
+                channel_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                role TEXT DEFAULT 'member',
+                UNIQUE(channel_id, user_id)
+            );
+            """
+        )
+        self.conn.executemany(
+            """
+            INSERT INTO channels (id, name, channel_type, created_by, description, privacy_mode)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ('general', 'general', 'public', 'system', 'General', 'open'),
+                ('Cnews', 'canopy-news', 'public', 'owner-user', 'News', 'open'),
+                ('Cprivate', 'staff', 'public', 'owner-user', 'Private', 'private'),
+            ],
+        )
+        self.conn.commit()
         self.users = {
             'owner-user': {
                 'id': 'owner-user',
@@ -46,6 +80,9 @@ class _FakeDbManager:
                 'password_hash': 'hash-agent',
             },
         }
+
+    def get_connection(self):
+        return self.conn
 
     def get_instance_owner_user_id(self):
         return 'owner-user'
@@ -78,6 +115,9 @@ class _FakeChannelManager:
         self.enforcement_calls = []
         self.should_quarantine_succeed = should_quarantine_succeed
         self.governance_enabled = governance_enabled
+
+    def ensure_default_channels_exist(self) -> None:
+        return None
 
     def ensure_agent_quarantine_assignment(self, user_id: str, *, updated_by: str = None, role: str = 'member'):
         self.quarantine_calls.append({
@@ -130,6 +170,16 @@ class TestAgentQuarantineAdminApprove(unittest.TestCase):
             sess['display_name'] = 'Owner'
             sess['_csrf_token'] = 'csrf-approve'
 
+    def tearDown(self) -> None:
+        self.db_manager.conn.close()
+
+    def _membership_ids(self, user_id: str) -> list[str]:
+        rows = self.db_manager.conn.execute(
+            "SELECT channel_id FROM channel_members WHERE user_id = ? ORDER BY channel_id",
+            (user_id,),
+        ).fetchall()
+        return [row['channel_id'] for row in rows]
+
     def test_admin_approve_quarantines_agent(self) -> None:
         response = self.client.post(
             '/ajax/admin/users/agent-user/approve',
@@ -144,6 +194,7 @@ class TestAgentQuarantineAdminApprove(unittest.TestCase):
         self.assertEqual(self.channel_manager.quarantine_calls[0]['user_id'], 'agent-user')
         self.assertEqual(self.channel_manager.quarantine_calls[0]['updated_by'], 'owner-user')
         self.assertEqual(self.channel_manager.enforcement_calls, ['agent-user'])
+        self.assertEqual(self._membership_ids('agent-user'), ['Cnews', 'general'])
 
     def test_admin_approve_reverts_to_pending_if_quarantine_fails(self) -> None:
         failing_channel_manager = _FakeChannelManager(should_quarantine_succeed=False)
@@ -179,6 +230,7 @@ class TestAgentQuarantineAdminApprove(unittest.TestCase):
         self.assertTrue(payload.get('success'))
         self.assertEqual(self.channel_manager.quarantine_calls[-1]['user_id'], 'agent-user')
         self.assertEqual(self.channel_manager.enforcement_calls[-1], 'agent-user')
+        self.assertEqual(self._membership_ids('agent-user'), ['Cnews', 'general'])
 
     def test_admin_classification_reverts_if_quarantine_fails(self) -> None:
         failing_channel_manager = _FakeChannelManager(should_quarantine_succeed=False)

--- a/tests/test_api_session_fallback.py
+++ b/tests/test_api_session_fallback.py
@@ -90,8 +90,16 @@ class TestApiSessionFallback(unittest.TestCase):
         self.p2p_manager.identity_manager = MagicMock()
         self.p2p_manager.identity_manager.peer_display_names = {}
         self.p2p_manager.identity_manager.peer_endpoints = {}
+        self.p2p_manager.identity_manager.local_identity = object()
         self.p2p_manager._active_relays = {}
         self.p2p_manager.reconnect_known_peers.return_value = True
+        self.config = types.SimpleNamespace(
+            meshspace=types.SimpleNamespace(
+                enabled=True,
+                meshspace_id='family-mesh',
+                name='Family Mesh',
+            )
+        )
 
         # Order must match get_app_components in canopy.core.utils
         components = (
@@ -104,7 +112,7 @@ class TestApiSessionFallback(unittest.TestCase):
             MagicMock(),               # feed_manager
             MagicMock(),               # interaction_manager
             MagicMock(),               # profile_manager
-            MagicMock(),               # config
+            self.config,               # config
             self.p2p_manager,          # p2p_manager
         )
 
@@ -286,6 +294,108 @@ class TestApiSessionFallback(unittest.TestCase):
         self.assertEqual(call_args[0].kwargs.get('scheme'), 'wss')
         self.assertEqual(call_args[1].args[1:], ('198.51.100.159', 7771))
         self.assertEqual(call_args[1].kwargs.get('scheme'), 'ws')
+
+    def test_non_admin_session_cannot_confirm_cross_mesh_reconnect(self) -> None:
+        csrf_token = 'csrf-cross-mesh-reconnect'
+        self._set_authenticated_session(csrf_token=csrf_token)
+        self.db_manager.get_instance_owner_user_id.return_value = 'owner-user'
+        self.p2p_manager.get_peer_cross_mesh_status.return_value = {
+            'requires_manual_confirmation': True,
+            'remote_meshspace_name': 'Other Mesh',
+        }
+
+        response = self.client.post(
+            '/api/v1/p2p/reconnect',
+            json={'peer_id': 'peer-beta', 'allow_cross_mesh': True},
+            headers={'X-CSRFToken': csrf_token},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('diagnostic_code'), 'cross_mesh_admin_required')
+        self.p2p_manager.mark_peer_cross_mesh_allowed.assert_not_called()
+
+    def test_non_admin_session_cannot_confirm_cross_mesh_invite_import(self) -> None:
+        csrf_token = 'csrf-cross-mesh-invite'
+        self._set_authenticated_session(csrf_token=csrf_token)
+        self.db_manager.get_instance_owner_user_id.return_value = 'owner-user'
+
+        invite = types.SimpleNamespace(
+            peer_id='peer-foreign',
+            meshspace_id='other-mesh',
+            mesh_name='Other Mesh',
+            meshspace_fingerprint='ABCD-1234',
+        )
+
+        with patch('canopy.network.invite.InviteCode.decode', return_value=invite):
+            response = self.client.post(
+                '/api/v1/p2p/invite/import',
+                json={'invite_code': 'canopy:test', 'allow_cross_mesh': True},
+                headers={'X-CSRFToken': csrf_token},
+            )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('diagnostic_code'), 'cross_mesh_admin_required')
+        self.p2p_manager.mark_peer_cross_mesh_allowed.assert_not_called()
+
+    def test_admin_can_treat_peer_mesh_as_same_mesh_alias(self) -> None:
+        csrf_token = 'csrf-mesh-alias'
+        self._set_authenticated_session(csrf_token=csrf_token)
+        self.db_manager.get_instance_owner_user_id.return_value = 'test-user'
+        self.p2p_manager.mark_peer_meshspace_equivalent.return_value = {
+            'peer_id': 'peer-beta',
+            'mesh_relationship': 'same_mesh_alias_confirmed',
+        }
+
+        response = self.client.post(
+            '/api/v1/p2p/mesh_relationship',
+            json={'peer_id': 'peer-beta', 'action': 'same_mesh_alias'},
+            headers={'X-CSRFToken': csrf_token},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('status'), 'same_mesh_alias_confirmed')
+        self.p2p_manager.mark_peer_meshspace_equivalent.assert_called_once_with('peer-beta')
+        self.p2p_manager.mark_peer_cross_mesh_allowed.assert_not_called()
+
+    def test_admin_can_keep_cross_mesh_bridge_without_aliasing(self) -> None:
+        csrf_token = 'csrf-mesh-bridge'
+        self._set_authenticated_session(csrf_token=csrf_token)
+        self.db_manager.get_instance_owner_user_id.return_value = 'test-user'
+        self.p2p_manager.get_peer_cross_mesh_status.return_value = {
+            'peer_id': 'peer-beta',
+            'mesh_relationship': 'cross_mesh_bridge_allowed',
+        }
+
+        response = self.client.post(
+            '/api/v1/p2p/mesh_relationship',
+            json={'peer_id': 'peer-beta', 'action': 'cross_mesh_bridge'},
+            headers={'X-CSRFToken': csrf_token},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('status'), 'cross_mesh_bridge_allowed')
+        self.p2p_manager.mark_peer_cross_mesh_allowed.assert_called_once_with('peer-beta', True)
+        self.p2p_manager.mark_peer_meshspace_equivalent.assert_not_called()
+
+    def test_non_admin_cannot_resolve_mesh_relationship(self) -> None:
+        csrf_token = 'csrf-mesh-review-denied'
+        self._set_authenticated_session(csrf_token=csrf_token)
+        self.db_manager.get_instance_owner_user_id.return_value = 'owner-user'
+
+        response = self.client.post(
+            '/api/v1/p2p/mesh_relationship',
+            json={'peer_id': 'peer-beta', 'action': 'same_mesh_alias'},
+            headers={'X-CSRFToken': csrf_token},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('diagnostic_code'), 'mesh_identity_admin_required')
+        self.p2p_manager.mark_peer_meshspace_equivalent.assert_not_called()
 
     def test_authorization_header_parses_lowercase_bearer_scheme(self) -> None:
         key_info = ApiKeyInfo(

--- a/tests/test_connection_log_noise_regressions.py
+++ b/tests/test_connection_log_noise_regressions.py
@@ -104,7 +104,7 @@ class TestConnectionLogNoiseRegressions(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(manager._should_replace_existing_connection(existing, candidate))
 
-    async def test_handshake_peerid_mismatch_reassigns_endpoint_to_actual_peer(self):
+    async def test_handshake_peerid_mismatch_quarantines_stale_endpoint_without_adopting_actual_peer(self):
         identity_manager = _FakeIdentityManager()
         manager = ConnectionManager(
             local_peer_id='peer-local',
@@ -121,10 +121,7 @@ class TestConnectionLogNoiseRegressions(unittest.IsolatedAsyncioTestCase):
             identity_manager.removed,
             [('peer-expected', 'ws://198.51.100.50:7771')],
         )
-        self.assertEqual(
-            identity_manager.recorded,
-            [('peer-actual', 'ws://198.51.100.50:7771', True)],
-        )
+        self.assertEqual(identity_manager.recorded, [])
 
 
 if __name__ == '__main__':

--- a/tests/test_cross_mesh_safety_remaining_paths.py
+++ b/tests/test_cross_mesh_safety_remaining_paths.py
@@ -1,0 +1,352 @@
+"""Regression tests for remaining cross-mesh safety gaps."""
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+# Ensure repository root is importable when running tests directly.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Provide a lightweight zeroconf stub for environments without optional deps.
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.network.manager import P2PNetworkManager
+
+
+LOCAL_MESH_ID = 'mesh-local-aaa'
+FOREIGN_MESH_ID = 'mesh-foreign-bbb'
+LOCAL_PEER_ID = 'local-peer-0001'
+FOREIGN_PEER_ID = 'foreign-peer-0002'
+RELAY_PEER_ID = 'relay-peer-0003'
+
+
+def _make_local_identity(peer_id: str = LOCAL_PEER_ID):
+    return SimpleNamespace(peer_id=peer_id)
+
+
+def _make_config(meshspace_id: str = LOCAL_MESH_ID, meshspace_name: str = 'Local Mesh'):
+    meshspace = SimpleNamespace(
+        meshspace_id=meshspace_id,
+        name=meshspace_name,
+        enabled=bool(meshspace_id),
+    )
+    return SimpleNamespace(
+        meshspace=meshspace,
+        security=SimpleNamespace(trust_threshold=50),
+    )
+
+
+def _make_identity_manager_with_hint(
+    peer_id: str,
+    remote_mesh_id: str,
+    *,
+    cross_mesh_allowed: bool = False,
+) -> MagicMock:
+    hint = {
+        'meshspace_id': remote_mesh_id,
+        'meshspace_name': 'Foreign Mesh',
+        'meshspace_fingerprint': 'fp-foreign',
+        'cross_mesh_allowed': cross_mesh_allowed,
+    }
+    im = MagicMock()
+    im.peer_meshspace_hints = {peer_id: hint}
+    im.peer_endpoints = {}
+    im.record_endpoint = MagicMock()
+    im.get_peer_meshspace_hint = MagicMock(return_value=hint)
+    im.record_peer_meshspace_hint = MagicMock()
+    return im
+
+
+def _make_base_manager(*, mesh_id: str = LOCAL_MESH_ID) -> P2PNetworkManager:
+    manager = P2PNetworkManager.__new__(P2PNetworkManager)
+    manager.local_identity = _make_local_identity()
+    manager.config = _make_config(meshspace_id=mesh_id)
+    manager._running = True
+    manager.message_router = MagicMock()
+    manager._active_relays = {}
+    manager.peer_versions = {}
+    manager._introduced_peers = {}
+    manager.connection_manager = MagicMock()
+    manager.connection_manager.is_connected = MagicMock(return_value=False)
+    manager.discovery = None
+    manager._event_loop = None
+    manager._activity_lock = __import__('threading').Lock()
+    manager._activity_events = __import__('collections').deque(maxlen=200)
+    manager._endpoint_health_lock = __import__('threading').Lock()
+    manager._endpoint_health = {}
+    return manager
+
+
+class TestConnectToEndpointPostHandshakeCrossMeshGuard(unittest.IsolatedAsyncioTestCase):
+    def _make_manager_no_prior_hint(self) -> P2PNetworkManager:
+        manager = _make_base_manager()
+        im = MagicMock()
+        im.peer_meshspace_hints = {}
+        im.peer_endpoints = {}
+        im.record_endpoint = MagicMock()
+        im.get_peer_meshspace_hint = MagicMock(return_value={})
+        im.record_peer_meshspace_hint = MagicMock()
+        manager.identity_manager = im
+        manager._record_connection_event = MagicMock()
+        manager._record_endpoint_result = MagicMock()
+        return manager
+
+    async def test_outgoing_connection_to_cross_mesh_peer_is_disconnected_post_handshake(self):
+        manager = self._make_manager_no_prior_hint()
+
+        foreign_conn = SimpleNamespace(
+            meshspace_id=FOREIGN_MESH_ID,
+            meshspace_name='Foreign Mesh',
+            meshspace_fingerprint='fp-foreign',
+        )
+        manager.connection_manager.connect_to_peer = AsyncMock(return_value=True)
+        manager.connection_manager.get_connection = MagicMock(return_value=foreign_conn)
+        manager.connection_manager.disconnect_peer = AsyncMock()
+
+        def _side_effect_record_hint(peer_id, meta, *, source, cross_mesh_allowed=None):
+            if meta and meta.get('meshspace_id'):
+                hint = {
+                    'meshspace_id': meta['meshspace_id'],
+                    'meshspace_name': meta.get('meshspace_name', ''),
+                    'meshspace_fingerprint': meta.get('meshspace_fingerprint', ''),
+                    'cross_mesh_allowed': bool(cross_mesh_allowed),
+                }
+                manager.identity_manager.peer_meshspace_hints[peer_id] = hint
+                manager.identity_manager.get_peer_meshspace_hint.return_value = hint
+
+        manager._record_peer_meshspace_hint = _side_effect_record_hint
+
+        result = await manager._connect_to_endpoint(FOREIGN_PEER_ID, 'ws://10.0.0.2:7771')
+
+        self.assertFalse(result)
+        manager.connection_manager.disconnect_peer.assert_called_once_with(FOREIGN_PEER_ID)
+        event_call = manager._record_connection_event.call_args
+        self.assertEqual(event_call.kwargs.get('status') or event_call.args[1], 'blocked')
+
+    async def test_outgoing_connection_to_same_mesh_peer_is_kept(self):
+        manager = self._make_manager_no_prior_hint()
+
+        same_conn = SimpleNamespace(
+            meshspace_id=LOCAL_MESH_ID,
+            meshspace_name='Local Mesh',
+            meshspace_fingerprint='fp-local',
+        )
+        manager.connection_manager.connect_to_peer = AsyncMock(return_value=True)
+        manager.connection_manager.get_connection = MagicMock(return_value=same_conn)
+        manager.connection_manager.disconnect_peer = AsyncMock()
+        manager.identity_manager.record_endpoint = MagicMock()
+
+        def _side_effect_record_hint(peer_id, meta, *, source, cross_mesh_allowed=None):
+            if meta and meta.get('meshspace_id'):
+                hint = {
+                    'meshspace_id': meta['meshspace_id'],
+                    'meshspace_name': meta.get('meshspace_name', ''),
+                    'cross_mesh_allowed': bool(cross_mesh_allowed),
+                }
+                manager.identity_manager.peer_meshspace_hints[peer_id] = hint
+                manager.identity_manager.get_peer_meshspace_hint.return_value = hint
+
+        manager._record_peer_meshspace_hint = _side_effect_record_hint
+
+        result = await manager._connect_to_endpoint('same-mesh-peer', 'ws://10.0.0.3:7771')
+
+        self.assertTrue(result)
+        manager.connection_manager.disconnect_peer.assert_not_called()
+
+    async def test_allow_cross_mesh_flag_bypasses_post_handshake_guard(self):
+        manager = self._make_manager_no_prior_hint()
+
+        foreign_conn = SimpleNamespace(
+            meshspace_id=FOREIGN_MESH_ID,
+            meshspace_name='Foreign Mesh',
+            meshspace_fingerprint='fp-foreign',
+        )
+        manager.connection_manager.connect_to_peer = AsyncMock(return_value=True)
+        manager.connection_manager.get_connection = MagicMock(return_value=foreign_conn)
+        manager.connection_manager.disconnect_peer = AsyncMock()
+        manager.identity_manager.record_endpoint = MagicMock()
+
+        def _side_effect_record_hint(peer_id, meta, *, source, cross_mesh_allowed=None):
+            if meta and meta.get('meshspace_id'):
+                hint = {
+                    'meshspace_id': meta['meshspace_id'],
+                    'cross_mesh_allowed': bool(cross_mesh_allowed),
+                }
+                manager.identity_manager.peer_meshspace_hints[peer_id] = hint
+                manager.identity_manager.get_peer_meshspace_hint.return_value = hint
+
+        manager._record_peer_meshspace_hint = _side_effect_record_hint
+        manager.mark_peer_cross_mesh_allowed = MagicMock()
+
+        result = await manager._connect_to_endpoint(
+            FOREIGN_PEER_ID,
+            'ws://10.0.0.4:7771',
+            allow_cross_mesh=True,
+        )
+
+        self.assertTrue(result)
+        manager.connection_manager.disconnect_peer.assert_not_called()
+
+    async def test_allow_mesh_review_keeps_transport_without_approving_bridge(self):
+        manager = self._make_manager_no_prior_hint()
+
+        foreign_conn = SimpleNamespace(
+            meshspace_id=FOREIGN_MESH_ID,
+            meshspace_name='Foreign Mesh',
+            meshspace_fingerprint='fp-foreign',
+        )
+        manager.connection_manager.connect_to_peer = AsyncMock(return_value=True)
+        manager.connection_manager.get_connection = MagicMock(return_value=foreign_conn)
+        manager.connection_manager.disconnect_peer = AsyncMock()
+        manager.identity_manager.record_endpoint = MagicMock()
+
+        def _side_effect_record_hint(peer_id, meta, *, source, cross_mesh_allowed=None):
+            if meta and meta.get('meshspace_id'):
+                hint = {
+                    'meshspace_id': meta['meshspace_id'],
+                    'meshspace_name': meta.get('meshspace_name', ''),
+                    'meshspace_fingerprint': meta.get('meshspace_fingerprint', ''),
+                    'cross_mesh_allowed': bool(cross_mesh_allowed),
+                }
+                manager.identity_manager.peer_meshspace_hints[peer_id] = hint
+                manager.identity_manager.get_peer_meshspace_hint.return_value = hint
+
+        manager._record_peer_meshspace_hint = _side_effect_record_hint
+        manager.mark_peer_cross_mesh_allowed = MagicMock()
+
+        result = await manager._connect_to_endpoint(
+            FOREIGN_PEER_ID,
+            'ws://10.0.0.5:7771',
+            allow_mesh_review=True,
+        )
+
+        self.assertTrue(result)
+        manager.mark_peer_cross_mesh_allowed.assert_not_called()
+        manager.connection_manager.disconnect_peer.assert_not_called()
+        statuses = [
+            (call.kwargs.get('status') or (call.args[1] if len(call.args) > 1 else ''))
+            for call in manager._record_connection_event.call_args_list
+        ]
+        self.assertIn('mesh_review_required', statuses)
+
+    async def test_no_boundary_no_disconnect(self):
+        manager = _make_base_manager(mesh_id='')
+        im = MagicMock()
+        im.peer_meshspace_hints = {}
+        im.peer_endpoints = {}
+        im.record_endpoint = MagicMock()
+        im.get_peer_meshspace_hint = MagicMock(return_value={})
+        im.record_peer_meshspace_hint = MagicMock()
+        manager.identity_manager = im
+        manager._record_connection_event = MagicMock()
+        manager._record_endpoint_result = MagicMock()
+
+        foreign_conn = SimpleNamespace(
+            meshspace_id=FOREIGN_MESH_ID,
+            meshspace_name='Foreign Mesh',
+            meshspace_fingerprint='fp-foreign',
+        )
+        manager.connection_manager.connect_to_peer = AsyncMock(return_value=True)
+        manager.connection_manager.get_connection = MagicMock(return_value=foreign_conn)
+        manager.connection_manager.disconnect_peer = AsyncMock()
+        manager.identity_manager.record_endpoint = MagicMock()
+        manager._record_peer_meshspace_hint = lambda *args, **kwargs: None
+
+        result = await manager._connect_to_endpoint(FOREIGN_PEER_ID, 'ws://10.0.0.5:7771')
+
+        self.assertTrue(result)
+        manager.connection_manager.disconnect_peer.assert_not_called()
+
+
+class TestRelayOfferCrossMeshGuard(unittest.TestCase):
+    def _make_manager_with_cross_mesh_hint(self) -> P2PNetworkManager:
+        manager = _make_base_manager()
+        manager.identity_manager = _make_identity_manager_with_hint(
+            FOREIGN_PEER_ID,
+            FOREIGN_MESH_ID,
+        )
+        manager._record_connection_event = MagicMock()
+        manager.connection_manager.is_connected = MagicMock(
+            side_effect=lambda pid: pid == RELAY_PEER_ID
+        )
+        return manager
+
+    def test_relay_offer_for_cross_mesh_target_is_declined(self):
+        manager = self._make_manager_with_cross_mesh_hint()
+
+        manager._on_relay_offer(relay_peer=RELAY_PEER_ID, target_peer=FOREIGN_PEER_ID)
+
+        manager.message_router.update_routing_table.assert_not_called()
+        self.assertNotIn(FOREIGN_PEER_ID, manager._active_relays)
+
+    def test_relay_offer_for_same_mesh_target_is_accepted(self):
+        manager = _make_base_manager()
+        im = MagicMock()
+        im.peer_meshspace_hints = {}
+        im.get_peer_meshspace_hint = MagicMock(return_value={})
+        manager.identity_manager = im
+        manager.connection_manager.is_connected = MagicMock(
+            side_effect=lambda pid: pid == RELAY_PEER_ID
+        )
+        manager._record_connection_event = MagicMock()
+
+        manager._on_relay_offer(relay_peer=RELAY_PEER_ID, target_peer='same-mesh-peer')
+
+        manager.message_router.update_routing_table.assert_called_once_with(
+            'same-mesh-peer',
+            RELAY_PEER_ID,
+        )
+        self.assertEqual(manager._active_relays.get('same-mesh-peer'), RELAY_PEER_ID)
+
+    def test_relay_offer_for_approved_cross_mesh_target_is_accepted(self):
+        manager = _make_base_manager()
+        im = _make_identity_manager_with_hint(
+            FOREIGN_PEER_ID,
+            FOREIGN_MESH_ID,
+            cross_mesh_allowed=True,
+        )
+        manager.identity_manager = im
+        manager.connection_manager.is_connected = MagicMock(
+            side_effect=lambda pid: pid == RELAY_PEER_ID
+        )
+        manager._record_connection_event = MagicMock()
+
+        manager._on_relay_offer(relay_peer=RELAY_PEER_ID, target_peer=FOREIGN_PEER_ID)
+
+        manager.message_router.update_routing_table.assert_called_once_with(
+            FOREIGN_PEER_ID,
+            RELAY_PEER_ID,
+        )
+        self.assertEqual(manager._active_relays.get(FOREIGN_PEER_ID), RELAY_PEER_ID)
+
+    def test_relay_offer_declined_when_relay_peer_not_connected(self):
+        manager = _make_base_manager()
+        im = MagicMock()
+        im.peer_meshspace_hints = {}
+        im.get_peer_meshspace_hint = MagicMock(return_value={})
+        manager.identity_manager = im
+        manager.connection_manager.is_connected = MagicMock(return_value=False)
+
+        manager._on_relay_offer(relay_peer='unconnected-relay', target_peer='any-peer')
+
+        manager.message_router.update_routing_table.assert_not_called()
+        self.assertNotIn('any-peer', manager._active_relays)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_device_profile_avatar_hardening.py
+++ b/tests/test_device_profile_avatar_hardening.py
@@ -26,10 +26,14 @@ if 'zeroconf' not in sys.modules:
     sys.modules['zeroconf'] = zeroconf_stub
 
 from canopy.api.routes import create_api_blueprint
-from canopy.core.device import normalize_device_avatar
+from canopy.core.device import normalize_device_avatar, normalize_device_icon
 
 
 class TestDeviceProfileAvatarHardening(unittest.TestCase):
+    def test_normalize_device_icon_clamps_to_known_choices(self):
+        self.assertEqual(normalize_device_icon('bi-laptop'), 'bi-laptop')
+        self.assertEqual(normalize_device_icon('bi totally-bad'), 'bi-pc-display-horizontal')
+
     def test_normalize_device_avatar_converts_to_bounded_jpeg(self):
         from PIL import Image
 
@@ -106,6 +110,55 @@ class TestDeviceProfileAvatarHardening(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         payload = response.get_json() or {}
         self.assertIn('base64', str(payload.get('error') or '').lower())
+
+    def test_device_profile_api_refreshes_live_public_hint(self):
+        db_manager = MagicMock()
+        db_manager.get_user.return_value = {
+            'id': 'test-user',
+            'username': 'test-user',
+            'display_name': 'Test User',
+            'account_type': 'human',
+            'status': 'active',
+        }
+        api_key_manager = MagicMock()
+        api_key_manager.validate_key.return_value = None
+        p2p_manager = MagicMock()
+        p2p_manager.is_running.return_value = False
+
+        components = (
+            db_manager,
+            api_key_manager,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            p2p_manager,
+        )
+
+        with patch('canopy.api.routes.get_app_components', return_value=components), \
+             patch('canopy.core.device.set_device_profile', return_value=True):
+            app = Flask(__name__)
+            app.config['TESTING'] = True
+            app.secret_key = 'test-secret'
+            app.register_blueprint(create_api_blueprint(), url_prefix='/api/v1')
+            client = app.test_client()
+            with client.session_transaction() as sess:
+                sess['authenticated'] = True
+                sess['user_id'] = 'test-user'
+                sess['_csrf_token'] = 'csrf-device-refresh'
+
+            response = client.post(
+                '/api/v1/device/profile',
+                json={'display_name': 'Updated Device'},
+                headers={'X-CSRFToken': 'csrf-device-refresh'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        p2p_manager.refresh_local_public_identity_hint.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/test_dm_agent_endpoint_regressions.py
+++ b/tests/test_dm_agent_endpoint_regressions.py
@@ -31,6 +31,7 @@ if 'zeroconf' not in sys.modules:
 from canopy.api.routes import create_api_blueprint
 from canopy.core.inbox import InboxManager
 from canopy.core.messaging import MessageManager
+from canopy.core.messaging import compute_group_id
 from canopy.security.api_keys import ApiKeyInfo, Permission
 
 
@@ -425,6 +426,164 @@ class TestDmAgentEndpointRegressions(unittest.TestCase):
             ['agent-local', 'author', 'remote-shadow'],
         )
         self.assertIsNotNone(dm_item.get('edited_at'))
+
+    def test_api_group_dm_can_start_fresh_same_member_thread(self) -> None:
+        base_group_id = compute_group_id(['agent-local', 'author', 'remote-shadow'])
+        response = self.client.post(
+            '/api/v1/messages',
+            json={
+                'content': 'Fresh group instance',
+                'recipient_ids': ['agent-local', 'remote-shadow'],
+                'force_new_group': True,
+            },
+            headers=self._headers('key-author'),
+        )
+        self.assertEqual(response.status_code, 201)
+        payload = response.get_json() or {}
+        message = payload.get('message') or {}
+        self.assertTrue(message.get('id'))
+        self.assertTrue(payload.get('group_id'))
+        self.assertTrue(payload.get('group_thread_id'))
+        self.assertEqual(payload.get('base_group_id'), base_group_id)
+        self.assertNotEqual(payload.get('group_id'), base_group_id)
+
+        metadata = message.get('metadata') or {}
+        self.assertEqual(metadata.get('group_id'), payload.get('group_id'))
+        self.assertEqual(metadata.get('base_group_id'), base_group_id)
+        self.assertEqual(metadata.get('group_thread_id'), payload.get('group_thread_id'))
+
+        inbox_row = self.conn.execute(
+            "SELECT payload_json FROM agent_inbox WHERE source_id = ? AND agent_user_id = ?",
+            (message.get('id'), 'agent-local'),
+        ).fetchone()
+        self.assertIsNotNone(inbox_row)
+        inbox_payload = json.loads(inbox_row['payload_json'])
+        self.assertEqual(inbox_payload.get('group_thread_id'), payload.get('group_thread_id'))
+        self.assertEqual(inbox_payload.get('base_group_id'), base_group_id)
+
+        self.p2p_manager.direct_messages.clear()
+        reply_resp = self.client.post(
+            '/api/v1/messages/reply',
+            json={
+                'message_id': message.get('id'),
+                'content': 'Reply inside fresh group instance',
+            },
+            headers=self._headers('key-agent-local'),
+        )
+        self.assertEqual(reply_resp.status_code, 201)
+        reply_payload = reply_resp.get_json() or {}
+        reply_message = reply_payload.get('message') or {}
+        self.assertEqual(reply_payload.get('group_id'), payload.get('group_id'))
+        self.assertEqual(reply_payload.get('group_thread_id'), payload.get('group_thread_id'))
+        self.assertEqual((reply_message.get('metadata') or {}).get('group_thread_id'), payload.get('group_thread_id'))
+        self.assertEqual(
+            sorted(item['recipient_id'] for item in self.p2p_manager.direct_messages),
+            ['author', 'remote-shadow'],
+        )
+
+    def test_group_dm_reply_expands_partial_relay_member_sets(self) -> None:
+        shared_group_id = 'group:split-relay'
+        self.conn.executemany(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    'DM-split-local', 'agent-local', shared_group_id, 'Partial local leg',
+                    'text', 'delivered', '2026-03-07T10:08:00+00:00',
+                    '2026-03-07T10:08:01+00:00', None, None,
+                    json.dumps({'group_id': shared_group_id, 'group_members': ['author', 'agent-local']}),
+                ),
+                (
+                    'DM-split-remote', 'remote-shadow', shared_group_id, 'Partial remote leg',
+                    'text', 'delivered', '2026-03-07T10:09:00+00:00',
+                    '2026-03-07T10:09:01+00:00', None, None,
+                    json.dumps({'group_id': shared_group_id, 'group_members': ['author', 'remote-shadow']}),
+                ),
+            ],
+        )
+        self.conn.commit()
+        self.p2p_manager.direct_messages.clear()
+
+        reply_resp = self.client.post(
+            '/api/v1/messages/reply',
+            json={
+                'message_id': 'DM-split-local',
+                'content': 'Reply to the whole split group',
+            },
+            headers=self._headers('key-author'),
+        )
+        self.assertEqual(reply_resp.status_code, 201)
+        payload = reply_resp.get_json() or {}
+        self.assertEqual(payload.get('group_id'), shared_group_id)
+        self.assertEqual(
+            sorted(item['recipient_id'] for item in self.p2p_manager.direct_messages),
+            ['agent-local', 'remote-shadow'],
+        )
+
+        row = self.conn.execute(
+            "SELECT metadata FROM messages WHERE id = ?",
+            ((payload.get('message') or {}).get('id'),),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        metadata = json.loads(row['metadata'])
+        self.assertEqual(
+            metadata.get('group_members'),
+            ['agent-local', 'author', 'remote-shadow'],
+        )
+
+    def test_resolve_group_members_skips_unrelated_group_rows_that_would_exhaust_limit(self) -> None:
+        shared_group_id = 'group:split-relay-limit'
+        filler_rows = [
+            (
+                f'DM-filler-{index}',
+                'remote-shadow',
+                f'group:filler-{index}',
+                f'Unrelated filler {index}',
+                'text',
+                'delivered',
+                f'2026-03-07T09:{index // 60:02d}:{index % 60:02d}+00:00',
+                f'2026-03-07T09:{index // 60:02d}:{index % 60:02d}+00:00',
+                None,
+                None,
+                json.dumps({'group_id': f'group:filler-{index}', 'group_members': ['peer-x', 'peer-y']}),
+            )
+            for index in range(1000)
+        ]
+        self.conn.executemany(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    'DM-limit-local', 'agent-local', shared_group_id, 'Partial local leg',
+                    'text', 'delivered', '2026-03-07T08:59:00+00:00',
+                    '2026-03-07T08:59:01+00:00', None, None,
+                    json.dumps({'group_id': shared_group_id, 'group_members': ['author', 'agent-local']}),
+                ),
+                *filler_rows,
+                (
+                    'DM-limit-remote', 'remote-shadow', shared_group_id, 'Partial remote leg',
+                    'text', 'delivered', '2026-03-07T10:09:00+00:00',
+                    '2026-03-07T10:09:01+00:00', None, None,
+                    json.dumps({'group_id': shared_group_id, 'group_members': ['author', 'remote-shadow']}),
+                ),
+            ],
+        )
+        self.conn.commit()
+
+        resolved = self.message_manager.resolve_group_members(
+            'author',
+            shared_group_id,
+            ['author', 'agent-local'],
+        )
+        self.assertEqual(resolved, ['agent-local', 'author', 'remote-shadow'])
 
     def test_dm_inbox_exposes_reply_target_and_reply_endpoint_keeps_response_in_dm(self) -> None:
         send_resp = self.client.post(

--- a/tests/test_dm_group_message_access.py
+++ b/tests/test_dm_group_message_access.py
@@ -25,6 +25,7 @@ if 'zeroconf' not in sys.modules:
 
 from canopy.core.messaging import MessageManager
 from canopy.core.messaging import compute_group_id
+from canopy.core.messaging import compute_group_thread_id
 
 
 class _FakeDbManager:
@@ -208,6 +209,45 @@ class TestDmGroupMessageAccess(unittest.TestCase):
         visible = self.message_manager.get_group_conversation("agent-local", canonical_group_id, limit=20)
 
         self.assertEqual([message.id for message in visible], ["DM-group-visible", "DM-group-relayed"])
+
+    def test_explicit_group_thread_does_not_merge_with_same_member_legacy_group(self) -> None:
+        base_group_id = compute_group_id(["agent-local", "peer-a", "peer-b"])
+        fresh_group_id = compute_group_thread_id(["agent-local", "peer-a", "peer-b"], "fresh-1")
+        self.db.conn.execute(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "DM-group-fresh",
+                "peer-a",
+                fresh_group_id,
+                "fresh same-member discussion",
+                "text",
+                "delivered",
+                "2026-03-07T10:05:00+00:00",
+                "2026-03-07T10:05:01+00:00",
+                None,
+                None,
+                json.dumps(
+                    {
+                        "group_id": fresh_group_id,
+                        "base_group_id": base_group_id,
+                        "group_thread_id": "fresh-1",
+                        "group_members": ["agent-local", "peer-a", "peer-b"],
+                    }
+                ),
+            ),
+        )
+        self.db.conn.commit()
+
+        legacy = self.message_manager.get_group_conversation("agent-local", base_group_id, limit=20)
+        fresh = self.message_manager.get_group_conversation("agent-local", fresh_group_id, limit=20)
+
+        self.assertEqual([message.id for message in legacy], ["DM-group-visible", "DM-group-relayed"])
+        self.assertEqual([message.id for message in fresh], ["DM-group-fresh"])
 
     # --- Security regression tests ---
 

--- a/tests/test_file_upload_metadata_hardening.py
+++ b/tests/test_file_upload_metadata_hardening.py
@@ -9,6 +9,7 @@ import unittest
 from contextlib import contextmanager
 from datetime import datetime, timezone
 import hashlib
+import io
 from pathlib import Path
 
 # Ensure repository root is importable when running tests directly.
@@ -128,6 +129,34 @@ class TestFileUploadMetadataHardening(unittest.TestCase):
         assert row is not None
         self.assertEqual(row["original_name"], "file.md")
         self.assertEqual(row["content_type"], "text/markdown")
+
+    def test_image_thumbnail_applies_exif_orientation(self) -> None:
+        try:
+            from PIL import Image
+        except ImportError:
+            self.skipTest("Pillow unavailable")
+
+        image = Image.new("RGB", (1200, 800), (32, 96, 160))
+        exif = Image.Exif()
+        exif[274] = 6  # rotate 90 degrees clockwise for display
+        raw = io.BytesIO()
+        image.save(raw, format="JPEG", exif=exif)
+
+        info = self.file_manager.save_file(
+            file_data=raw.getvalue(),
+            original_name="phone-portrait.jpg",
+            content_type="image/jpeg",
+            uploaded_by="user-test",
+        )
+        self.assertIsNotNone(info)
+        assert info is not None
+
+        thumb = self.file_manager.get_thumbnail_data(info.id)
+        self.assertIsNotNone(thumb)
+        assert thumb is not None
+        thumb_bytes, _ = thumb
+        opened = Image.open(io.BytesIO(thumb_bytes))
+        self.assertGreater(opened.size[1], opened.size[0])
 
 
 if __name__ == '__main__':

--- a/tests/test_frontend_regressions.py
+++ b/tests/test_frontend_regressions.py
@@ -78,6 +78,48 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn("workspaceGovernanceDirtyIndicator.textContent = workspaceGovernanceDirty ? 'Unsaved changes' : 'Saved';", admin_template)
         self.assertIn('[workspaceSaveGovernanceBtn, workspaceSaveGovernanceBottomBtn].filter(Boolean).forEach((button) => {', admin_template)
 
+    def test_connect_preview_understands_mesh_avatar_and_alias_hints(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn('CURRENT_MESHSPACE_ID_ALIASES', connect_template)
+        self.assertIn('PEER_PREVIEW_PROFILES', connect_template)
+        self.assertIn('PEER_MESH_HINTS', connect_template)
+        self.assertIn('function meshIdsMatch(remoteId, remoteAliases)', connect_template)
+        self.assertIn('meshspaceIdAliases', connect_template)
+        self.assertIn('meshAvatarB64', connect_template)
+        self.assertIn('invite-preview-peer-avatar', connect_template)
+        self.assertIn('Peer ID', connect_template)
+        self.assertIn('Node hint', connect_template)
+        self.assertIn("apiJsonFetch('/api/v1/p2p/invite/preview'", connect_template)
+        self.assertIn('function enrichInvitePreview(preview, sequence)', connect_template)
+        self.assertIn('Remote preview refreshed from', connect_template)
+        self.assertIn('peerAvatarB64', connect_template)
+        self.assertIn('preview.peerLabel || knownLabel', connect_template)
+        self.assertIn('const DEVICE_ICON_CHOICES = new Set([', connect_template)
+        self.assertIn('function normalizePeerIcon(icon)', connect_template)
+        self.assertIn('peerIcon: normalizePeerIcon(data.pi || \'\')', connect_template)
+        self.assertIn('remote.peer_icon', connect_template)
+
+    def test_profile_settings_and_mesh_pages_explain_connection_hint_roles(self) -> None:
+        profile_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'profile.html').read_text(encoding='utf-8')
+        settings_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'settings.html').read_text(encoding='utf-8')
+        mesh_detail_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'meshspace_detail.html').read_text(encoding='utf-8')
+
+        self.assertIn('Connection Hint Preview', profile_template)
+        self.assertIn('Connection review model:', profile_template)
+        self.assertIn('device profile for the peer name and peer avatar', profile_template)
+        self.assertIn('Node hint', profile_template)
+
+        self.assertIn('peer identity shown during connection review', settings_template)
+        self.assertIn('peer identity', settings_template)
+        self.assertIn('Identity split:', settings_template)
+        self.assertIn('Connection Hint Preview', settings_template)
+        self.assertIn('Node Hint Icon', settings_template)
+        self.assertIn('Shared in the invite as a compact fallback', settings_template)
+
+        self.assertIn('device-level peer identity stay unchanged', mesh_detail_template)
+        self.assertIn('Connection Hint Preview', mesh_detail_template)
+        self.assertIn('Node hint', mesh_detail_template)
+
     def test_admin_governance_secondary_save_button_defaults_to_outline(self) -> None:
         admin_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'admin.html').read_text(encoding='utf-8')
         self.assertIn('class="btn btn-outline-success btn-sm" id="workspace-save-governance-bottom-btn"', admin_template)
@@ -111,11 +153,36 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn("runTrustPeerAction('{{ peer_id }}', 'sync_now', this)", trust_template)
         self.assertIn("href=\"#trust-peer-{{ peer.peer_id }}\"", trust_template)
 
+    def test_trust_page_surfaces_preview_only_sync_approval_controls(self) -> None:
+        trust_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'trust.html').read_text(encoding='utf-8')
+        self.assertIn("runTrustPeerAction('{{ peer_id }}', 'allow_sync', this)", trust_template)
+        self.assertIn("runTrustPeerAction('{{ peer_id }}', 'allow_mesh_sync', this)", trust_template)
+        self.assertIn("runTrustPeerAction('{{ peer_id }}', 'treat_same_mesh', this)", trust_template)
+        self.assertIn("runTrustPeerAction('{{ peer_id }}', 'keep_cross_mesh_bridge', this)", trust_template)
+        self.assertIn('preview-only until you approve sync', trust_template)
+        self.assertIn('Mesh Preview', trust_template)
+        self.assertIn('Mesh Relationship', trust_template)
+        self.assertIn('class="trust-peer-summary" aria-label="Peer review summary"', trust_template)
+        self.assertIn('{% for item in peer.review_summary %}', trust_template)
+
+    def test_trust_page_pending_peer_cards_prioritize_summary_over_status_pile(self) -> None:
+        trust_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'trust.html').read_text(encoding='utf-8')
+        self.assertIn('.trust-peer-summary {', trust_template)
+        self.assertIn('trust-summary-item {{ item.class_name }}', trust_template)
+        self.assertIn('trust-summary-value', trust_template)
+        self.assertIn('trust-summary-note', trust_template)
+        self.assertNotIn('trust-badge role-{{ peer.role_state }}', trust_template)
+        self.assertNotIn('trust-badge source-{{', trust_template)
+        self.assertIn('data-needs-review="{{ 1 if peer.requires_review_attention else 0 }}"', trust_template)
+        self.assertIn('Only the instance admin can change trust tiers.', trust_template)
+        self.assertIn('fresh label and avatar hints', (ROOT / 'canopy' / 'ui' / 'routes.py').read_text(encoding='utf-8'))
+
     def test_trust_page_disables_review_action_buttons_while_request_is_in_flight(self) -> None:
         trust_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'trust.html').read_text(encoding='utf-8')
         self.assertIn("if (triggerEl) {", trust_template)
         self.assertIn("triggerEl.disabled = true;", trust_template)
         self.assertIn("triggerEl.disabled = false;", trust_template)
+        self.assertIn('document.querySelectorAll(\'.trust-node[data-needs-review="1"]\')', trust_template)
 
     def test_trust_page_potential_peers_require_explicit_tier_assignment(self) -> None:
         trust_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'trust.html').read_text(encoding='utf-8')
@@ -144,11 +211,100 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn('external_endpoint=', connect_template)
         self.assertIn('Regenerated with external endpoint!', connect_template)
 
+    def test_connect_page_previews_invites_before_importing(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn('id="invitePreview"', connect_template)
+        self.assertIn('function decodeInvitePreview(code)', connect_template)
+        self.assertIn("new TextDecoder('utf-8').decode(bytes)", connect_template)
+        self.assertIn('function previewInvite(force)', connect_template)
+        self.assertIn('function connectPreviewedInvite()', connect_template)
+        self.assertIn('Review before connecting', connect_template)
+        self.assertIn('Mesh hint differs from this workspace', connect_template)
+        self.assertIn('Meshspace ID differs from this workspace', connect_template)
+        self.assertIn('allow_cross_mesh', connect_template)
+        self.assertIn('Labels are sender-provided hints', connect_template)
+        self.assertIn('Mesh identity review requires instance admin approval on this workspace.', connect_template)
+        self.assertIn('Only the instance admin can connect and review a peer from a different meshspace.', connect_template)
+        self.assertIn('Only the instance admin can approve a cross-mesh reconnect from this workspace.', connect_template)
+        self.assertIn('Connected to <code>\' + safePeerId + \'</code>, but mesh identity needs admin review before sync.', connect_template)
+        self.assertIn('function reviewPeerMesh(peerId, action, buttonEl)', connect_template)
+        self.assertIn('/api/v1/p2p/mesh_relationship', connect_template)
+        self.assertIn('Treat as same mesh', connect_template)
+        self.assertIn('Keep bridge', connect_template)
+        self.assertIn("btn.disabled = true;", connect_template)
+
+    def test_connect_known_peer_rows_use_public_identity_fallback(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn("{% set pubid = peer.public_identity if peer.public_identity else {} %}", connect_template)
+        self.assertIn("{% elif pubid.node_name %}", connect_template)
+        self.assertIn("Unverified {{ pubid.source }} label", connect_template)
+
+    def test_connect_connected_and_discovered_rows_use_public_identity_fallback(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn("{% set pub = peer_public_identities.get(pid) if peer_public_identities else {} %}", connect_template)
+        self.assertIn("{% elif pub and pub.node_name %}", connect_template)
+        self.assertIn("{% set dpub = peer_public_identities.get(peer.peer_id) if peer_public_identities else {} %}", connect_template)
+        self.assertIn("{% elif dpub and dpub.node_name %}", connect_template)
+        self.assertIn("pub.avatar_initials", connect_template)
+        self.assertIn("dpub.avatar_initials", connect_template)
+
+    def test_connect_page_api_errors_carry_diagnostic_code(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn('err.status = response.status;', connect_template)
+        self.assertIn("if (data && data.diagnostic_code) err.diagnosticCode = data.diagnostic_code;", connect_template)
+        self.assertIn("const code = err?.diagnosticCode;", connect_template)
+        self.assertIn("code === 'cross_mesh_admin_required'", connect_template)
+        self.assertIn("code === 'mesh_identity_admin_required'", connect_template)
+        self.assertIn("code === 'cross_mesh_confirmation_required'", connect_template)
+        self.assertIn("code === 'cross_mesh_reconnect_confirmation_required'", connect_template)
+        self.assertIn('Instance admin permission is required to connect to a peer from a different meshspace.', connect_template)
+
+    def test_connect_page_mesh_badge_distinguishes_no_hint_from_mismatch(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn('No mesh hint', connect_template)
+        self.assertIn('const hasMeshInfo = Boolean(preview.meshspaceId || preview.meshName);', connect_template)
+        self.assertIn('Current mesh hint', connect_template)
+        self.assertIn('Check mesh hint', connect_template)
+
+    def test_connect_page_disables_import_button_for_non_admin_cross_mesh(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn('isCrossMeshBlocked', connect_template)
+        self.assertIn('Admin required', connect_template)
+        self.assertIn('const blocked = Boolean(', connect_template)
+
     def test_feed_video_surfaces_preserve_actual_video_mime_type(self) -> None:
         feed_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'feed.html').read_text(encoding='utf-8')
         self.assertIn("metadata.video_type = firstType || 'video/mp4';", feed_template)
         self.assertIn("type=\"{{ post.metadata.video_type or 'video/mp4' }}\"", feed_template)
         self.assertIn("type=\"{{ em.get('video_type') or 'video/mp4' }}\"", feed_template)
+
+    def test_safe_markdown_renderer_is_bounded_and_shared(self) -> None:
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        base_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'base.html').read_text(encoding='utf-8')
+        self.assertIn('function hasCanopyMarkdownSyntax(text)', main_js)
+        self.assertIn('function renderCanopyInlineMarkdown(html)', main_js)
+        self.assertIn('function renderCanopyBlockMarkdown(html)', main_js)
+        self.assertIn('hasCanopyMarkdownSyntax(rawText)', main_js)
+        self.assertIn('<code class="canopy-inline-code no-katex">', main_js)
+        self.assertIn('class="canopy-md-list"', main_js)
+        self.assertIn('class="canopy-md-quote"', main_js)
+        self.assertIn('class="canopy-md-heading ', main_js)
+        self.assertIn("html.includes('<ul')", main_js)
+        self.assertIn("html.includes('<blockquote')", main_js)
+        self.assertIn('.canopy-inline-code', base_template)
+        self.assertIn('.canopy-md-heading', base_template)
+        self.assertIn('.canopy-md-list', base_template)
+        self.assertIn('.canopy-md-quote', base_template)
+
+    def test_timestamp_formatter_is_immediate_shared_and_utc_safe(self) -> None:
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        self.assertIn("normalized = raw.replace(' ', 'T') + 'Z';", main_js)
+        self.assertIn("normalized = raw + 'Z';", main_js)
+        self.assertIn('function formatTimestamps(scope)', main_js)
+        self.assertIn("root.querySelectorAll('[data-timestamp]').forEach", main_js)
+        self.assertIn('window.formatTimestamps = formatTimestamps;', main_js)
+        self.assertIn("document.addEventListener('DOMContentLoaded', () => formatTimestamps());", main_js)
+        self.assertIn('setInterval(() => formatTimestamps(), 30000);', main_js)
 
     def test_attention_bell_defaults_new_users_to_inbox_only(self) -> None:
         main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
@@ -259,6 +415,23 @@ class TestFrontendRegressions(unittest.TestCase):
         macros_template = (ROOT / 'canopy' / 'ui' / 'templates' / '_messages_macros.html').read_text(encoding='utf-8')
         self.assertIn('title="Download from peer"', macros_template)
         self.assertIn('<i class="bi bi-cloud-download"></i> Download', macros_template)
+
+    def test_messages_workspace_uses_mobile_thread_first_layout(self) -> None:
+        template = (ROOT / 'canopy' / 'ui' / 'templates' / 'messages.html').read_text(encoding='utf-8')
+        header = (ROOT / 'canopy' / 'ui' / 'templates' / '_messages_thread_header.html').read_text(encoding='utf-8')
+        self.assertIn('.messages-page.has-active-thread .messages-topbar {', template)
+        self.assertIn('.messages-page.has-active-thread .dm-sidebar {', template)
+        self.assertIn('.messages-page.has-active-thread.dm-mobile-sidebar-open .dm-sidebar {', template)
+        self.assertIn('.dm-sidebar-mobile-header', template)
+        self.assertIn('.dm-mobile-sidebar-backdrop', template)
+        self.assertIn('dm-composer-recipient-mode', template)
+        self.assertIn('function toggleDmMobileSidebar(forceOpen)', template)
+        self.assertIn('function syncDmMobileLayoutState(options)', template)
+        self.assertIn("toggleDmMobileSidebar(false)", template)
+        self.assertIn('id="dm-sidebar"', template)
+        self.assertIn("button.setAttribute('aria-expanded', isSidebarOpen ? 'true' : 'false');", template)
+        self.assertIn('class="btn btn-sm btn-outline-secondary dm-mobile-sidebar-toggle"', header)
+        self.assertIn('aria-controls="dm-sidebar"', header)
 
     def test_miniplayer_no_longer_eagerly_docks_youtube_on_update(self) -> None:
         main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
@@ -480,6 +653,16 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn('function startCanopyWorkspaceAttentionPolling()', main_js)
         self.assertIn('function pollCanopyWorkspaceAttentionEvents()', main_js)
         self.assertIn("requestCanopySidebarDmRefresh({ force: false }).catch(() => {});", main_js)
+
+    def test_sidebar_refresh_dedup_guard_and_debounce_present(self) -> None:
+        main_js = (ROOT / 'canopy' / 'ui' / 'static' / 'js' / 'canopy-main.js').read_text(encoding='utf-8')
+        self.assertIn('listenersAttached: false,', main_js)
+        self.assertIn('visibilityFocusDebounceHandle: null,', main_js)
+        self.assertIn('function _scheduleCanopyVisibilityFocusRefresh()', main_js)
+        self.assertIn('window.clearTimeout(canopySidebarAttentionState.visibilityFocusDebounceHandle);', main_js)
+        self.assertIn('if (!canopySidebarAttentionState.listenersAttached) {', main_js)
+        self.assertIn("document.addEventListener('visibilitychange', function() {", main_js)
+        self.assertIn('_scheduleCanopyVisibilityFocusRefresh();', main_js)
 
     def test_bookmarks_navigation_and_save_controls_exist(self) -> None:
         base_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'base.html').read_text(encoding='utf-8')
@@ -1182,3 +1365,21 @@ class TestFrontendRegressions(unittest.TestCase):
             "if (data && (data.marked_read || Number(data.acknowledged_mentions || 0) > 0) && typeof window.requestCanopySidebarAttentionRefresh === 'function') {",
             channels_template,
         )
+
+    def test_mobile_resize_dedup_gates_collapse_redundant_layout_work(self) -> None:
+        channels_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'channels.html').read_text(encoding='utf-8')
+        messages_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'messages.html').read_text(encoding='utf-8')
+        feed_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'feed.html').read_text(encoding='utf-8')
+
+        self.assertIn('let channelViewportSyncQueued = false;', channels_template)
+        self.assertIn('function scheduleChannelViewportSync()', channels_template)
+        self.assertIn("window.addEventListener('resize', scheduleChannelViewportSync)", channels_template)
+        self.assertIn("window.visualViewport.addEventListener('resize', scheduleChannelViewportSync)", channels_template)
+
+        self.assertIn('let _dmLayoutSyncQueued = false;', messages_template)
+        self.assertIn('function scheduleDmMobileLayoutSync()', messages_template)
+        self.assertIn("window.addEventListener('resize', scheduleDmMobileLayoutSync)", messages_template)
+
+        self.assertIn('let _feedComposerSyncQueued = false;', feed_template)
+        self.assertIn('function scheduleFeedComposerSync()', feed_template)
+        self.assertIn("window.addEventListener('resize', scheduleFeedComposerSync)", feed_template)

--- a/tests/test_manager_trust_gating.py
+++ b/tests/test_manager_trust_gating.py
@@ -7,6 +7,7 @@ import sys
 import types
 import unittest
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -52,6 +53,13 @@ class TestManagerTrustGating(unittest.TestCase):
         manager._cancel_reconnect = lambda peer_id: None
         manager._refresh_peer_version_info = lambda peer_id: None
         manager._peer_is_trusted_for_content = lambda peer_id: False
+        manager.get_peer_sync_status = lambda peer_id: {'preview_only': False}
+        manager._remember_live_peer_endpoints = lambda peer_id: None
+        manager._wait_for_connection_settle = AsyncMock(return_value=True)
+        manager._post_connect_retry_counts = {}
+        manager._post_connect_retry_tokens = {}
+        manager._request_post_connect_sync_retry = lambda peer_id, reason: None
+        manager.connection_manager = SimpleNamespace(get_connection=lambda peer_id: None)
 
         calls = []
 
@@ -71,6 +79,52 @@ class TestManagerTrustGating(unittest.TestCase):
         asyncio.run(manager._run_post_connect_sync_impl('peer-guest'))
 
         self.assertEqual(calls, [('channel_sync', 'peer-guest'), ('metadata_replay', 'peer-guest'), ('catchup', 'peer-guest')])
+
+    def test_preview_only_peer_skips_post_connect_bootstrap(self) -> None:
+        manager = P2PNetworkManager.__new__(P2PNetworkManager)
+        manager.on_peer_connected = None
+        manager._cancel_reconnect = lambda peer_id: None
+        manager._refresh_peer_version_info = lambda peer_id: None
+        manager._peer_is_trusted_for_content = lambda peer_id: False
+        manager.get_peer_sync_status = lambda peer_id: {
+            'preview_only': True,
+            'remote_meshspace_name': 'Family Mesh',
+            'remote_meshspace_id': 'family-mesh',
+        }
+        manager._record_connection_event = lambda *args, **kwargs: None
+        manager._remember_live_peer_endpoints = lambda peer_id: None
+        manager._post_connect_retry_counts = {}
+        manager._post_connect_retry_tokens = {}
+        manager._request_post_connect_sync_retry = lambda peer_id, reason: None
+        manager._wait_for_connection_settle = AsyncMock(return_value=True)
+        manager.connection_manager = SimpleNamespace(get_connection=lambda peer_id: None)
+
+        calls = []
+
+        async def _record(name, peer_id):
+            calls.append((name, peer_id))
+
+        manager._send_channel_sync_to_peer = lambda peer_id: _record('channel_sync', peer_id)
+        manager._send_public_channel_metadata_replay_to_peer = lambda peer_id: _record('metadata_replay', peer_id)
+        manager._send_catchup_request = lambda peer_id: _record('catchup', peer_id)
+        manager._send_device_preview_to_peer = lambda peer_id: _record('device_preview', peer_id)
+        manager._send_membership_recovery_query = lambda peer_id: _record('membership', peer_id)
+        manager._retry_missing_channel_key_requests_for_peer = lambda peer_id: _record('keys', peer_id)
+        manager._send_profile_to_peer = lambda peer_id: _record('profile', peer_id)
+        manager._send_peer_announcement_to = lambda peer_id: _record('peer_announce', peer_id)
+        manager._announce_new_peer_to_others = lambda peer_id: _record('announce_others', peer_id)
+        manager.message_router = SimpleNamespace(flush_pending_messages=lambda peer_id: _record('flush', peer_id))
+
+        asyncio.run(manager._run_post_connect_sync_impl('peer-guest'))
+
+        self.assertEqual(calls, [('device_preview', 'peer-guest')])
+
+    def test_trigger_peer_sync_refuses_preview_only_peer(self) -> None:
+        manager = P2PNetworkManager.__new__(P2PNetworkManager)
+        manager.get_peer_sync_status = lambda peer_id: {'preview_only': True}
+        manager._event_loop = None
+
+        self.assertFalse(manager.trigger_peer_sync('peer-guest'))
 
     def test_untrusted_catchup_request_sends_only_public_channel_timestamps(self) -> None:
         manager = P2PNetworkManager.__new__(P2PNetworkManager)

--- a/tests/test_meshspace_runtime_host_filter_regressions.py
+++ b/tests/test_meshspace_runtime_host_filter_regressions.py
@@ -1,0 +1,67 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from canopy.core import meshspaces
+from canopy.core.meshspaces import MeshspaceRegistryManager
+
+
+class MeshspaceRuntimeHostFilterRegressionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.registry_root = Path(self.tempdir.name) / "registry"
+
+    def test_windows_listener_pid_for_port_ignores_other_loopback_host(self) -> None:
+        result = SimpleNamespace(
+            stdout=(
+                "  TCP    127.0.0.2:7800       0.0.0.0:0              LISTENING       106220\n"
+            ),
+            stderr="",
+        )
+
+        with patch("canopy.core.meshspaces._is_windows_platform", return_value=True), \
+             patch("canopy.core.meshspaces.subprocess.run", return_value=result):
+            self.assertEqual(meshspaces._windows_listener_pid_for_port(7800, host="127.0.0.1"), 0)
+            self.assertEqual(meshspaces._windows_listener_pid_for_port(7800, host="127.0.0.2"), 106220)
+
+    def test_probe_meshspace_runtime_ignores_foreign_loopback_listener_and_stale_pid(self) -> None:
+        manager = MeshspaceRegistryManager(registry_root=self.registry_root)
+        manager.create_meshspace(
+            name="Canopy Mesh",
+            meshspace_id="canopy-mesh",
+            description="Official Canopy Mesh",
+            http_port=7800,
+            mesh_port=7801,
+            discovery_port=7802,
+        )
+        record = manager.get_meshspace("canopy-mesh")
+        self.assertIsNotNone(record)
+        record["http_host"] = "127.0.0.1"
+        record["status"] = "stopping"
+        record["pid"] = 106220
+        manager._upsert_record(record)
+
+        result = SimpleNamespace(
+            stdout=(
+                "  TCP    127.0.0.2:7800       0.0.0.0:0              LISTENING       106220\n"
+            ),
+            stderr="",
+        )
+
+        with patch("canopy.core.meshspaces._is_windows_platform", return_value=True), \
+             patch("canopy.core.meshspaces.subprocess.run", return_value=result), \
+             patch("canopy.core.meshspaces._pid_is_alive", return_value=True), \
+             patch("canopy.core.meshspaces._port_accepts_connections", return_value=False), \
+             patch("canopy.core.meshspaces._http_json", return_value={}):
+            probe = manager.probe_meshspace_runtime("canopy-mesh")
+
+        self.assertFalse(probe["live"])
+        self.assertEqual(probe["detected_pid"], 0)
+        self.assertEqual(probe["effective_status"], "stopped")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meshspaces_foundation.py
+++ b/tests/test_meshspaces_foundation.py
@@ -29,7 +29,8 @@ if 'zeroconf' not in sys.modules:
     sys.modules['zeroconf'] = zeroconf_stub
 
 from canopy.core.app import create_app
-from canopy.core.meshspaces import build_meshspace_notification_summary
+from canopy.core.meshspaces import MeshspaceRegistryManager, build_meshspace_notification_summary
+from canopy.network.invite import InviteCode
 
 _PNG_1X1 = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg=="
@@ -60,6 +61,15 @@ class _FakeP2PNetworkManager:
 
     def get_connected_peers(self):
         return []
+
+    def get_discovered_peers(self):
+        return []
+
+    def get_introduced_peers(self):
+        return []
+
+    def get_relay_status(self):
+        return {}
 
     def peer_supports_capability(self, peer_id, capability):
         return False
@@ -175,6 +185,35 @@ class MeshspaceFoundationTest(unittest.TestCase):
         self.assertEqual((identity_payload.get('meshspace') or {}).get('meshspace_id'), 'family-lab')
         self.assertEqual((identity_payload.get('peer') or {}).get('peer_id'), 'peer-mesh-test')
 
+    def test_public_mesh_identity_includes_compact_preview_fields(self) -> None:
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        config = self.app.config['CANOPY_CONFIG']
+        meshspace_id = config.meshspace.meshspace_id
+        manager.set_meshspace_avatar(
+            meshspace_id,
+            _PNG_1X1,
+            filename='identity.png',
+            content_type='image/png',
+        )
+        with patch('canopy.api.routes._current_local_peer_hint_payload', return_value={
+            'peer_label': 'Windy Admin',
+            'instance_label': 'Alvin Node',
+            'peer_avatar_b64': base64.b64encode(_PNG_1X1).decode('ascii'),
+            'peer_avatar_mime': 'image/png',
+            'peer_icon': 'bi-laptop',
+        }):
+            identity = self.client.get('/api/v1/mesh/identity')
+        self.assertEqual(identity.status_code, 200)
+        payload = identity.get_json() or {}
+        self.assertEqual((payload.get('meshspace') or {}).get('meshspace_id'), meshspace_id)
+        self.assertTrue((payload.get('meshspace') or {}).get('meshspace_fingerprint'))
+        self.assertTrue((payload.get('meshspace') or {}).get('meshspace_avatar_b64'))
+        self.assertEqual((payload.get('meshspace') or {}).get('meshspace_avatar_mime'), 'image/png')
+        self.assertEqual((payload.get('peer') or {}).get('peer_label'), 'Windy Admin')
+        self.assertTrue((payload.get('peer') or {}).get('peer_avatar_b64'))
+        self.assertEqual((payload.get('peer') or {}).get('peer_avatar_mime'), 'image/png')
+        self.assertEqual((payload.get('peer') or {}).get('peer_icon'), 'bi-laptop')
+
     def test_meshspace_registry_tracks_current_runtime(self) -> None:
         manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
         record = manager.get_meshspace('family-lab')
@@ -244,6 +283,9 @@ class MeshspaceFoundationTest(unittest.TestCase):
             name='Research Lab',
             meshspace_id='research-lab',
             description='Experimental mesh for testing.',
+            http_port=18700,
+            mesh_port=18701,
+            discovery_port=18702,
         )
         manager.update_runtime_state('research-lab', 'running', peer_id='peer-research')
 
@@ -825,6 +867,141 @@ class MeshspaceFoundationTest(unittest.TestCase):
         isolate_body = isolate_response.get_data(as_text=True)
         self.assertIn('Enable networking after restart', isolate_body)
 
+    def test_stopped_meshspace_port_update_preserves_identity_and_updates_launch_env(self) -> None:
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        manager.create_meshspace(
+            name='Research Lab',
+            meshspace_id='research-lab',
+            description='Experimental mesh for testing.',
+            http_port=18700,
+            mesh_port=18701,
+            discovery_port=18702,
+        )
+        before = manager.get_meshspace('research-lab')
+        self.assertIsNotNone(before)
+
+        with patch('canopy.core.meshspaces._listener_pid_for_port', return_value=0), \
+             patch('canopy.core.meshspaces._port_accepts_connections', return_value=False), \
+             patch('canopy.core.meshspaces._http_json', return_value={}):
+            updated = manager.update_meshspace_ports('research-lab', http_port=18800)
+
+        self.assertIsNotNone(updated)
+        self.assertEqual(updated.get('http_port'), 18800)
+        self.assertEqual(updated.get('mesh_port'), 18801)
+        self.assertEqual(updated.get('discovery_port'), 18802)
+        self.assertEqual(updated.get('meshspace_id'), before.get('meshspace_id'))
+        self.assertEqual(updated.get('data_dir'), before.get('data_dir'))
+        self.assertEqual(updated.get('database_path'), before.get('database_path'))
+        self.assertEqual(updated.get('session_cookie_name'), before.get('session_cookie_name'))
+        self.assertEqual(updated.get('launch_url'), 'http://127.0.0.1:18800')
+
+        launch_env = manager.launch_environment('research-lab')
+        self.assertEqual(launch_env.get('CANOPY_PORT'), '18800')
+        self.assertEqual(launch_env.get('CANOPY_MESH_PORT'), '18801')
+        self.assertEqual(launch_env.get('CANOPY_DISCOVERY_PORT'), '18802')
+        self.assertEqual(launch_env.get('CANOPY_MESHSPACE_ID'), 'research-lab')
+
+    def test_stopped_meshspace_port_update_rejects_registry_conflict(self) -> None:
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        manager.create_meshspace(
+            name='Research Lab',
+            meshspace_id='research-lab',
+            http_port=18700,
+            mesh_port=18701,
+            discovery_port=18702,
+        )
+        manager.create_meshspace(
+            name='Studio Lab',
+            meshspace_id='studio-lab',
+            http_port=18800,
+            mesh_port=18801,
+            discovery_port=18802,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            manager.update_meshspace_ports('studio-lab', http_port=18700)
+        self.assertIn("Research Lab", str(ctx.exception))
+        self.assertIn("18700", str(ctx.exception))
+
+    def test_stopped_meshspace_port_update_rejects_live_runtime(self) -> None:
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        manager.create_meshspace(
+            name='Research Lab',
+            meshspace_id='research-lab',
+            http_port=18700,
+            mesh_port=18701,
+            discovery_port=18702,
+        )
+        manager.update_runtime_state('research-lab', 'running', peer_id='peer-research')
+
+        with patch.object(manager, 'probe_meshspace_runtime', return_value={
+            'live': True,
+            'effective_status': 'running',
+            'detected_pid': 4242,
+        }):
+            with self.assertRaises(ValueError) as ctx:
+                manager.update_meshspace_ports('research-lab', http_port=18800)
+        self.assertIn('Stop this meshspace before changing its ports', str(ctx.exception))
+
+    def test_stopped_meshspace_port_update_rejects_host_aware_listener_conflict(self) -> None:
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        manager.create_meshspace(
+            name='Research Lab',
+            meshspace_id='research-lab',
+            http_port=18700,
+            mesh_port=18701,
+            discovery_port=18702,
+        )
+
+        def _fake_listener(port, host=None):
+            self.assertEqual(host, '127.0.0.1')
+            return 4242 if int(port) == 18801 else 0
+
+        with patch('canopy.core.meshspaces._listener_pid_for_port', side_effect=_fake_listener), \
+             patch('canopy.core.meshspaces._port_accepts_connections', return_value=False), \
+             patch('canopy.core.meshspaces._http_json', return_value={}):
+            with self.assertRaises(ValueError) as ctx:
+                manager.update_meshspace_ports('research-lab', http_port=18800)
+        self.assertIn('mesh:18801 pid:4242', str(ctx.exception))
+
+    def test_admin_can_update_stopped_meshspace_ports_from_detail(self) -> None:
+        self._authenticate()
+
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        manager.create_meshspace(
+            name='Research Lab',
+            meshspace_id='research-lab',
+            description='Experimental mesh for testing.',
+            http_port=18700,
+            mesh_port=18701,
+            discovery_port=18702,
+        )
+
+        with patch('canopy.core.meshspaces._listener_pid_for_port', return_value=0), \
+             patch('canopy.core.meshspaces._port_accepts_connections', return_value=False), \
+             patch('canopy.core.meshspaces._http_json', return_value={}):
+            response = self.client.post(
+                '/meshes/research-lab/ports',
+                data={
+                    'csrf_token': 'csrf-mesh',
+                    'http_port': '18800',
+                },
+                follow_redirects=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+        self.assertIn('Updated', body)
+        self.assertIn('18800', body)
+        self.assertIn('18801', body)
+        self.assertIn('18802', body)
+        self.assertIn('/meshes/research-lab/ports', body)
+
+        record = manager.get_meshspace('research-lab')
+        self.assertEqual(record.get('http_port'), 18800)
+        self.assertEqual(record.get('mesh_port'), 18801)
+        self.assertEqual(record.get('discovery_port'), 18802)
+
     def test_admin_can_edit_meshspace_identity_metadata(self) -> None:
         self._authenticate()
 
@@ -1004,6 +1181,9 @@ class MeshspaceFoundationTest(unittest.TestCase):
             name='Research Lab',
             meshspace_id='research-lab',
             description='Experimental mesh for testing.',
+            http_port=18700,
+            mesh_port=18701,
+            discovery_port=18702,
         )
 
         response = self.client.get('/meshes/research-lab/open')
@@ -1353,6 +1533,313 @@ class LegacyMeshspaceAdoptionTest(unittest.TestCase):
         self.assertIn('Default Mesh', body)
         self.assertIn('Rename the default mesh before adding more so each world stays clear.', body)
         self.assertIn('Needs name', body)
+
+    def test_invite_generation_uses_device_profile_as_peer_identity_without_bloating_invite_payload(self) -> None:
+        self._authenticate()
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        config = self.app.config['CANOPY_CONFIG']
+        meshspace_id = config.meshspace.meshspace_id
+        manager.update_meshspace_metadata(meshspace_id, name='Windy Mesh')
+        manager.set_meshspace_avatar(
+            meshspace_id,
+            _PNG_1X1,
+            filename='windy.png',
+            content_type='image/png',
+        )
+
+        fake_invite = SimpleNamespace(
+            encode=lambda: 'canopy:test',
+            peer_id='peer-mesh-test',
+            endpoints=['ws://192.168.1.12:7771'],
+            meshspace_id=meshspace_id,
+            mesh_name='Windy Mesh',
+            meshspace_fingerprint='ABCD-1234',
+            to_dict=lambda: {'mn': 'Windy Mesh'},
+        )
+        with patch('canopy.network.invite.generate_invite', return_value=fake_invite) as generate_invite_mock, \
+             patch('canopy.core.device.get_device_profile', return_value={'display_name': 'Alvin Node', 'icon': 'bi-server'}), \
+             patch('canopy.core.device.get_device_label', return_value='Alvin Device'):
+            response = self.client.get('/api/v1/p2p/invite')
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('meshspace_name'), 'Windy Mesh')
+        self.assertEqual(payload.get('peer_label'), 'Alvin Node')
+        self.assertEqual(payload.get('instance_label'), 'Alvin Node')
+        self.assertEqual(generate_invite_mock.call_args.kwargs.get('mesh_name'), 'Windy Mesh')
+        self.assertEqual(generate_invite_mock.call_args.kwargs.get('peer_label'), 'Alvin Node')
+        self.assertEqual(generate_invite_mock.call_args.kwargs.get('instance_label'), 'Alvin Node')
+        self.assertEqual(generate_invite_mock.call_args.kwargs.get('peer_icon'), 'bi-server')
+        self.assertIsNone(generate_invite_mock.call_args.kwargs.get('meshspace_avatar_b64'))
+        self.assertIsNone(generate_invite_mock.call_args.kwargs.get('meshspace_avatar_mime'))
+        self.assertIsNone(generate_invite_mock.call_args.kwargs.get('meshspace_id_aliases'))
+
+    def test_connect_page_uses_device_profile_as_primary_peer_hint(self) -> None:
+        self._authenticate()
+        fake_invite = SimpleNamespace(
+            encode=lambda: 'canopy:test',
+            peer_id='peer-mesh-test',
+            endpoints=['ws://192.168.1.12:7771'],
+        )
+        with patch('canopy.core.device.get_device_profile', return_value={'display_name': 'Alvin Node'}), \
+             patch('canopy.core.device.get_device_label', return_value='Alvin Device'), \
+             patch('canopy.network.invite.generate_invite', return_value=fake_invite):
+            response = self.client.get('/connect')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+        self.assertIn('Alvin Node', body)
+        self.assertIn('Node hint Alvin Node', body)
+
+    def test_invite_preview_probe_fetches_remote_mesh_identity_from_advertised_endpoint(self) -> None:
+        self._authenticate()
+
+        invite = (
+            'canopy:'
+            'eyJ2IjoxLCJwaWQiOiJwZWVyLXdpbmR5IiwiZXBrIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJ4cGsiOiIxMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExIiwiZXAiOlsid3M6Ly8xOTIuMTY4LjEuMTU5Ojc3NzEiXSwibW4iOiJHb2xkR2FuZyIsIm1pZCI6ImdvbGRnYW5nIiwibWYiOiI5M0Q4LTkzMTQifQ'
+        )
+
+        class _FakeResponse:
+            def __init__(self, payload, url):
+                self._payload = payload
+                self.status = 200
+                self.headers = {'Content-Type': 'application/json'}
+                self._url = url
+
+            def read(self, *_args, **_kwargs):
+                return json.dumps(self._payload).encode('utf-8')
+
+            def geturl(self):
+                return self._url
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        remote_payload = {
+            'meshspace': {
+                'meshspace_id': 'goldgang',
+                'meshspace_id_aliases': ['legacy-gold'],
+                'name': 'GoldGang',
+                'meshspace_fingerprint': '93D8-9314',
+                'meshspace_avatar_b64': base64.b64encode(_PNG_1X1).decode('ascii'),
+                'meshspace_avatar_mime': 'image/png',
+            },
+            'peer': {
+                'peer_id': 'peer-windy',
+                'peer_label': 'Maddog',
+                'peer_avatar_b64': base64.b64encode(_PNG_1X1).decode('ascii'),
+                'peer_avatar_mime': 'image/png',
+                'instance_label': 'WINDYLAPTOP',
+                'peer_icon': 'bi-laptop',
+            },
+            'version': '0.6.18',
+            'ready': True,
+        }
+        remote_url = 'http://192.168.1.159:7770/api/v1/mesh/identity'
+        with patch('canopy.api.routes.urlopen', return_value=_FakeResponse(remote_payload, remote_url)) as remote_get:
+            response = self.client.post(
+                '/api/v1/p2p/invite/preview',
+                json={'invite_code': invite},
+                headers={'X-CSRFToken': 'csrf-mesh'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('ok'))
+        self.assertEqual(payload.get('meshspace_name'), 'GoldGang')
+        self.assertEqual(payload.get('meshspace_id'), 'goldgang')
+        self.assertTrue(payload.get('meshspace_avatar_b64'))
+        self.assertEqual(payload.get('peer_label'), 'Maddog')
+        self.assertTrue(payload.get('peer_avatar_b64'))
+        self.assertEqual(payload.get('instance_label'), 'WINDYLAPTOP')
+        self.assertEqual(payload.get('peer_icon'), 'bi-laptop')
+        self.assertEqual(payload.get('source_endpoint'), 'ws://192.168.1.159:7771')
+        self.assertEqual(payload.get('source_url'), remote_url)
+        request_obj = remote_get.call_args.args[0]
+        self.assertEqual(request_obj.full_url, remote_url)
+
+    def test_invite_preview_probe_tolerates_remote_fetch_failure(self) -> None:
+        from urllib.error import URLError
+
+        self._authenticate()
+        invite = (
+            'canopy:'
+            'eyJ2IjoxLCJwaWQiOiJwZWVyLXdpbmR5IiwiZXBrIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJ4cGsiOiIxMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExIiwiZXAiOlsid3M6Ly8xOTIuMTY4LjEuMTU5Ojc3NzEiXSwibW4iOiJHb2xkR2FuZyIsIm1pZCI6ImdvbGRnYW5nIiwibWYiOiI5M0Q4LTkzMTQifQ'
+        )
+        with patch('canopy.api.routes.urlopen', side_effect=URLError('connection refused')):
+            response = self.client.post(
+                '/api/v1/p2p/invite/preview',
+                json={'invite_code': invite},
+                headers={'X-CSRFToken': 'csrf-mesh'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertFalse(payload.get('ok'))
+        self.assertEqual(payload.get('status'), 'unavailable')
+
+    def test_admin_can_promote_legacy_meshspace_to_explicit_identity(self) -> None:
+        self._authenticate()
+        config = self.app.config['CANOPY_CONFIG']
+        old_meshspace_id = config.meshspace.meshspace_id
+
+        class _NoopThread:
+            def __init__(self, target=None, daemon=None):
+                self.target = target
+                self.daemon = daemon
+
+            def start(self):
+                return None
+
+        with patch('canopy.ui.routes.schedule_self_restart', return_value=999) as restart_mock, \
+             patch('canopy.ui.routes.threading.Thread', _NoopThread):
+            response = self.client.post(
+                f'/meshes/{old_meshspace_id}/promote',
+                data={
+                    'csrf_token': 'csrf-mesh',
+                    'stable_meshspace_id': 'windy-mesh',
+                    'stable_meshspace_name': 'Windy Mesh',
+                },
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Restarting Windy Mesh', response.get_data(as_text=True))
+        restart_mock.assert_called_once()
+
+        manager = self.app.config.get('MESHSPACE_REGISTRY_MANAGER')
+        promoted = manager.get_meshspace('windy-mesh')
+        self.assertIsNotNone(promoted)
+        self.assertEqual(promoted.get('runtime_mode'), 'meshspace')
+        self.assertIn(old_meshspace_id, promoted.get('meshspace_id_aliases') or [])
+        self.assertIsNone(manager.get_meshspace(old_meshspace_id))
+
+        self.assertTrue(config.meshspace.enabled)
+        self.assertEqual(config.meshspace.meshspace_id, 'windy-mesh')
+        self.assertIn(old_meshspace_id, config.meshspace.meshspace_id_aliases)
+
+    def test_promoted_mesh_accepts_old_alias_invite_without_cross_mesh_confirmation(self) -> None:
+        self._authenticate()
+        config = self.app.config['CANOPY_CONFIG']
+        old_meshspace_id = config.meshspace.meshspace_id
+
+        class _NoopThread:
+            def __init__(self, target=None, daemon=None):
+                self.target = target
+                self.daemon = daemon
+
+            def start(self):
+                return None
+
+        with patch('canopy.ui.routes.schedule_self_restart', return_value=999), \
+             patch('canopy.ui.routes.threading.Thread', _NoopThread):
+            promote_response = self.client.post(
+                f'/meshes/{old_meshspace_id}/promote',
+                data={
+                    'csrf_token': 'csrf-mesh',
+                    'stable_meshspace_id': 'windy-mesh',
+                    'stable_meshspace_name': 'Windy Mesh',
+                },
+                follow_redirects=False,
+            )
+        self.assertEqual(promote_response.status_code, 200)
+
+        invite = InviteCode(
+            peer_id='peer-windy-remote',
+            ed25519_public_key_b58='11111111111111111111111111111111',
+            x25519_public_key_b58='11111111111111111111111111111111',
+            endpoints=['ws://192.168.1.80:7771'],
+            mesh_name='Windy Mesh',
+            meshspace_id=old_meshspace_id,
+        )
+        with patch('canopy.network.invite.InviteCode.decode', return_value=invite), \
+             patch('canopy.network.invite.import_invite', return_value={'peer_id': invite.peer_id, 'endpoints': invite.endpoints}):
+            response = self.client.post(
+                '/api/v1/p2p/invite/import',
+                json={'invite_code': 'canopy:test'},
+                headers={'X-CSRFToken': 'csrf-mesh'},
+            )
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertNotEqual(payload.get('status'), 'confirmation_required')
+
+
+class MeshspaceRegistryManagerIsolationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.registry_root = Path(self.tempdir.name) / 'registry'
+
+    def test_custom_registry_root_is_used_for_registry_writes(self) -> None:
+        manager = MeshspaceRegistryManager(registry_root=self.registry_root)
+        manager.create_meshspace(name='Research Lab', meshspace_id='research-lab')
+
+        registry_path = self.registry_root / 'registry.json'
+        self.assertTrue(registry_path.exists())
+
+        payload = json.loads(registry_path.read_text())
+        mesh_ids = {item.get('meshspace_id') for item in payload.get('meshspaces', [])}
+        self.assertIn('research-lab', mesh_ids)
+
+    def test_testing_legacy_runtime_uses_data_local_registry_root(self) -> None:
+        from canopy.core.config import Config
+
+        legacy_root = Path(self.tempdir.name) / 'legacy-current'
+        with patch.dict(
+            os.environ,
+            {
+                'CANOPY_TESTING': 'true',
+                'CANOPY_DATA_DIR': str(legacy_root),
+                'CANOPY_DATABASE_PATH': str(legacy_root / 'canopy.db'),
+                'CANOPY_SECRET_KEY': 'test-secret',
+            },
+            clear=False,
+        ):
+            config = Config.from_env()
+        self.assertEqual(config.meshspace.registry_root, str(legacy_root / '.meshspaces-registry'))
+
+    def test_list_meshspaces_prunes_stopped_temp_legacy_records(self) -> None:
+        manager = MeshspaceRegistryManager(registry_root=self.registry_root)
+        self.registry_root.mkdir(parents=True, exist_ok=True)
+        registry_path = self.registry_root / 'registry.json'
+        registry_path.write_text(json.dumps({
+            'version': 1,
+            'meshspaces': [
+                {
+                    'meshspace_id': 'legacy-device-temp',
+                    'name': 'Default Mesh',
+                    'runtime_mode': 'legacy-default',
+                    'is_default': True,
+                    'status': 'stopped',
+                    'data_dir': str(Path(tempfile.gettempdir()) / 'canopy-bad-legacy'),
+                    'database_path': str(Path(tempfile.gettempdir()) / 'canopy-bad-legacy' / 'canopy.db'),
+                    'http_port': 7770,
+                    'mesh_port': 7771,
+                    'discovery_port': 7772,
+                },
+                {
+                    'meshspace_id': 'research-lab',
+                    'name': 'Research Lab',
+                    'runtime_mode': 'meshspace',
+                    'is_default': False,
+                    'status': 'defined',
+                    'data_dir': str(Path(self.tempdir.name) / 'research-lab'),
+                    'database_path': str(Path(self.tempdir.name) / 'research-lab' / 'canopy.db'),
+                    'http_port': 7800,
+                    'mesh_port': 7801,
+                    'discovery_port': 7802,
+                },
+            ],
+        }))
+
+        records = manager.list_meshspaces()
+        self.assertEqual([record.get('meshspace_id') for record in records], ['research-lab'])
+
+        payload = json.loads(registry_path.read_text())
+        mesh_ids = {item.get('meshspace_id') for item in payload.get('meshspaces', [])}
+        self.assertEqual(mesh_ids, {'research-lab'})
 
 
 class WindowsMeshspacePortProbeTest(unittest.TestCase):

--- a/tests/test_messages_ui_workspace.py
+++ b/tests/test_messages_ui_workspace.py
@@ -258,6 +258,53 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         self.assertNotIn("threadPane.addEventListener('paste'", body)
         self.assertIn('grid-template-rows: auto minmax(0, 1fr);', body)
         self.assertIn('position: sticky;', body)
+        self.assertIn('class="messages-page has-active-thread"', body)
+        self.assertIn('dm-sidebar-mobile-header', body)
+        self.assertIn('dm-mobile-sidebar-backdrop', body)
+        self.assertIn('toggleDmMobileSidebar(true)', body)
+        self.assertIn('function syncDmMobileLayoutState(options)', body)
+        self.assertIn("window.addEventListener('resize', scheduleDmMobileLayoutSync);", body)
+
+    def test_dm_message_text_preserves_multiline_content(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        template = (root / 'canopy' / 'ui' / 'templates' / 'messages.html').read_text(encoding='utf-8')
+        self.assertIn('.dm-bubble-copy {', template)
+        self.assertIn('white-space: pre-wrap;', template)
+        self.assertIn('line-height: 1.45;', template)
+
+    def test_inline_edit_js_reapplies_rich_content_after_text_update(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        template = (root / 'canopy' / 'ui' / 'templates' / 'messages.html').read_text(encoding='utf-8')
+        pattern = re.compile(
+            r"function applyInlineDmMessageEdit\(messageId, content, editedAt\)\s*\{.*?"
+            r"textEl\.textContent = content \|\| '';\s*"
+            r"applyDmRichContentInScope\(msgEl\);",
+            re.S,
+        )
+        self.assertRegex(template, pattern)
+
+    def test_inline_edit_success_path_avoids_full_thread_snapshot_reload(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        template = (root / 'canopy' / 'ui' / 'templates' / 'messages.html').read_text(encoding='utf-8')
+        pattern = re.compile(
+            r"showAlert\('Message updated successfully', 'success'\);\s*"
+            r"(?:(?!loadDmSnapshot).)*?\.catch\(err => showAlert\('Failed to update message:",
+            re.S,
+        )
+        self.assertRegex(template, pattern)
+
+    def test_visibility_change_relies_on_event_poll_without_forcing_full_snapshot(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        template = (root / 'canopy' / 'ui' / 'templates' / 'messages.html').read_text(encoding='utf-8')
+        pattern = re.compile(
+            r"document\.addEventListener\('visibilitychange', \(\) => \{\s*"
+            r"if \(!document\.hidden && !isDmSearchActive\(\)\) \{\s*"
+            r"syncDmMobileLayoutState\(\{ keepSidebarOpen: true \}\);\s*"
+            r"pollDmEvents\(\);\s*"
+            r"\}\s*\}\);",
+            re.S,
+        )
+        self.assertRegex(template, pattern)
 
     def test_messages_page_acknowledges_dm_mentions_for_open_thread(self) -> None:
         self.conn.execute(
@@ -507,6 +554,38 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         self.assertEqual(metadata.get('reply_to'), 'DM-root')
         self.assertEqual(self.p2p_manager.direct_messages[-1]['metadata'].get('reply_to'), 'DM-root')
 
+    def test_ajax_send_message_can_start_fresh_same_member_group_thread(self) -> None:
+        base_group_id = compute_group_id(['owner', 'peer-b', 'peer-c'])
+        response = self.client.post(
+            '/ajax/send_message',
+            json={
+                'recipient_ids': ['peer-b', 'peer-c'],
+                'content': 'Fresh same people thread',
+                'force_new_group': True,
+            },
+            headers={'X-CSRFToken': 'csrf-ui-messages'},
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        self.assertTrue(payload.get('group_thread_id'))
+        self.assertTrue(payload.get('group_id'))
+        self.assertNotEqual(payload.get('group_id'), base_group_id)
+        self.assertEqual(payload.get('base_group_id'), base_group_id)
+
+        row = self.conn.execute(
+            'SELECT recipient_id, metadata FROM messages WHERE id = ?',
+            (payload['message']['id'],),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row['recipient_id'], payload.get('group_id'))
+        metadata = json.loads(row['metadata']) if row['metadata'] else {}
+        self.assertEqual(metadata.get('group_id'), payload.get('group_id'))
+        self.assertEqual(metadata.get('base_group_id'), base_group_id)
+        self.assertEqual(metadata.get('group_thread_id'), payload.get('group_thread_id'))
+        self.assertEqual(metadata.get('group_members'), ['owner', 'peer-b', 'peer-c'])
+        self.assertEqual(self.p2p_manager.direct_messages[-1]['metadata'].get('group_thread_id'), payload.get('group_thread_id'))
+
     def test_group_thread_view_uses_canonical_identity_for_relayed_group_messages(self) -> None:
         canonical_group_id = compute_group_id(['owner', 'peer-b', 'peer-c'])
 
@@ -517,6 +596,49 @@ class TestMessagesUiWorkspace(unittest.TestCase):
         self.assertIn('Group check-in', body)
         self.assertIn('Relay delivered through broker', body)
         self.assertIn(f'/messages?group={canonical_group_id}', body)
+
+    def test_group_thread_merges_partial_relay_member_sets_by_group_alias(self) -> None:
+        shared_group_id = 'group:split-relay'
+        partial_group_id = compute_group_id(['owner', 'peer-b'])
+        self.conn.executemany(
+            """
+            INSERT INTO messages (
+                id, sender_id, recipient_id, content, message_type, status,
+                created_at, delivered_at, read_at, edited_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    'DM-split-b', 'peer-b', shared_group_id, 'Partial relay from Bob',
+                    'text', 'delivered', '2026-03-07T10:08:00+00:00',
+                    '2026-03-07T10:08:01+00:00', None, None,
+                    json.dumps({'group_id': shared_group_id, 'group_members': ['owner', 'peer-b']}),
+                ),
+                (
+                    'DM-split-c', 'peer-c', shared_group_id, 'Partial relay from Cara',
+                    'text', 'delivered', '2026-03-07T10:09:00+00:00',
+                    '2026-03-07T10:09:01+00:00', None, None,
+                    json.dumps({'group_id': shared_group_id, 'group_members': ['owner', 'peer-c']}),
+                ),
+            ],
+        )
+        self.conn.commit()
+
+        messages = self.message_manager.get_group_conversation('owner', partial_group_id, limit=20)
+        self.assertEqual([message.id for message in messages[-2:]], ['DM-split-b', 'DM-split-c'])
+
+        response = self.client.get(f'/ajax/messages/thread_snapshot?group={partial_group_id}')
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        self.assertIn('Partial relay from Bob', payload.get('thread_body_html') or '')
+        self.assertIn('Partial relay from Cara', payload.get('thread_body_html') or '')
+        composer_ids = sorted(
+            item.get('user_id')
+            for item in payload.get('composer_recipients') or []
+            if item.get('user_id')
+        )
+        self.assertEqual(composer_ids, ['peer-b', 'peer-c'])
 
 
 if __name__ == '__main__':

--- a/tests/test_network_connectivity_regressions.py
+++ b/tests/test_network_connectivity_regressions.py
@@ -8,7 +8,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Ensure repository root is importable when running tests directly.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -52,6 +52,14 @@ class _DummyConfig:
             e2e_private_channels=False,
             e2e_private_channels_enforce=False,
             identity_portability_enabled=False,
+        )
+        self.meshspace = types.SimpleNamespace(
+            enabled=True,
+            meshspace_id='family-mesh',
+            meshspace_id_aliases=[],
+            name='Family Mesh',
+            registry_root='',
+            network_quarantined=False,
         )
 
 
@@ -103,6 +111,9 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
                 'ws://0.0.0.0:7771',
                 'not-an-endpoint',
             ],
+            mesh_name='Research Mesh',
+            meshspace_id='research-mesh',
+            meshspace_fingerprint='A123-B456',
         )
 
         imported = import_invite(identity_manager, None, invite)
@@ -115,6 +126,36 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
             imported['endpoints'],
             ['ws://198.51.100.50:7771', 'ws://[2001:db8::10]:7771'],
         )
+        self.assertEqual(
+            identity_manager.get_peer_meshspace_hint('peer-remote').get('meshspace_id'),
+            'research-mesh',
+        )
+
+    def test_identity_manager_mesh_sync_approval_inherits_to_later_peer(self) -> None:
+        identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
+        identity_manager.initialize()
+
+        identity_manager.record_peer_meshspace_hint(
+            'peer-alpha',
+            meshspace_id='family-mesh',
+            meshspace_name='Family Mesh',
+            meshspace_fingerprint='ABCD-1234',
+            source='handshake',
+        )
+        identity_manager.record_peer_meshspace_hint(
+            'peer-beta',
+            meshspace_id='family-mesh',
+            meshspace_name='Family Mesh',
+            meshspace_fingerprint='ABCD-1234',
+            source='handshake',
+        )
+
+        identity_manager.set_peer_sync_approval('peer-alpha', 'mesh')
+
+        status = identity_manager.get_peer_sync_approval_status('peer-beta')
+        self.assertFalse(status.get('preview_only'))
+        self.assertEqual(status.get('effective_scope'), 'mesh')
+        self.assertEqual(status.get('inherited_from_peer_id'), 'peer-alpha')
 
     def test_generate_invite_accepts_explicit_external_mesh_endpoint(self) -> None:
         identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
@@ -128,6 +169,88 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(invite.endpoints[0], 'wss://demo.ngrok-free.app:443')
         self.assertTrue(any(endpoint.startswith('ws://') for endpoint in invite.endpoints[1:]))
+
+    def test_invite_encode_decode_preserves_preview_metadata(self) -> None:
+        invite = InviteCode(
+            peer_id='peer-remote',
+            ed25519_public_key_b58='ed-key',
+            x25519_public_key_b58='x-key',
+            endpoints=['wss://mesh.example:443'],
+            mesh_name='Family Mesh',
+            meshspace_id='family-mesh',
+            meshspace_fingerprint='E4A1-22B0',
+            peer_label='Kitchen Node',
+            instance_label='Mac Mini',
+            peer_icon='bi-laptop',
+            generated_at='2026-04-10T12:00:00+00:00',
+        )
+
+        decoded = InviteCode.decode(invite.encode())
+
+        self.assertEqual(decoded.peer_id, 'peer-remote')
+        self.assertEqual(decoded.endpoints, ['wss://mesh.example:443'])
+        self.assertEqual(decoded.mesh_name, 'Family Mesh')
+        self.assertEqual(decoded.meshspace_id, 'family-mesh')
+        self.assertEqual(decoded.meshspace_fingerprint, 'E4A1-22B0')
+        self.assertEqual(decoded.peer_label, 'Kitchen Node')
+        self.assertEqual(decoded.instance_label, 'Mac Mini')
+        self.assertEqual(decoded.peer_icon, 'bi-laptop')
+        self.assertEqual(decoded.generated_at, '2026-04-10T12:00:00+00:00')
+
+    def test_invite_decode_raw_json_does_not_inherit_base64_padding(self) -> None:
+        raw_json = (
+            '{"v":1,"pid":"peer-remote","epk":"ed-key","xpk":"x-key",'
+            '"ep":["wss://mesh.example:443"],"mn":"Family Mesh"}'
+        )
+
+        decoded = InviteCode.decode(raw_json)
+
+        self.assertEqual(decoded.peer_id, 'peer-remote')
+        self.assertEqual(decoded.mesh_name, 'Family Mesh')
+        self.assertEqual(decoded.endpoints, ['wss://mesh.example:443'])
+
+    def test_generate_invite_accepts_preview_metadata(self) -> None:
+        identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
+        identity_manager.initialize()
+
+        invite = generate_invite(
+            identity_manager,
+            7771,
+            mesh_name='Business Mesh',
+            meshspace_id='business-mesh',
+            peer_label='VPS Bridge',
+            instance_label='canopy-vps-1',
+            peer_icon='bi-server',
+            generated_at='2026-04-10T12:00:00+00:00',
+        )
+
+        self.assertEqual(invite.mesh_name, 'Business Mesh')
+        self.assertEqual(invite.meshspace_id, 'business-mesh')
+        self.assertRegex(invite.meshspace_fingerprint or '', r'^[0-9A-F]{4}-[0-9A-F]{4}$')
+        self.assertEqual(invite.peer_label, 'VPS Bridge')
+        self.assertEqual(invite.instance_label, 'canopy-vps-1')
+        self.assertEqual(invite.peer_icon, 'bi-server')
+        self.assertEqual(invite.generated_at, '2026-04-10T12:00:00+00:00')
+        self.assertEqual(InviteCode.decode(invite.encode()).mesh_name, 'Business Mesh')
+        self.assertEqual(InviteCode.decode(invite.encode()).meshspace_id, 'business-mesh')
+
+    def test_invite_decode_accepts_labeled_copy_block(self) -> None:
+        invite = InviteCode(
+            peer_id='peer-remote',
+            ed25519_public_key_b58='ed-key',
+            x25519_public_key_b58='x-key',
+            endpoints=['wss://mesh.example:443'],
+            mesh_name='Family Mesh',
+            meshspace_id='family-mesh',
+            meshspace_fingerprint='E4A1-22B0',
+        )
+
+        decoded = InviteCode.decode(
+            f"Canopy invite for Family Mesh [E4A1-22B0]\n{invite.encode()}\nVerify before connecting."
+        )
+
+        self.assertEqual(decoded.peer_id, 'peer-remote')
+        self.assertEqual(decoded.meshspace_id, 'family-mesh')
 
     def test_generate_invite_defaults_wss_external_endpoint_to_443(self) -> None:
         identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
@@ -300,6 +423,9 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
             captured[0][0]['endpoints'],
             ['ws://198.51.100.55:7771'],
         )
+        self.assertEqual(captured[0][0]['display_name'], 'Remote Node')
+        self.assertEqual(captured[0][0]['peer_label'], 'Remote Node')
+        self.assertEqual(captured[0][0]['instance_label'], 'Remote Node')
 
     def test_current_connection_endpoint_preserves_wss_scheme_from_endpoint_uri(self) -> None:
         manager = self._build_manager()
@@ -347,6 +473,95 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
             'peer_advertised',
             manager._introduced_peers['peer-remote'].get('endpoint_sources', []),
         )
+
+    def test_incoming_cross_mesh_peer_is_disconnected_until_approved(self) -> None:
+        manager = self._build_manager()
+        manager._event_loop = MagicMock()
+        manager._event_loop.is_closed.return_value = False
+        manager.connection_manager = types.SimpleNamespace(disconnect_peer=AsyncMock())
+        manager._remember_peer_advertised_endpoints = MagicMock()
+        manager._remember_discovered_peer_endpoints = MagicMock()
+        manager._refresh_peer_version_info = MagicMock()
+        manager._record_connection_event = MagicMock()
+
+        with patch('asyncio.run_coroutine_threadsafe') as run_threadsafe:
+            manager._on_incoming_peer_authenticated(
+                'peer-remote',
+                {
+                    'meshspace_id': 'other-mesh',
+                    'meshspace_name': 'Other Mesh',
+                    'meshspace_fingerprint': 'ABCD-1234',
+                    'advertised_endpoints': ['wss://demo.example.com:443'],
+                },
+            )
+
+        self.assertEqual(
+            manager.identity_manager.get_peer_meshspace_hint('peer-remote').get('meshspace_id'),
+            'other-mesh',
+        )
+        manager._remember_peer_advertised_endpoints.assert_not_called()
+        manager._remember_discovered_peer_endpoints.assert_not_called()
+        run_threadsafe.assert_called_once()
+        disconnect_coro = run_threadsafe.call_args.args[0]
+        self.assertTrue(asyncio.iscoroutine(disconnect_coro))
+        disconnect_coro.close()
+        self.assertEqual(run_threadsafe.call_args.args[1], manager._event_loop)
+        blocked_calls = [
+            call for call in manager._record_connection_event.call_args_list
+            if call.kwargs.get('status') == 'blocked'
+        ]
+        self.assertEqual(len(blocked_calls), 1)
+        self.assertIn('Incoming connection rejected', blocked_calls[0].kwargs.get('detail', ''))
+
+    def test_disconnected_cleanup_skips_reconnect_for_cross_mesh_peer(self) -> None:
+        manager = self._build_manager()
+        manager.identity_manager.known_peers['peer-remote'] = types.SimpleNamespace()
+        manager.identity_manager.peer_endpoints['peer-remote'] = ['ws://198.51.100.50:7771']
+        manager.identity_manager.record_peer_meshspace_hint(
+            'peer-remote',
+            meshspace_id='other-mesh',
+            meshspace_name='Other Mesh',
+            meshspace_fingerprint='DEAD-BEEF',
+            source='invite',
+        )
+        manager.message_router = None
+
+        schedule_calls: list[str] = []
+        manager._schedule_reconnect = lambda peer_id, attempt=1: schedule_calls.append(peer_id)  # type: ignore[assignment]
+
+        manager.on_peer_disconnected_cleanup('peer-remote')
+
+        self.assertEqual(schedule_calls, [])
+
+    def test_cross_mesh_status_exposes_pending_bridge_and_alias_relationships(self) -> None:
+        manager = self._build_manager()
+        manager.identity_manager.record_peer_meshspace_hint(
+            'peer-remote',
+            meshspace_id='family-mesh-legacy',
+            meshspace_name='Family Mesh',
+            source='invite',
+        )
+
+        pending = manager.get_peer_cross_mesh_status('peer-remote')
+        self.assertTrue(pending.get('requires_manual_confirmation'))
+        self.assertEqual(pending.get('mesh_relationship'), 'mesh_mismatch_pending_review')
+
+        manager.mark_peer_cross_mesh_allowed('peer-remote', True)
+        bridge = manager.get_peer_cross_mesh_status('peer-remote')
+        self.assertFalse(bridge.get('requires_manual_confirmation'))
+        self.assertEqual(bridge.get('mesh_relationship'), 'cross_mesh_bridge_allowed')
+        self.assertNotIn('family-mesh-legacy', manager.config.meshspace.meshspace_id_aliases)
+
+        manager.identity_manager.record_peer_meshspace_hint(
+            'peer-alias',
+            meshspace_id='family-mesh-old',
+            meshspace_name='Family Mesh',
+            source='invite',
+        )
+        alias_status = manager.mark_peer_meshspace_equivalent('peer-alias')
+        self.assertFalse(alias_status.get('requires_manual_confirmation'))
+        self.assertEqual(alias_status.get('mesh_relationship'), 'same_mesh_alias_confirmed')
+        self.assertIn('family-mesh-old', manager.config.meshspace.meshspace_id_aliases)
 
     def test_get_introduced_peers_marks_broker_only_when_no_direct_endpoints(self) -> None:
         manager = self._build_manager()
@@ -516,6 +731,36 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
             manager.identity_manager.peer_endpoints.get('peer-remote', []),
         )
 
+    async def test_startup_reconnect_skips_unapproved_cross_mesh_peer(self) -> None:
+        manager = self._build_manager()
+        manager.identity_manager.known_peers['peer-remote'] = types.SimpleNamespace()
+        manager.identity_manager.peer_endpoints['peer-remote'] = ['ws://198.51.100.50:7771']
+        manager.identity_manager.record_peer_meshspace_hint(
+            'peer-remote',
+            meshspace_id='business-mesh',
+            meshspace_name='Business Mesh',
+            meshspace_fingerprint='7D4A-22BE',
+            source='invite',
+        )
+        attempts: list[str] = []
+
+        async def _connect(peer_id: str, endpoint: str) -> bool:
+            attempts.append(endpoint)
+            return True
+
+        manager._connect_to_endpoint = _connect  # type: ignore[assignment]
+        manager.connection_manager = types.SimpleNamespace(
+            is_connected=lambda _peer_id: False
+        )
+
+        async def _fast_sleep(_delay: float) -> None:
+            return None
+
+        with patch('canopy.network.manager.asyncio.sleep', new=_fast_sleep):
+            await manager._reconnect_known_peers()
+
+        self.assertEqual(attempts, [])
+
     async def test_enqueue_sync_coalesces_duplicate_peer_requests(self) -> None:
         manager = self._build_manager()
         manager._sync_queue = asyncio.Queue()
@@ -540,6 +785,17 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(manager._sync_queue.qsize(), 0)
         self.assertEqual(manager._resync_after_current, {'peer-remote'})
+
+    def test_catchup_timeconstants_are_tuned_for_fast_repair(self) -> None:
+        manager = self._build_manager()
+
+        self.assertEqual(manager._STARTUP_GRACE_PERIOD, 8.0)
+        self.assertEqual(manager._POST_CONNECT_SETTLE_WINDOW_S, 1.0)
+        self.assertEqual(manager._MAX_CONCURRENT_CATCHUPS_STARTUP, 3)
+        self.assertEqual(manager._MAX_CONCURRENT_CATCHUPS_NORMAL, 6)
+        self.assertEqual(manager.PERIODIC_CATCHUP_INITIAL_DELAY, 20)
+        self.assertEqual(manager.PERIODIC_CATCHUP_INTERVAL, 90)
+        self.assertEqual(manager.PERIODIC_CATCHUP_PEER_STAGGER, 0.75)
 
     async def test_wait_for_connection_settle_sleeps_until_window_elapses(self) -> None:
         manager = self._build_manager()
@@ -598,6 +854,7 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
         manager = self._build_manager()
         manager.on_peer_connected = None
         manager._peer_is_trusted_for_content = lambda peer_id: True
+        manager.get_peer_sync_status = lambda peer_id: {'preview_only': False}
         manager._refresh_peer_version_info = lambda peer_id: None
         cancelled: list[str] = []
         calls: list[tuple[str, str]] = []

--- a/tests/test_peer_public_identity_preview.py
+++ b/tests/test_peer_public_identity_preview.py
@@ -38,7 +38,7 @@ def _make_manager(*, introduced=None, peer_display_names=None):
 
 
 class TestPeerPublicIdentityHelper(unittest.TestCase):
-    def test_announced_display_name_is_preferred_without_avatar_bytes(self) -> None:
+    def test_announced_display_name_is_preferred_without_leaking_announced_avatar(self) -> None:
         manager = _make_manager(
             introduced={
                 'peer-bob': {
@@ -61,8 +61,13 @@ class TestPeerPublicIdentityHelper(unittest.TestCase):
         self.assertIsNone(result['avatar_mime'])
         self.assertTrue(result['unverified'])
 
-    def test_identity_cache_and_fallback_stay_public_safe(self) -> None:
+    def test_identity_cache_device_profile_and_fallback_stay_public_safe(self) -> None:
         manager = _make_manager(peer_display_names={'peer-charlie': 'Charlie Hub'})
+        manager.get_peer_device_profile = lambda peer_id: {
+            'display_name': 'Charlie Device',
+            'avatar_b64': 'avatar-preview',
+            'avatar_mime': 'image/webp',
+        } if peer_id == 'peer-charlie' else None
 
         identified = manager.get_peer_public_identity('peer-charlie')
         fallback = manager.get_peer_public_identity('abcdef1234567890')
@@ -70,10 +75,41 @@ class TestPeerPublicIdentityHelper(unittest.TestCase):
         self.assertEqual(identified['node_name'], 'Charlie Hub')
         self.assertEqual(identified['source'], 'identity')
         self.assertTrue(identified['avatar_color'].startswith('hsl('))
+        self.assertEqual(identified['avatar_b64'], 'avatar-preview')
+        self.assertEqual(identified['avatar_mime'], 'image/webp')
         self.assertEqual(fallback['node_name'], 'abcdef123456')
         self.assertEqual(fallback['source'], 'fallback')
         self.assertNotIn('bio', identified)
         self.assertNotIn('email', identified)
+
+    def test_handshake_public_label_is_remembered_before_trust(self) -> None:
+        manager = _make_manager()
+
+        remembered = manager._remember_peer_public_identity_hint(
+            'peer-handshake',
+            {
+                'peer_label': 'Goose Laptop',
+                'instance_label': 'MSI Node',
+            },
+            source='handshake',
+        )
+        identity = manager.get_peer_public_identity('peer-handshake')
+
+        self.assertEqual(remembered['display_name'], 'Goose Laptop')
+        self.assertEqual(identity['node_name'], 'Goose Laptop')
+        self.assertEqual(identity['source'], 'identity')
+
+    def test_local_public_peer_hint_uses_callback_and_sanitizes_labels(self) -> None:
+        manager = _make_manager()
+        manager.get_local_peer_public_hint = lambda: {
+            'peer_label': '  Local Node\nName  ',
+            'instance_label': '  Local Instance  ',
+        }
+
+        hint = manager._local_peer_public_identity_hint()
+
+        self.assertEqual(hint['peer_label'], 'Local Node Name')
+        self.assertEqual(hint['instance_label'], 'Local Instance')
 
 
 def _mock_trust_components():

--- a/tests/test_profile_sync_metadata.py
+++ b/tests/test_profile_sync_metadata.py
@@ -406,6 +406,43 @@ class TestProfileSyncMetadata(unittest.TestCase):
         self.assertEqual(row['display_name'], 'Remote Node')
         self.assertEqual(row['avatar_b64'], 'abc123')
 
+    def test_untrusted_profile_sync_stores_device_preview_without_importing_user(self) -> None:
+        app, db_manager, _trust_manager, p2p_manager = self._make_test_app()
+
+        profile_payload = {
+            'peer_id': 'peer-preview',
+            'user_id': 'remote-user',
+            'display_name': 'Remote User',
+            'username': 'remote_user',
+            'device': {
+                'display_name': 'Preview Node',
+                'description': 'visible before trust',
+                'avatar_b64': 'preview-avatar',
+                'avatar_mime': 'image/png',
+            },
+        }
+
+        with app.app_context():
+            p2p_manager.on_profile_sync(profile_payload, 'peer-preview')
+            with db_manager.get_connection() as conn:
+                profile_row = conn.execute(
+                    "SELECT display_name, avatar_b64 FROM peer_device_profiles WHERE peer_id = ?",
+                    ('peer-preview',),
+                ).fetchone()
+                user_row = conn.execute(
+                    "SELECT id FROM users WHERE id = ?",
+                    ('remote-user',),
+                ).fetchone()
+
+        self.assertIsNotNone(profile_row)
+        self.assertEqual(profile_row['display_name'], 'Preview Node')
+        self.assertEqual(profile_row['avatar_b64'], 'preview-avatar')
+        self.assertIsNone(user_row)
+        self.assertEqual(
+            p2p_manager.identity_manager.peer_display_names.get('peer-preview'),
+            'Preview Node',
+        )
+
     def test_profile_sync_reapplies_avatar_when_hash_is_unchanged_and_avatar_file_id_is_missing(self) -> None:
         app, db_manager, trust_manager, p2p_manager = self._make_test_app()
 

--- a/tests/test_public_channel_bootstrap_sync.py
+++ b/tests/test_public_channel_bootstrap_sync.py
@@ -49,6 +49,7 @@ class _FakeP2PNetworkManager:
         self.sync_requests = []
         self.metadata_requests = []
         self.metadata_replies = []
+        self.sync_statuses = {}
         self.on_channel_sync = None
         self.on_catchup_request = None
         self.on_catchup_response = None
@@ -75,6 +76,9 @@ class _FakeP2PNetworkManager:
     def trigger_peer_sync(self, peer_id):
         self.sync_requests.append(peer_id)
         return True
+
+    def get_peer_sync_status(self, peer_id):
+        return dict(self.sync_statuses.get(peer_id) or {})
 
     def send_channel_metadata_request(self, to_peer, channel_ids, request_id=None, reason=None):
         self.metadata_requests.append(
@@ -206,6 +210,32 @@ class TestPublicChannelBootstrapSync(unittest.TestCase):
         self.assertIsNone(private_row)
         self.assertIsNotNone(local_membership)
 
+    def test_preview_only_peer_channel_sync_is_ignored_until_approved(self) -> None:
+        self._mark_peer_untrusted('peer-guest')
+        self.p2p_manager.sync_statuses['peer-guest'] = {
+            'preview_only': True,
+            'remote_meshspace_name': 'Family Mesh',
+        }
+
+        self.p2p_manager.on_channel_sync(
+            [
+                {
+                    'id': 'Cpreview001',
+                    'name': 'preview-news',
+                    'type': 'public',
+                    'desc': 'public',
+                    'privacy_mode': 'open',
+                    'origin_peer': 'peer-guest',
+                },
+            ],
+            'peer-guest',
+        )
+
+        with self.db_manager.get_connection() as conn:
+            row = conn.execute("SELECT id FROM channels WHERE id = 'Cpreview001'").fetchone()
+
+        self.assertIsNone(row)
+
     def test_untrusted_catchup_request_serves_only_public_messages(self) -> None:
         self._mark_peer_untrusted('peer-guest')
 
@@ -238,6 +268,55 @@ class TestPublicChannelBootstrapSync(unittest.TestCase):
         self.assertEqual(channel_ids, {public_channel.id})
         self.assertIsNone((payload.get('extra_data') or {}).get('circles'))
         self.assertIsNone((payload.get('extra_data') or {}).get('tasks'))
+
+    def test_preview_only_peer_catchup_response_is_ignored_until_approved(self) -> None:
+        self._mark_peer_untrusted('peer-guest')
+        self.p2p_manager.sync_statuses['peer-guest'] = {
+            'preview_only': True,
+            'remote_meshspace_name': 'Family Mesh',
+        }
+
+        self.p2p_manager.on_catchup_response(
+            [
+                {
+                    'id': 'Mpreview001',
+                    'channel_id': 'general',
+                    'channel_type': 'public',
+                    'channel_privacy_mode': 'open',
+                    'user_id': 'peer-user',
+                    'content': 'preview hello',
+                    'created_at': '2026-04-13T12:00:00+00:00',
+                }
+            ],
+            'peer-guest',
+        )
+
+        with self.db_manager.get_connection() as conn:
+            row = conn.execute("SELECT id FROM channel_messages WHERE id = 'Mpreview001'").fetchone()
+
+        self.assertIsNone(row)
+
+    def test_preview_only_peer_catchup_request_is_ignored_until_approved(self) -> None:
+        self._mark_peer_untrusted('peer-guest')
+        self.p2p_manager.sync_statuses['peer-guest'] = {
+            'preview_only': True,
+            'remote_meshspace_name': 'Family Mesh',
+        }
+
+        public_channel = self.channel_manager.create_channel(
+            name='preview-public',
+            channel_type=ChannelType.PUBLIC,
+            created_by='owner-user',
+            description='public room',
+            privacy_mode='open',
+        )
+        assert public_channel is not None
+        self.channel_manager.send_message(channel_id=public_channel.id, user_id='owner-user', content='should not leak')
+
+        with patch('asyncio.ensure_future', lambda coro: asyncio.run(coro)):
+            self.p2p_manager.on_catchup_request({}, 'peer-guest')
+
+        self.assertEqual(self.p2p_manager.sent_catchup, [])
 
     def test_trusted_catchup_request_backfills_older_public_history_when_peer_is_sparse(self) -> None:
         self.trust_manager.set_trust_score('peer-origin', 100, reason='test-trusted')

--- a/tests/test_switching_responsiveness_optimizations.py
+++ b/tests/test_switching_responsiveness_optimizations.py
@@ -1,0 +1,76 @@
+"""Regression tests for switching-path optimization helpers."""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+from flask import Flask, session
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.ui import routes as ui_routes
+
+
+class TestSwitchingResponsivenessOptimizations(unittest.TestCase):
+    def test_current_session_meshspace_attention_is_cached_per_request(self) -> None:
+        app = Flask(__name__)
+        app.secret_key = 'switching-optimizations-test'
+
+        fake_components = (
+            MagicMock(),
+            None,
+            None,
+            None,
+            MagicMock(),
+            None,
+            MagicMock(),
+            None,
+            None,
+            None,
+            MagicMock(),
+        )
+
+        with patch('canopy.ui.routes._session_is_authenticated', return_value=True), \
+             patch('canopy.ui.routes._get_app_components_any', return_value=fake_components), \
+             patch(
+                 'canopy.ui.routes.build_meshspace_notification_summary',
+                 side_effect=[
+                     {'unread_count': 3, 'mention_count': 1, 'pending_review_count': 0, 'attention_count': 4},
+                     {'unread_count': 5, 'mention_count': 2, 'pending_review_count': 1, 'attention_count': 8},
+                 ],
+             ) as summary_mock:
+            with app.test_request_context('/'):
+                session['user_id'] = 'owner'
+                first = ui_routes._current_session_meshspace_attention()
+                self.assertEqual(summary_mock.call_count, 1)
+                self.assertEqual(first['unread_count'], 3)
+
+                first['unread_count'] = 99
+                second = ui_routes._current_session_meshspace_attention()
+                self.assertEqual(summary_mock.call_count, 1)
+                self.assertEqual(second['unread_count'], 3)
+
+            with app.test_request_context('/'):
+                session['user_id'] = 'owner'
+                third = ui_routes._current_session_meshspace_attention()
+                self.assertEqual(summary_mock.call_count, 2)
+                self.assertEqual(third['unread_count'], 5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_trust_admin_identity_context.py
+++ b/tests/test_trust_admin_identity_context.py
@@ -87,6 +87,164 @@ class TestTrustPageIdentityContext(unittest.TestCase):
         payload = response.get_json() or {}
         self.assertEqual(payload.get('template'), 'trust.html')
         self.assertEqual(payload.get('user_id'), 'user-trust-42')
+        self.assertFalse(bool(payload.get('is_admin')))
+
+    def test_pending_peer_cards_expose_decision_summary_without_duplicate_noise(self) -> None:
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'user-trust-42'
+            sess['username'] = 'trustuser'
+            sess['display_name'] = 'Trust User'
+
+        comps = _mock_components()
+        p2p = comps[10]
+        p2p.identity_manager = types.SimpleNamespace(
+            known_peers={},
+            peer_display_names={},
+            peer_endpoints={},
+        )
+        p2p.get_connected_peers.return_value = ['peer-pending-1234567890']
+        p2p.get_introduced_peers.return_value = []
+        p2p.get_peer_public_identity.return_value = {
+            'node_name': 'peer-pending',
+            'source': 'fallback',
+            'unverified': True,
+        }
+        p2p.get_peer_endpoint_diagnostics.return_value = [{
+            'endpoint': 'ws://192.168.1.104:61321',
+            'sources': ['handshake'],
+            'currently_connected': True,
+            'last_failure_reason': '',
+        }]
+        p2p.get_peer_sync_status.return_value = {
+            'preview_only': True,
+            'effective_scope': '',
+            'remote_meshspace_name': 'canopy-mesh',
+        }
+        p2p.get_peer_cross_mesh_status.return_value = {
+            'requires_manual_confirmation': False,
+            'mesh_relationship': 'same_mesh_confirmed',
+        }
+
+        with patch('canopy.ui.routes._get_app_components_any', return_value=comps), \
+             patch('canopy.ui.routes.render_template') as rt:
+            rt.side_effect = lambda tpl, **ctx: jsonify({'template': tpl, **ctx})
+            response = self.client.get('/trust')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        peers = payload.get('potential_peers') or []
+        self.assertEqual(len(peers), 1)
+        peer = peers[0]
+        summary = peer.get('review_summary') or []
+        self.assertEqual([item.get('label') for item in summary], ['Connection', 'Review gate', 'Identity'])
+        self.assertEqual(summary[0].get('value'), 'Connected')
+        self.assertEqual(summary[1].get('value'), 'Sync approval required')
+        self.assertEqual(summary[2].get('value'), 'Only peer ID available')
+        self.assertNotIn('Role unknown', peer.get('attention_flags') or [])
+        self.assertNotIn('Awaiting sync approval', peer.get('attention_flags') or [])
+        self.assertEqual((payload.get('trust_overview') or {}).get('attention_count'), 1)
+
+    def test_mesh_review_pending_peer_counts_toward_attention_metric(self) -> None:
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'user-trust-42'
+            sess['username'] = 'trustuser'
+            sess['display_name'] = 'Trust User'
+
+        comps = _mock_components()
+        p2p = comps[10]
+        p2p.identity_manager = types.SimpleNamespace(
+            known_peers={},
+            peer_display_names={},
+            peer_endpoints={'peer-mesh-review-123': ['ws://192.168.1.5:7771']},
+        )
+        p2p.get_connected_peers.return_value = ['peer-mesh-review-123']
+        p2p.get_introduced_peers.return_value = []
+        p2p.get_peer_public_identity.return_value = {
+            'node_name': 'Windy Laptop',
+            'source': 'handshake',
+            'unverified': True,
+        }
+        p2p.get_peer_endpoint_diagnostics.return_value = [{
+            'endpoint': 'ws://192.168.1.5:7771',
+            'sources': ['handshake'],
+            'currently_connected': True,
+            'last_failure_reason': '',
+        }]
+        p2p.get_peer_sync_status.return_value = {
+            'preview_only': False,
+            'effective_scope': '',
+            'remote_meshspace_name': 'gold-gang',
+        }
+        p2p.get_peer_cross_mesh_status.return_value = {
+            'requires_manual_confirmation': True,
+            'mesh_relationship': 'mesh_mismatch_pending_review',
+            'cross_mesh_allowed': False,
+        }
+
+        with patch('canopy.ui.routes._get_app_components_any', return_value=comps), \
+             patch('canopy.ui.routes.render_template') as rt:
+            rt.side_effect = lambda tpl, **ctx: jsonify({'template': tpl, **ctx})
+            response = self.client.get('/trust')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertEqual((payload.get('trust_overview') or {}).get('attention_count'), 1)
+        attention = payload.get('attention_peers') or []
+        self.assertEqual(len(attention), 1)
+        self.assertEqual(attention[0].get('review_gate_label'), 'Mesh review required')
+
+    def test_preview_only_pending_peer_keeps_refresh_profile_available(self) -> None:
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'user-trust-42'
+            sess['username'] = 'trustuser'
+            sess['display_name'] = 'Trust User'
+
+        comps = _mock_components()
+        p2p = comps[10]
+        p2p.identity_manager = types.SimpleNamespace(
+            known_peers={},
+            peer_display_names={},
+            peer_endpoints={'peer-preview-1': ['ws://192.168.1.9:7771']},
+        )
+        p2p.get_connected_peers.return_value = ['peer-preview-1']
+        p2p.get_introduced_peers.return_value = []
+        p2p.get_peer_public_identity.return_value = {
+            'node_name': 'Preview Peer',
+            'source': 'handshake',
+            'unverified': True,
+        }
+        p2p.get_peer_endpoint_diagnostics.return_value = [{
+            'endpoint': 'ws://192.168.1.9:7771',
+            'sources': ['handshake'],
+            'currently_connected': True,
+            'last_failure_reason': '',
+        }]
+        p2p.get_peer_sync_status.return_value = {
+            'preview_only': True,
+            'effective_scope': '',
+            'remote_meshspace_name': 'Preview Mesh',
+        }
+        p2p.get_peer_cross_mesh_status.return_value = {
+            'requires_manual_confirmation': False,
+            'mesh_relationship': 'same_mesh_confirmed',
+        }
+        p2p.clear_peer_profile_cache = MagicMock()
+        p2p.recover_peer_profile_state = MagicMock()
+
+        with patch('canopy.ui.routes._get_app_components_any', return_value=comps), \
+             patch('canopy.ui.routes.render_template') as rt:
+            rt.side_effect = lambda tpl, **ctx: jsonify({'template': tpl, **ctx})
+            response = self.client.get('/trust')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        peers = payload.get('potential_peers') or []
+        self.assertEqual(len(peers), 1)
+        self.assertTrue(bool(peers[0].get('can_refresh_profile')))
+        self.assertTrue(bool(peers[0].get('requires_review_attention')))
 
 
 class TestAdminPageIdentityContext(unittest.TestCase):

--- a/tests/test_trust_profile_recovery.py
+++ b/tests/test_trust_profile_recovery.py
@@ -168,9 +168,11 @@ class TestTrustProfileRecovery(unittest.TestCase):
             'recovered_user_count': 2,
             'sync_triggered_for': ['peer-1'],
         }
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
 
         components = (
-            MagicMock(),   # db_manager
+            db_manager,    # db_manager
             MagicMock(),   # api_key_manager
             trust_manager, # trust_manager
             MagicMock(),   # message_manager
@@ -219,6 +221,53 @@ class TestTrustProfileRecovery(unittest.TestCase):
         )
         p2p_manager.recover_peer_profile_state.assert_called_once_with('peer-1', trigger_sync=True)
 
+    def test_trust_update_requires_instance_admin(self) -> None:
+        trust_manager = _FakeTrustManager()
+        p2p_manager = MagicMock()
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
+
+        components = (
+            db_manager,
+            MagicMock(),
+            trust_manager,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            p2p_manager,
+        )
+
+        patcher = patch('canopy.ui.routes._get_app_components_any', return_value=components)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.register_blueprint(create_ui_blueprint())
+        client = app.test_client()
+
+        token = 'csrf-trust-update-non-admin'
+        with client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'not-owner'
+            sess['username'] = 'not-owner'
+            sess['_csrf_token'] = token
+
+        response = client.post(
+            '/trust/update',
+            json={'peer_id': 'peer-1', 'tier': 'safe'},
+            headers={'X-CSRFToken': token},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.get_json() or {}
+        self.assertIn('instance admin', payload.get('error', ''))
+
     def test_trust_peer_action_refresh_profile_clears_cache_and_recovers(self) -> None:
         trust_manager = _FakeTrustManager()
         p2p_manager = MagicMock()
@@ -228,9 +277,11 @@ class TestTrustProfileRecovery(unittest.TestCase):
             'skipped_untrusted': [],
             'recovered_user_count': 1,
         }
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
 
         components = (
-            MagicMock(),
+            db_manager,
             MagicMock(),
             trust_manager,
             MagicMock(),
@@ -272,13 +323,87 @@ class TestTrustProfileRecovery(unittest.TestCase):
         p2p_manager.clear_peer_profile_cache.assert_called_once_with('peer-1')
         p2p_manager.recover_peer_profile_state.assert_called_once_with('peer-1', trigger_sync=True)
 
+    def test_trust_peer_action_refresh_profile_reconnects_preview_only_peer(self) -> None:
+        trust_manager = _FakeTrustManager()
+        p2p_manager = MagicMock()
+        p2p_manager.clear_peer_profile_cache.return_value = {'cleared_hashes': 1, 'cleared_relays': 0}
+        p2p_manager.get_peer_sync_status.return_value = {
+            'preview_only': True,
+            'remote_meshspace_name': 'Preview Mesh',
+        }
+        connection_manager = MagicMock()
+        connection_manager.get_connection.return_value = types.SimpleNamespace(endpoint_uri='ws://192.168.1.44:7771')
+        disconnect_future = MagicMock()
+        disconnect_future.result.return_value = None
+        connect_future = MagicMock()
+        connect_future.result.return_value = True
+        p2p_manager.connection_manager = connection_manager
+        p2p_manager._event_loop = types.SimpleNamespace(is_closed=lambda: False)
+        p2p_manager.identity_manager = types.SimpleNamespace(peer_endpoints={'peer-1': ['ws://192.168.1.44:7771']})
+        p2p_manager.get_peer_endpoint_diagnostics.return_value = [{
+            'endpoint': 'ws://192.168.1.44:7771',
+            'sources': ['handshake'],
+            'currently_connected': True,
+            'last_failure_reason': '',
+        }]
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
+
+        components = (
+            db_manager,
+            MagicMock(),
+            trust_manager,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            p2p_manager,
+        )
+
+        patcher = patch('canopy.ui.routes._get_app_components_any', return_value=components)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.register_blueprint(create_ui_blueprint())
+        client = app.test_client()
+
+        token = 'csrf-trust-peer-action-refresh-preview'
+        with client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'owner'
+            sess['username'] = 'owner'
+            sess['_csrf_token'] = token
+
+        with patch('asyncio.run_coroutine_threadsafe', side_effect=[disconnect_future, connect_future]):
+            response = client.post(
+                '/trust/peer_action',
+                json={'peer_id': 'peer-1', 'action': 'refresh_profile'},
+                headers={'X-CSRFToken': token},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        self.assertTrue(payload.get('preview_only'))
+        self.assertIn('fresh label and avatar hints', payload.get('message', ''))
+        p2p_manager.clear_peer_profile_cache.assert_called_once_with('peer-1')
+        p2p_manager.recover_peer_profile_state.assert_not_called()
+
     def test_trust_peer_action_sync_now_triggers_peer_sync(self) -> None:
         trust_manager = _FakeTrustManager()
         p2p_manager = MagicMock()
         p2p_manager.trigger_peer_sync.return_value = True
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
 
         components = (
-            MagicMock(),
+            db_manager,
             MagicMock(),
             trust_manager,
             MagicMock(),
@@ -318,6 +443,168 @@ class TestTrustProfileRecovery(unittest.TestCase):
         payload = response.get_json() or {}
         self.assertTrue(payload.get('success'))
         p2p_manager.trigger_peer_sync.assert_called_once_with('peer-1')
+
+    def test_trust_peer_action_allow_sync_approves_peer_and_triggers_bootstrap(self) -> None:
+        trust_manager = _FakeTrustManager()
+        p2p_manager = MagicMock()
+        p2p_manager.get_peer_sync_status.return_value = {
+            'preview_only': True,
+            'remote_meshspace_name': 'Family Mesh',
+        }
+        p2p_manager.approve_peer_sync.return_value = {
+            'preview_only': False,
+            'effective_scope': 'peer',
+            'remote_meshspace_name': 'Family Mesh',
+        }
+        p2p_manager.trigger_peer_sync.return_value = True
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
+
+        components = (
+            db_manager,
+            MagicMock(),
+            trust_manager,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            p2p_manager,
+        )
+
+        patcher = patch('canopy.ui.routes._get_app_components_any', return_value=components)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.register_blueprint(create_ui_blueprint())
+        client = app.test_client()
+
+        token = 'csrf-trust-peer-action-allow-sync'
+        with client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'owner'
+            sess['username'] = 'owner'
+            sess['_csrf_token'] = token
+
+        response = client.post(
+            '/trust/peer_action',
+            json={'peer_id': 'peer-1', 'action': 'allow_sync'},
+            headers={'X-CSRFToken': token},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('success'))
+        p2p_manager.approve_peer_sync.assert_called_once_with('peer-1', scope='peer')
+        p2p_manager.trigger_peer_sync.assert_called_once_with('peer-1')
+
+    def test_trust_peer_action_allow_sync_requires_instance_admin(self) -> None:
+        trust_manager = _FakeTrustManager()
+        p2p_manager = MagicMock()
+        p2p_manager.get_peer_sync_status.return_value = {'preview_only': True}
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
+
+        components = (
+            db_manager,
+            MagicMock(),
+            trust_manager,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            p2p_manager,
+        )
+
+        patcher = patch('canopy.ui.routes._get_app_components_any', return_value=components)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.register_blueprint(create_ui_blueprint())
+        client = app.test_client()
+
+        token = 'csrf-trust-peer-action-allow-sync-non-admin'
+        with client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'not-owner'
+            sess['username'] = 'not-owner'
+            sess['_csrf_token'] = token
+
+        response = client.post(
+            '/trust/peer_action',
+            json={'peer_id': 'peer-1', 'action': 'allow_sync'},
+            headers={'X-CSRFToken': token},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.get_json() or {}
+        self.assertIn('instance admin', payload.get('error', ''))
+        p2p_manager.approve_peer_sync.assert_not_called()
+
+    def test_trust_peer_action_allow_mesh_sync_requires_mesh_identity(self) -> None:
+        trust_manager = _FakeTrustManager()
+        p2p_manager = MagicMock()
+        p2p_manager.get_peer_sync_status.return_value = {
+            'preview_only': True,
+            'remote_meshspace_name': '',
+            'remote_meshspace_id': '',
+            'remote_meshspace_fingerprint': '',
+        }
+        db_manager = MagicMock()
+        db_manager.get_instance_owner_user_id.return_value = 'owner'
+
+        components = (
+            db_manager,
+            MagicMock(),
+            trust_manager,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            p2p_manager,
+        )
+
+        patcher = patch('canopy.ui.routes._get_app_components_any', return_value=components)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.secret_key = 'test-secret'
+        app.register_blueprint(create_ui_blueprint())
+        client = app.test_client()
+
+        token = 'csrf-trust-peer-action-allow-mesh'
+        with client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'owner'
+            sess['username'] = 'owner'
+            sess['_csrf_token'] = token
+
+        response = client.post(
+            '/trust/peer_action',
+            json={'peer_id': 'peer-1', 'action': 'allow_mesh_sync'},
+            headers={'X-CSRFToken': token},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.get_json() or {}
+        self.assertIn('stable meshspace identity', payload.get('error', ''))
+        p2p_manager.approve_peer_sync.assert_not_called()
 
     def test_trust_view_marks_introduced_peer_with_no_endpoints_for_attention(self) -> None:
         trust_manager = _FakeTrustManager()

--- a/tests/test_ui_polish_regressions.py
+++ b/tests/test_ui_polish_regressions.py
@@ -41,6 +41,14 @@ class TestUiPolishRegressions(unittest.TestCase):
         self.assertIn("Repost</span>", feed)
         self.assertIn('aria-label="More post actions"', feed)
 
+    def test_feed_mobile_uses_collapsible_composer(self) -> None:
+        feed = (ROOT / "canopy" / "ui" / "templates" / "feed.html").read_text(encoding="utf-8")
+        self.assertIn('id="feed-mobile-composer-toggle"', feed)
+        self.assertIn('#post-composer.mobile-collapsed .card-body', feed)
+        self.assertIn("function syncFeedComposerLayout(options = {})", feed)
+        self.assertIn("function toggleFeedComposer(forceOpen)", feed)
+        self.assertIn("syncFeedComposerLayout({ forceExpand: true });", feed)
+
     def test_dm_sidebar_empty_states_have_icons(self) -> None:
         sidebar = (ROOT / "canopy" / "ui" / "templates" / "_messages_sidebar_sections.html").read_text(encoding="utf-8")
         self.assertIn("bi bi-chat-dots", sidebar)
@@ -81,6 +89,7 @@ class TestUiPolishRegressions(unittest.TestCase):
         self.assertIn('id="channel-header-search-toggle"', channels)
         self.assertIn(".channel-header-search.mobile-open", channels)
         self.assertIn("function toggleChannelHeaderSearch(forceOpen)", channels)
+        self.assertIn("return window.innerWidth <= 767;", channels)
         self.assertIn('id="channel-composer-more-toggle"', channels)
         self.assertIn("More compose tools", channels)
         self.assertIn(".channel-composer-advanced-tool", channels)
@@ -119,6 +128,26 @@ class TestUiPolishRegressions(unittest.TestCase):
     def test_profile_avatar_image_has_meaningful_alt_text(self) -> None:
         profile = (ROOT / "canopy" / "ui" / "templates" / "profile.html").read_text(encoding="utf-8")
         self.assertIn("Profile picture of", profile)
+
+    def test_dm_backdrop_has_aria_hidden_initially(self) -> None:
+        messages = (ROOT / "canopy" / "ui" / "templates" / "messages.html").read_text(encoding="utf-8")
+        self.assertIn('class="dm-mobile-sidebar-backdrop"', messages)
+        self.assertIn('aria-hidden="true"', messages)
+
+    def test_dm_mobile_sidebar_updates_backdrop_aria_hidden(self) -> None:
+        messages = (ROOT / "canopy" / "ui" / "templates" / "messages.html").read_text(encoding="utf-8")
+        self.assertIn("backdrop.setAttribute('aria-hidden', isSidebarOpen ? 'false' : 'true');", messages)
+        fn_start = messages.index("function toggleDmMobileSidebar(forceOpen)")
+        fn_end = messages.index("\n    function ", fn_start)
+        fn_body = messages[fn_start:fn_end]
+        self.assertIn("button.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');", fn_body)
+        self.assertIn("backdrop.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');", fn_body)
+
+    def test_feed_composer_toggle_has_initial_aria_binding(self) -> None:
+        feed = (ROOT / "canopy" / "ui" / "templates" / "feed.html").read_text(encoding="utf-8")
+        self.assertIn('id="feed-mobile-composer-toggle"', feed)
+        self.assertIn('aria-expanded="false"', feed)
+        self.assertIn('aria-controls="post-composer"', feed)
 
 
 if __name__ == "__main__":

--- a/tests/test_version_negotiation.py
+++ b/tests/test_version_negotiation.py
@@ -37,6 +37,8 @@ class _FakeLocalIdentity:
 class _FakeIdentityManager:
     def __init__(self) -> None:
         self.local_identity = _FakeLocalIdentity()
+        self.peer_display_names = {}
+        self.saved = False
 
     def export_public_identity(self):
         return {
@@ -47,8 +49,13 @@ class _FakeIdentityManager:
     def verify_peer_id(self, _peer_id, _pubkey):
         return True
 
-    def add_known_peer(self, _peer):
+    def add_known_peer(self, peer, endpoints=None, display_name=None):
+        if display_name:
+            self.peer_display_names[peer.peer_id] = display_name
         return None
+
+    def _save_known_peers(self):
+        self.saved = True
 
 
 class _FakePeerIdentity:
@@ -73,7 +80,13 @@ class _FakeWebSocket:
         return self._response
 
 
-def _handshake_ack(peer_id='peer-remote', canopy_version='0.4.30', protocol_version=1):
+def _handshake_ack(
+    peer_id='peer-remote',
+    canopy_version='0.4.30',
+    protocol_version=1,
+    peer_label='',
+    instance_label='',
+):
     return {
         'type': 'handshake_ack',
         'peer_id': peer_id,
@@ -82,6 +95,8 @@ def _handshake_ack(peer_id='peer-remote', canopy_version='0.4.30', protocol_vers
         'version': '0.1.0',
         'canopy_version': canopy_version,
         'protocol_version': protocol_version,
+        'peer_label': peer_label,
+        'instance_label': instance_label,
         'capabilities': ['chat', 'files'],
         'timestamp': 1700000000.0,
         'signature': 'bb' * 64,
@@ -115,6 +130,39 @@ class TestVersionNegotiation(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(connection.canopy_version, '0.4.30')
         self.assertEqual(websocket.sent[0].get('protocol_version'), 1)
         self.assertEqual(websocket.sent[0].get('canopy_version'), '0.4.30')
+
+    async def test_handshake_exchanges_public_peer_labels_before_trust(self):
+        identity_manager = _FakeIdentityManager()
+        manager = ConnectionManager(
+            local_peer_id='peer-local',
+            identity_manager=identity_manager,
+            canopy_version='0.6.20',
+            protocol_version=1,
+            peer_label='Local Kitchen Node',
+            instance_label='Kitchen Mac Mini',
+        )
+        websocket = _FakeWebSocket(_handshake_ack(
+            protocol_version=1,
+            peer_label='Remote Goose Node',
+            instance_label='Goose Laptop',
+        ))
+        connection = PeerConnection(
+            peer_id='peer-remote',
+            address='127.0.0.1',
+            port=7771,
+            state=ConnectionState.HANDSHAKING,
+            websocket=websocket,
+        )
+
+        with patch('canopy.network.identity.PeerIdentity', _FakePeerIdentity):
+            ok = await manager._perform_handshake(connection)
+
+        self.assertTrue(ok)
+        self.assertEqual(websocket.sent[0].get('peer_label'), 'Local Kitchen Node')
+        self.assertEqual(websocket.sent[0].get('instance_label'), 'Kitchen Mac Mini')
+        self.assertEqual(connection.peer_label, 'Remote Goose Node')
+        self.assertEqual(connection.instance_label, 'Goose Laptop')
+        self.assertEqual(identity_manager.peer_display_names.get('peer-remote'), 'Remote Goose Node')
 
     async def test_canopy_version_diff_with_same_protocol_is_allowed(self):
         identity_manager = _FakeIdentityManager()

--- a/tests/test_workspace_event_handler_paths.py
+++ b/tests/test_workspace_event_handler_paths.py
@@ -1,6 +1,7 @@
 """End-to-end handler-path regressions for workspace event Patch 1."""
 
 import os
+import json
 import sqlite3
 import sys
 import tempfile
@@ -222,6 +223,39 @@ class TestWorkspaceEventHandlerPaths(unittest.TestCase):
             self.assertEqual([row['id'] for row in messages], ['DM-handler-1'])
             self.assertEqual(len(event_rows), 1)
             self.assertEqual(event_rows[0]['message_id'], 'DM-handler-1')
+
+    def test_real_inbound_group_dm_repairs_partial_member_list_for_local_recipient(self) -> None:
+        self._mark_peer_trusted('peer-remote')
+        with self.app.app_context():
+            self.p2p_manager.on_direct_message(
+                sender_id='remote-user',
+                recipient_id='agent-local',
+                content='partial group hello',
+                message_id='DM-handler-group-partial',
+                timestamp='2026-03-09T12:00:30+00:00',
+                display_name='Remote User',
+                metadata={
+                    'group_id': 'group:split-relay',
+                    'group_members': ['remote-user', 'other-remote'],
+                    'is_group': True,
+                },
+                update_only=False,
+                edited_at=None,
+                from_peer='peer-remote',
+            )
+            with self.db_manager.get_connection() as conn:
+                row = conn.execute(
+                    "SELECT recipient_id, metadata FROM messages WHERE id = ?",
+                    ('DM-handler-group-partial',),
+                ).fetchone()
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row['recipient_id'], 'group:split-relay')
+        metadata = json.loads(row['metadata'])
+        self.assertEqual(
+            metadata.get('group_members'),
+            ['agent-local', 'other-remote', 'remote-user'],
+        )
 
     def test_real_inbound_dm_delete_emits_one_deleted_event_and_cleans_inbox(self) -> None:
         self._mark_peer_trusted('peer-remote')


### PR DESCRIPTION
## Summary
- curate the public Canopy repo up to the current 0.6.27 release surface using the public-safe local file set
- include the connection review, preview-only Trust workflow, meshspace/runtime, UI, and regression-test updates that differ from public main
- keep internal dev-mirror tooling and internal-only docs out of the public promotion

## Test plan
- rely on public repo CI for the curated 0.6.27 delta
- confirm version/docs alignment and public-safe file exclusions before merge