### PR TITLE
feat: ship 0.6.32 transport and remote mesh review updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.6.32] - 2026-04-17
+
+### Changed
+- **Introduced peers from other meshspaces now require an explicit Connect-page review step instead of blending into routine contact introductions** - introduced cross-mesh peers are separated into a dedicated remote-meshspace section, blocked from the quick-connect path unless the operator explicitly confirms the bridge, and require instance-admin approval before the connection can proceed.
+
+## [0.6.31] - 2026-04-17
+
+### Changed
+- **Sidebar connected peers now deep-link into the right review surfaces instead of behaving like inert labels** - clicking an individual connected peer in the left rail now opens the matching Trust Network card, the header peer-count link now jumps to the Connected Peers section on Connect, and both destinations add target highlighting so operators land on the right peer state immediately.
+- **Notification bell filters now support multi-toggle adjustment without collapsing the menu after every click** - Mentions, Inbox, DMs, Channels, Feed, and Reset now keep the dropdown open while the user refines filters, without changing normal notification-item navigation or clear behavior.
+
+## [0.6.30] - 2026-04-16
+
+### Changed
+- **Admins can now configure secure mesh transport from the UI instead of hand-editing shell environment** - the Admin page adds a Transport Security panel for self-signed local TLS, provided certificate paths, external TLS terminator declaration, restart-required state, and secure-invite readiness so VPS and tunnel setup is much easier to understand and operate.
+- **Generated invites and handshake advertisements now stay honest while transport changes are pending restart** - saving a future TLS mode no longer causes Canopy to advertise `wss://` listener endpoints before the running mesh listener has actually restarted into secure mode, and stale external endpoint intent is cleared when operators switch back to non-external modes.
+
+## [0.6.29] - 2026-04-16
+
+### Changed
+- **Explicit public WSS invites now stay clearer from generation through live transport state** - public `wss://` invites no longer co-advertise same-host plain `ws://` fallback unless the operator explicitly opts in, active peer rows/diagnostics now distinguish the current live transport from other known endpoints, and operator-selected public endpoint intent no longer lingers after invite generation returns to the default/local path.
+
+## [0.6.28] - 2026-04-16
+
+### Changed
+- **WSS invite handling is now safer and clearer for VPS/public operators** - explicit `wss://` peer endpoints no longer silently downgrade to `ws://` when TLS fails, Connect now shows transport-security posture and secure-vs-plain advertised endpoint counts, and the docs explain how Canopy currently handles TLS, reverse proxies, self-signed certificates, and strict verified-WSS mode.
+
 ## [0.6.27] - 2026-04-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.6.27-blue" alt="Version 0.6.27">
+  <img src="https://img.shields.io/badge/version-0.6.32-blue" alt="Version 0.6.32">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="Apache 2.0 License">
   <img src="https://img.shields.io/badge/encryption-ChaCha20--Poly1305-blueviolet" alt="ChaCha20-Poly1305">
@@ -102,6 +102,9 @@ Recent end-user improvements reflected in the app and docs:
 - **Preview-only review before sync** — first contact can connect for review while channels and history stay paused until an admin explicitly approves peer or mesh sync from the Trust page.
 - **Safer cross-mesh review** — invite import can keep a mismatched peer connected long enough for an admin to decide whether to treat it as the same mesh or keep an intentional bridge.
 - **Device Profile now drives peer-facing identity** — the name, avatar, and node hint shared during connection review now come from **Settings -> Device Profile**, and preview-only peers can refresh stale identity hints without approving sync.
+- **Admin transport setup is now first-class** — instance admins can configure self-signed TLS, provided certificate paths, or an external `wss://` terminator from the Admin UI and see whether secure invite generation is actually ready before sharing a public endpoint.
+- **Sidebar peer navigation is more useful** — connected peers in the left rail now open the matching Trust card, and the header peer count jumps directly to the Connected Peers section on Connect instead of dropping you at a generic page top.
+- **Remote meshspace introductions are now visually separated on Connect** — peers introduced through your contacts but advertising a different meshspace now appear in an explicit review section and require an intentional admin-approved bridge action instead of looking like routine same-mesh introductions.
 - **Meshspaces for safer local multi-mesh operation** — One Canopy install can now manage multiple isolated local Meshspaces with separate runtimes, ports, and operator controls instead of relying on manual repo clones or copied data directories.
 - **Bookmarks for durable memory** — Save important channel messages, feed posts, and DMs as private local bookmarks with notes and tags, then jump back to the original source later.
 - **Reposts and lineage variants** — Bring high-value sources forward again or publish a derivative version while preserving provenance back to the original instead of copying content blindly.
@@ -361,7 +364,7 @@ Agent account first-run guide: [docs/AGENT_ONBOARDING.md](docs/AGENT_ONBOARDING.
 Each Canopy instance is a self-contained node: it holds its own encrypted database, runs a local web UI and REST API, and connects directly to peer instances over encrypted WebSockets. There is no central server because the network is the peers themselves.
 
 - Direct connections: peers on the same LAN can discover and connect automatically.
-- Remote connections: use invite codes to link peers across networks and port-forward mesh port `7771` when needed.
+- Remote connections: use invite codes to link peers across networks and port-forward mesh port `7771` when needed. Public VPS/tunnel endpoints can be advertised as `wss://...`; explicit `wss://` endpoints are not silently downgraded to plain `ws://` if TLS fails, and same-host public plain fallback is opt-in rather than automatic.
 - Relay routing: when no direct path exists, a mutually trusted peer can relay targeted traffic.
 - Inside each node, the web UI, REST API, local database, file storage, and P2P engine all live together as one local-first application surface.
 
@@ -517,6 +520,7 @@ Full reference: [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
 | A peer shows as preview-only after first connect | Transport is up, but sync/history are intentionally paused until review is complete. | Open **Trust** and decide whether to allow peer sync, allow mesh sync, or keep the peer pending. |
 | Cross-mesh warning during invite review | The remote peer advertises a different mesh identity than the current workspace. | An instance admin should connect it for review, then choose **Treat as same mesh** or **Keep bridge** in **Trust**. |
 | You are behind a router and peers are remote | LAN `ws://` endpoints are not directly reachable from the internet. | Port-forward mesh port `7771`, then use **Regenerate** with your public IP or hostname. |
+| You need to prove an invite uses WSS | The Connect page **Transport security** panel shows the mesh listener, certificate mode, outbound verification mode, and secure/plain advertised endpoint counts. | Use a full `wss://...` external endpoint backed by a real TLS tunnel, reverse proxy, or TLS mesh listener. |
 | "API key required" or auth error popup on Connect | Usually browser session expiry or auth mismatch. | Reload, sign in again. For scripts and CLI, include `X-API-Key`. |
 | Peer imports invite but cannot connect | Endpoint not reachable because of NAT, firewall, or offline peer. | Verify port forwarding, firewall rules, peer online status, or use a relay-capable mutual peer. |
 

--- a/canopy/__init__.py
+++ b/canopy/__init__.py
@@ -8,7 +8,7 @@ Project: Canopy - Local Mesh Communication
 License: Apache 2.0
 """
 
-__version__ = "0.6.27"
+__version__ = "0.6.32"
 __protocol_version__ = 1
 __author__ = "Canopy Contributors"
 __license__ = "Apache-2.0"

--- a/canopy/api/routes.py
+++ b/canopy/api/routes.py
@@ -239,6 +239,69 @@ def _current_local_peer_hint_payload(
     )
 
 
+def _transport_security_status(
+    p2p_manager: Any,
+    advertised_endpoints: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Return API-safe transport security diagnostics for invite responses."""
+    from ..network.invite import classify_invite_endpoints
+
+    endpoints = [
+        str(endpoint or '').strip()
+        for endpoint in (advertised_endpoints or [])
+        if str(endpoint or '').strip()
+    ]
+    classification = classify_invite_endpoints(endpoints)
+    conn_mgr = getattr(p2p_manager, 'connection_manager', None) if p2p_manager else None
+    if conn_mgr and hasattr(conn_mgr, 'get_transport_security_status'):
+        try:
+            status = dict(conn_mgr.get_transport_security_status(advertised_endpoints=endpoints) or {})
+            status.update(classification)
+            decorator = getattr(p2p_manager, '_decorate_transport_security_status', None) if p2p_manager else None
+            if callable(decorator) and getattr(decorator, '__self__', None) is p2p_manager:
+                status = dict(decorator(status) or status)
+            return status
+        except Exception:
+            logger.debug("Could not load connection-manager transport security status", exc_info=True)
+    if p2p_manager and hasattr(p2p_manager, 'get_transport_security_status'):
+        try:
+            status = dict(p2p_manager.get_transport_security_status() or {})
+            if endpoints:
+                status['advertised_endpoints'] = endpoints
+                status['advertised_secure_count'] = sum(1 for ep in endpoints if ep.lower().startswith('wss://'))
+                status['advertised_plain_count'] = sum(1 for ep in endpoints if ep.lower().startswith('ws://'))
+            status.update(classification)
+            return status
+        except Exception:
+            logger.debug("Could not load P2P transport security status", exc_info=True)
+    secure_count = sum(1 for ep in endpoints if ep.lower().startswith('wss://'))
+    plain_count = sum(1 for ep in endpoints if ep.lower().startswith('ws://'))
+    return {
+        'mesh_scheme': 'ws',
+        'tls_enabled': False,
+        'transport_label': 'Plain WebSocket (ws)',
+        'listener_endpoint': '',
+        'tls_cert_mode': 'disabled',
+        'tls_cert_path_present': False,
+        'tls_key_path_present': False,
+        'client_verification_mode': 'permissive',
+        'advertised_endpoints': endpoints,
+        'advertised_secure_count': secure_count,
+        'advertised_plain_count': plain_count,
+        'explicit_wss_downgrade_allowed': False,
+        'warnings': ['P2P transport security status is unavailable.'],
+        **classification,
+    }
+
+
+def _live_invite_endpoint_scheme(config: Any, p2p_manager: Any) -> str:
+    """Return the current listener scheme for truthful invite generation."""
+    conn_mgr = getattr(p2p_manager, 'connection_manager', None) if p2p_manager else None
+    if conn_mgr is not None:
+        return 'wss' if bool(getattr(conn_mgr, 'enable_tls', False)) else 'ws'
+    return 'wss' if bool(getattr(getattr(config, 'network', None), 'enable_tls', False)) else 'ws'
+
+
 def _public_mesh_identity_payload() -> dict[str, Any]:
     """Return a shell-safe public identity payload for invite preview enrichment."""
     from ..core.device import get_device_label, get_device_profile
@@ -3172,11 +3235,22 @@ def create_api_blueprint() -> Blueprint:
             connected_peer_details = []
             for peer_id in connected_peers:
                 ver = peer_versions.get(peer_id, {}) if isinstance(peer_versions, dict) else {}
+                active_transport = {}
+                get_active_transport = getattr(p2p_manager, 'get_peer_active_transport', None)
+                if callable(get_active_transport):
+                    try:
+                        active_transport = dict(get_active_transport(peer_id) or {})
+                    except Exception:
+                        active_transport = {}
                 connected_peer_details.append({
                     'peer_id': peer_id,
                     'canopy_version': ver.get('canopy_version'),
                     'protocol_version': ver.get('protocol_version'),
                     'compatible_protocol': ver.get('compatible_protocol'),
+                    'active_endpoint': active_transport.get('active_endpoint', ''),
+                    'active_transport': active_transport.get('active_transport', ''),
+                    'active_transport_label': active_transport.get('active_transport_label', ''),
+                    'active_transport_secure': bool(active_transport.get('active_transport_secure')),
                 })
             
             return jsonify({
@@ -3206,7 +3280,11 @@ def create_api_blueprint() -> Blueprint:
             public_host = request.args.get('public_host')
             public_port = request.args.get('public_port', type=int)
             external_endpoint = request.args.get('external_endpoint', type=str)
+            allow_plain_fallback = _as_bool(request.args.get('allow_plain_fallback'))
             mesh_port = config.network.mesh_port if config else 7771
+            configured_external_endpoint = str(getattr(getattr(config, 'network', None), 'external_tls_endpoint', '') or '').strip()
+            effective_external_endpoint = str(external_endpoint or configured_external_endpoint or '').strip() or None
+            endpoint_scheme = _live_invite_endpoint_scheme(config, p2p_manager)
             mesh_hint = _current_runtime_mesh_hint_payload()
             mesh_name = str(mesh_hint.get('meshspace_name') or '').strip()
             meshspace_id = str(mesh_hint.get('meshspace_id') or '').strip()
@@ -3232,7 +3310,9 @@ def create_api_blueprint() -> Blueprint:
                 mesh_port,
                 public_host=public_host,
                 public_port=public_port,
-                external_endpoint=external_endpoint,
+                external_endpoint=effective_external_endpoint,
+                allow_plain_fallback=allow_plain_fallback,
+                endpoint_scheme=endpoint_scheme,
                 mesh_name=mesh_name or None,
                 meshspace_id=meshspace_id or None,
                 meshspace_id_aliases=list(mesh_hint.get('meshspace_id_aliases') or []) or None,
@@ -3242,10 +3322,30 @@ def create_api_blueprint() -> Blueprint:
                 peer_icon=peer_icon or None,
                 generated_at=datetime.now(timezone.utc).isoformat(),
             )
+            transport_security = _transport_security_status(
+                p2p_manager,
+                list(invite.endpoints or []),
+            )
+            remember_operator = getattr(p2p_manager, 'remember_operator_advertised_endpoint', None)
+            if callable(remember_operator):
+                try:
+                    remember_operator(
+                        external_endpoint=effective_external_endpoint,
+                        public_host=public_host,
+                        public_port=public_port,
+                        allow_plain_fallback=allow_plain_fallback,
+                    )
+                except Exception:
+                    logger.debug("Could not remember operator advertised endpoint", exc_info=True)
             return jsonify({
                 'invite_code': invite.encode(),
                 'peer_id': invite.peer_id,
                 'endpoints': invite.endpoints,
+                'transport_security': transport_security,
+                'recommended_endpoint': transport_security.get('recommended_endpoint'),
+                'recommended_transport': transport_security.get('recommended_transport'),
+                'invite_policy': transport_security.get('invite_policy'),
+                'invite_policy_label': transport_security.get('invite_policy_label'),
                 'meshspace_id': invite.meshspace_id,
                 'meshspace_name': invite.mesh_name,
                 'meshspace_fingerprint': invite.meshspace_fingerprint,
@@ -3402,6 +3502,7 @@ def create_api_blueprint() -> Blueprint:
 
             # Attempt to connect to each endpoint
             connected = False
+            endpoint_failures: list[dict[str, Any]] = []
             if p2p_manager.connection_manager:
                 for ep in list(getattr(invite, 'endpoints', []) or []):
                     try:
@@ -3433,7 +3534,11 @@ def create_api_blueprint() -> Blueprint:
                                 )
                             else:
                                 connect_coro = p2p_manager.connection_manager.connect_to_peer(
-                                    invite.peer_id, host, port, scheme=scheme
+                                    invite.peer_id,
+                                    host,
+                                    port,
+                                    scheme=scheme,
+                                    scheme_explicit=str(ep or '').strip().lower().startswith('wss://'),
                                 )
                             future = asyncio.run_coroutine_threadsafe(
                                 connect_coro,
@@ -3482,17 +3587,41 @@ def create_api_blueprint() -> Blueprint:
                                 except Exception as sync_err:
                                     logger.warning(f"Post-connect sync failed for {invite.peer_id}: {sync_err}")
                             break
+                        failure = None
+                        if hasattr(p2p_manager.connection_manager, 'get_last_connect_failure'):
+                            try:
+                                failure = p2p_manager.connection_manager.get_last_connect_failure(
+                                    invite.peer_id,
+                                    host,
+                                    port,
+                                )
+                            except Exception:
+                                failure = None
+                        if isinstance(failure, dict) and failure:
+                            endpoint_failures.append({
+                                'endpoint': ep,
+                                'reason': failure.get('reason'),
+                                'detail': failure.get('detail'),
+                            })
                     except Exception as ce:
                         logger.warning(f"Connection to {ep} failed: {ce}")
                         continue
 
             if not connected:
                 result['status'] = 'imported_not_connected'
+                if endpoint_failures:
+                    result['endpoint_failures'] = endpoint_failures[:5]
                 if not list(result.get('endpoints') or []):
                     result['diagnostic_code'] = 'invite_has_no_usable_endpoints'
                     result['message'] = (
                         'Peer registered, but the invite did not contain any usable direct endpoints. '
                         'Ask the remote peer to regenerate the invite with a public or tunnel endpoint.'
+                    )
+                elif any(item.get('reason') == 'wss_downgrade_blocked' for item in endpoint_failures):
+                    result['diagnostic_code'] = 'secure_transport_failed'
+                    result['message'] = (
+                        'Peer registered, but an explicit wss:// endpoint failed TLS connection and Canopy refused to downgrade it to plain ws://. '
+                        'Confirm that the remote VPS, tunnel, or reverse proxy is actually accepting secure WebSocket traffic at the advertised endpoint.'
                     )
                 else:
                     result['diagnostic_code'] = 'direct_connect_failed'
@@ -3564,7 +3693,7 @@ def create_api_blueprint() -> Blueprint:
     def connect_introduced_peer():
         """Connect to a peer that was introduced by a contact."""
         import asyncio
-        *_, p2p_manager = _get_app_components_any(current_app)
+        db_manager, *_, p2p_manager = _get_app_components_any(current_app)
         if not p2p_manager or not p2p_manager.connection_manager:
             return jsonify({'error': 'P2P not running'}), 500
 
@@ -3577,11 +3706,48 @@ def create_api_blueprint() -> Blueprint:
             or data.get('force_failover')
             or data.get('skip_direct')
         )
+        allow_cross_mesh = _as_bool(
+            data.get('allow_cross_mesh')
+            or data.get('explicit_meshspace_connect')
+        )
 
         # Look up introduced peer info
         intro = p2p_manager._introduced_peers.get(peer_id)
         if not intro:
             return jsonify({'error': 'Peer not found in introduced list'}), 404
+
+        meshspace_status = {}
+        get_intro_mesh_status = getattr(p2p_manager, 'get_introduced_peer_meshspace_status', None)
+        if callable(get_intro_mesh_status):
+            try:
+                meshspace_status = dict(get_intro_mesh_status(peer_id) or {})
+            except Exception:
+                meshspace_status = {}
+        if meshspace_status.get('requires_explicit_meshspace_connect') and not allow_cross_mesh:
+            return jsonify({
+                'status': 'confirmation_required',
+                'error': 'Remote meshspace candidate requires explicit confirmation',
+                'diagnostic_code': 'introduced_cross_mesh_confirmation_required',
+                'message': (
+                    'This introduced peer advertises a different meshspace. '
+                    'Use the explicit remote-meshspace action only if the bridge is intentional.'
+                ),
+                'cross_mesh': meshspace_status,
+            }), 409
+        if allow_cross_mesh and not _request_is_instance_admin(db_manager):
+            return jsonify({
+                'error': 'Instance admin required',
+                'diagnostic_code': 'cross_mesh_admin_required',
+                'message': (
+                    'Only the instance admin can approve an introduced cross-mesh connection from this workspace.'
+                ),
+                'cross_mesh': meshspace_status,
+            }), 403
+        if allow_cross_mesh and hasattr(p2p_manager, 'mark_peer_cross_mesh_allowed'):
+            try:
+                p2p_manager.mark_peer_cross_mesh_allowed(peer_id, True)
+            except Exception:
+                logger.debug("Could not mark introduced peer as cross-mesh allowed", exc_info=True)
 
         ev_loop = p2p_manager._event_loop
         if not ev_loop or ev_loop.is_closed():
@@ -3671,10 +3837,20 @@ def create_api_blueprint() -> Blueprint:
                     host, port, scheme = parsed
                     connect_to_endpoint = getattr(type(p2p_manager), '_connect_to_endpoint', None)
                     if callable(connect_to_endpoint):
-                        connect_coro = connect_to_endpoint(p2p_manager, peer_id, ep)
+                        connect_coro = connect_to_endpoint(
+                            p2p_manager,
+                            peer_id,
+                            ep,
+                            allow_cross_mesh=allow_cross_mesh,
+                        )
                     else:
                         connect_coro = p2p_manager.connection_manager.connect_to_peer(
-                            peer_id, host, port, scheme=scheme)
+                            peer_id,
+                            host,
+                            port,
+                            scheme=scheme,
+                            scheme_explicit=str(ep or '').strip().lower().startswith('wss://'),
+                        )
                     future = asyncio.run_coroutine_threadsafe(
                         connect_coro,
                         ev_loop
@@ -3759,6 +3935,7 @@ def create_api_blueprint() -> Blueprint:
                     broker_sent = p2p_manager.send_broker_request(
                         target_peer_id=peer_id,
                         via_peer_id=broker_peer,
+                        allow_cross_mesh=allow_cross_mesh,
                     )
                 except Exception as be:
                     logger.warning(f"Broker request via {broker_peer} failed: {be}")
@@ -3987,7 +4164,12 @@ def create_api_blueprint() -> Blueprint:
                     )
                 else:
                     connect_coro = p2p_manager.connection_manager.connect_to_peer(
-                        peer_id, host, port, scheme=scheme)
+                        peer_id,
+                        host,
+                        port,
+                        scheme=scheme,
+                        scheme_explicit=str(ep or '').strip().lower().startswith('wss://'),
+                    )
                 future = asyncio.run_coroutine_threadsafe(
                     connect_coro,
                     ev_loop
@@ -4229,7 +4411,12 @@ def create_api_blueprint() -> Blueprint:
                     connect_coro = connect_to_endpoint(p2p_manager, peer_id, ep)
                 else:
                     connect_coro = p2p_manager.connection_manager.connect_to_peer(
-                        peer_id, host, port, scheme=scheme)
+                        peer_id,
+                        host,
+                        port,
+                        scheme=scheme,
+                        scheme_explicit=str(ep or '').strip().lower().startswith('wss://'),
+                    )
                 future = _asyncio.run_coroutine_threadsafe(
                     connect_coro,
                     ev_loop,

--- a/canopy/core/config.py
+++ b/canopy/core/config.py
@@ -27,6 +27,159 @@ from .meshspaces import (
 
 logger = logging.getLogger('canopy.config')
 
+TRANSPORT_SECURITY_CONFIG_FILENAME = 'transport_security.json'
+TRANSPORT_SECURITY_MODES = {
+    'disabled',
+    'self_signed',
+    'provided',
+    'external_terminator',
+}
+
+
+def _config_data_dir(config: 'Config') -> Path:
+    raw_data_dir = str(getattr(getattr(config, 'storage', None), 'data_dir', '') or '').strip()
+    if raw_data_dir:
+        return Path(raw_data_dir).expanduser()
+    raw_db_path = str(getattr(getattr(config, 'storage', None), 'database_path', '') or '').strip()
+    if raw_db_path:
+        return Path(raw_db_path).expanduser().parent
+    return Path(__file__).resolve().parents[2] / 'data'
+
+
+def transport_security_config_path(config: 'Config') -> Path:
+    """Return the node-owned persistent transport-security settings path."""
+    path = _config_data_dir(config) / TRANSPORT_SECURITY_CONFIG_FILENAME
+    try:
+        config.network.transport_security_config_path = str(path)
+    except Exception:
+        pass
+    return path
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    return text in {'1', 'true', 'yes', 'on'}
+
+
+def normalize_transport_security_settings(settings: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Normalize persisted/admin transport settings without validating reachability."""
+    raw = dict(settings or {})
+    external_endpoint = str(raw.get('external_tls_endpoint') or '').strip()
+    cert_path = str(raw.get('tls_cert_path') or '').strip()
+    key_path = str(raw.get('tls_key_path') or '').strip()
+    mode = str(raw.get('mode') or raw.get('transport_security_mode') or '').strip().lower()
+    if mode not in TRANSPORT_SECURITY_MODES:
+        if external_endpoint:
+            mode = 'external_terminator'
+        elif _as_bool(raw.get('enable_tls'), False):
+            mode = 'provided' if cert_path and key_path else 'self_signed'
+        else:
+            mode = 'disabled'
+
+    enable_tls = _as_bool(raw.get('enable_tls'), mode in {'self_signed', 'provided'})
+    if mode == 'external_terminator':
+        enable_tls = False
+    elif mode == 'disabled':
+        enable_tls = False
+
+    return {
+        'mode': mode,
+        'enable_tls': enable_tls,
+        'tls_cert_path': cert_path,
+        'tls_key_path': key_path,
+        'require_verified_wss': _as_bool(raw.get('require_verified_wss'), False),
+        'external_tls_endpoint': external_endpoint if mode == 'external_terminator' else '',
+        'updated_at': str(raw.get('updated_at') or '').strip(),
+    }
+
+
+def load_transport_security_settings(config: 'Config') -> Dict[str, Any]:
+    """Load persisted transport-security settings for this device/meshspace."""
+    path = transport_security_config_path(config)
+    try:
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding='utf-8'))
+        if not isinstance(data, dict):
+            return {}
+        return normalize_transport_security_settings(data)
+    except Exception as exc:
+        logger.warning("Could not load transport security settings from %s: %s", path, exc)
+        return {}
+
+
+def save_transport_security_settings(config: 'Config', settings: Dict[str, Any]) -> Path:
+    """Persist transport-security settings into the active node/meshspace data dir."""
+    normalized = normalize_transport_security_settings(settings)
+    path = transport_security_config_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(normalized, indent=2, sort_keys=True), encoding='utf-8')
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+    return path
+
+
+def apply_transport_security_settings(
+    config: 'Config',
+    settings: Dict[str, Any],
+    *,
+    env_overrides: Optional[Dict[str, bool]] = None,
+) -> Dict[str, Any]:
+    """Apply normalized transport settings to a Config object, respecting env overrides."""
+    normalized = normalize_transport_security_settings(settings)
+    overrides = env_overrides or {}
+    network = config.network
+
+    if not overrides.get('transport_security_mode'):
+        network.transport_security_mode = normalized['mode']
+    if not overrides.get('enable_tls'):
+        network.enable_tls = bool(normalized['enable_tls'])
+    if not overrides.get('require_verified_wss'):
+        network.require_verified_wss = bool(normalized['require_verified_wss'])
+
+    mode = normalized['mode']
+    if mode in {'self_signed', 'provided'}:
+        if not overrides.get('tls_cert_path') and normalized['tls_cert_path']:
+            network.tls_cert_path = normalized['tls_cert_path']
+        if not overrides.get('tls_key_path') and normalized['tls_key_path']:
+            network.tls_key_path = normalized['tls_key_path']
+        if not overrides.get('external_tls_endpoint'):
+            network.external_tls_endpoint = ''
+    elif mode == 'external_terminator':
+        if not overrides.get('external_tls_endpoint'):
+            network.external_tls_endpoint = normalized['external_tls_endpoint']
+        if not overrides.get('tls_cert_path'):
+            network.tls_cert_path = ''
+        if not overrides.get('tls_key_path'):
+            network.tls_key_path = ''
+    elif mode == 'disabled':
+        if not overrides.get('external_tls_endpoint'):
+            network.external_tls_endpoint = ''
+
+    network.transport_security_config_path = str(transport_security_config_path(config))
+    return normalized
+
+
+def apply_persisted_transport_security_settings(
+    config: 'Config',
+    *,
+    env_overrides: Optional[Dict[str, bool]] = None,
+) -> Dict[str, Any]:
+    """Apply node-owned persisted transport settings after storage paths are known."""
+    settings = load_transport_security_settings(config)
+    if settings:
+        return apply_transport_security_settings(config, settings, env_overrides=env_overrides)
+    config.network.transport_security_config_path = str(transport_security_config_path(config))
+    return {}
+
 
 def _resolve_meshspace_registry_root(config: 'Config', data_root: str) -> str:
     """Choose the registry root for this runtime."""
@@ -52,6 +205,10 @@ class NetworkConfig:
     enable_tls: bool = False  # Use wss:// for P2P connections
     tls_cert_path: str = ""  # Path to TLS cert (auto-generated if empty)
     tls_key_path: str = ""   # Path to TLS key (auto-generated if empty)
+    require_verified_wss: bool = False  # Verify outbound wss:// certs/hostnames
+    external_tls_endpoint: str = ""  # Public wss:// endpoint when TLS terminates at a proxy/tunnel
+    transport_security_mode: str = ""  # disabled, self_signed, provided, external_terminator
+    transport_security_config_path: str = ""  # Node-owned persisted settings file
 
 
 @dataclass
@@ -336,6 +493,29 @@ class Config:
         if relay := os.getenv('CANOPY_RELAY_POLICY'):
             if relay in ('off', 'broker_only', 'full_relay'):
                 config.network.relay_policy = relay
+        network_env_overrides = {
+            'enable_tls': os.getenv('CANOPY_ENABLE_TLS') is not None,
+            'tls_cert_path': os.getenv('CANOPY_TLS_CERT_PATH') is not None,
+            'tls_key_path': os.getenv('CANOPY_TLS_KEY_PATH') is not None,
+            'require_verified_wss': os.getenv('CANOPY_REQUIRE_VERIFIED_WSS') is not None,
+            'external_tls_endpoint': os.getenv('CANOPY_EXTERNAL_TLS_ENDPOINT') is not None,
+            'transport_security_mode': os.getenv('CANOPY_TRANSPORT_SECURITY_MODE') is not None,
+        }
+        config.network.enable_tls = _env_bool('CANOPY_ENABLE_TLS', config.network.enable_tls)
+        if tls_cert_path := os.getenv('CANOPY_TLS_CERT_PATH'):
+            config.network.tls_cert_path = tls_cert_path
+        if tls_key_path := os.getenv('CANOPY_TLS_KEY_PATH'):
+            config.network.tls_key_path = tls_key_path
+        config.network.require_verified_wss = _env_bool(
+            'CANOPY_REQUIRE_VERIFIED_WSS',
+            config.network.require_verified_wss,
+        )
+        if external_tls_endpoint := os.getenv('CANOPY_EXTERNAL_TLS_ENDPOINT'):
+            config.network.external_tls_endpoint = external_tls_endpoint.strip()
+        if transport_mode := os.getenv('CANOPY_TRANSPORT_SECURITY_MODE'):
+            clean_mode = transport_mode.strip().lower()
+            if clean_mode in TRANSPORT_SECURITY_MODES:
+                config.network.transport_security_mode = clean_mode
 
         # Store device info on config for display. The peer identity remains mesh-local
         # because it lives under config.storage.data_dir, but the machine device label is
@@ -391,6 +571,11 @@ class Config:
         if secret_key := os.getenv('CANOPY_SECRET_KEY'):
             config.secret_key = secret_key
 
+        apply_persisted_transport_security_settings(
+            config,
+            env_overrides=network_env_overrides,
+        )
+
         return config
     
     def to_dict(self) -> Dict[str, Any]:
@@ -409,6 +594,14 @@ class Config:
                 'discovery_port': self.network.discovery_port,
                 'max_peers': self.network.max_peers,
                 'connection_timeout': self.network.connection_timeout,
+                'relay_policy': self.network.relay_policy,
+                'enable_tls': self.network.enable_tls,
+                'tls_cert_path': self.network.tls_cert_path,
+                'tls_key_path': self.network.tls_key_path,
+                'require_verified_wss': self.network.require_verified_wss,
+                'external_tls_endpoint': self.network.external_tls_endpoint,
+                'transport_security_mode': self.network.transport_security_mode,
+                'transport_security_config_path': self.network.transport_security_config_path,
             },
             'security': {
                 'encryption_algorithm': self.security.encryption_algorithm,

--- a/canopy/core/meshspaces.py
+++ b/canopy/core/meshspaces.py
@@ -79,6 +79,12 @@ _MESHSPACE_RUNTIME_ENV_KEYS = {
     "CANOPY_MESHSPACE_ROOT",
     "CANOPY_MESHSPACE_SUPERVISED",
     "CANOPY_MESHSPACE_NETWORK_QUARANTINED",
+    "CANOPY_ENABLE_TLS",
+    "CANOPY_TLS_CERT_PATH",
+    "CANOPY_TLS_KEY_PATH",
+    "CANOPY_REQUIRE_VERIFIED_WSS",
+    "CANOPY_EXTERNAL_TLS_ENDPOINT",
+    "CANOPY_TRANSPORT_SECURITY_MODE",
 }
 
 
@@ -405,7 +411,23 @@ def build_runtime_environment_from_config(config: Any) -> Dict[str, str]:
         "CANOPY_PORT": str(int(getattr(config.network, "port", 0) or 0)),
         "CANOPY_MESH_PORT": str(int(getattr(config.network, "mesh_port", 0) or 0)),
         "CANOPY_DISCOVERY_PORT": str(int(getattr(config.network, "discovery_port", 0) or 0)),
+        "CANOPY_ENABLE_TLS": "true" if bool(getattr(config.network, "enable_tls", False)) else "false",
+        "CANOPY_REQUIRE_VERIFIED_WSS": "true"
+        if bool(getattr(config.network, "require_verified_wss", False))
+        else "false",
     }
+    tls_cert_path = str(getattr(config.network, "tls_cert_path", "") or "").strip()
+    tls_key_path = str(getattr(config.network, "tls_key_path", "") or "").strip()
+    external_tls_endpoint = str(getattr(config.network, "external_tls_endpoint", "") or "").strip()
+    transport_mode = str(getattr(config.network, "transport_security_mode", "") or "").strip()
+    if tls_cert_path:
+        env_map["CANOPY_TLS_CERT_PATH"] = tls_cert_path
+    if tls_key_path:
+        env_map["CANOPY_TLS_KEY_PATH"] = tls_key_path
+    if external_tls_endpoint:
+        env_map["CANOPY_EXTERNAL_TLS_ENDPOINT"] = external_tls_endpoint
+    if transport_mode:
+        env_map["CANOPY_TRANSPORT_SECURITY_MODE"] = transport_mode
     if mesh_cfg and str(getattr(mesh_cfg, "meshspace_id", "") or "").strip():
         env_map.update(
             {
@@ -1633,7 +1655,7 @@ class MeshspaceRegistryManager:
         record = self.get_meshspace(meshspace_id)
         if not record:
             return None
-        return {
+        env = {
             "CANOPY_MESHSPACE_ID": str(record["meshspace_id"]),
             "CANOPY_MESHSPACE_NAME": str(record["name"]),
             "CANOPY_MESHSPACE_ROOT": str(record["data_dir"]),
@@ -1643,6 +1665,18 @@ class MeshspaceRegistryManager:
             "CANOPY_MESH_PORT": str(record["mesh_port"]),
             "CANOPY_DISCOVERY_PORT": str(record["discovery_port"]),
         }
+        for key in (
+            "CANOPY_ENABLE_TLS",
+            "CANOPY_TLS_CERT_PATH",
+            "CANOPY_TLS_KEY_PATH",
+            "CANOPY_REQUIRE_VERIFIED_WSS",
+            "CANOPY_EXTERNAL_TLS_ENDPOINT",
+            "CANOPY_TRANSPORT_SECURITY_MODE",
+        ):
+            value = str(os.environ.get(key) or "").strip()
+            if value:
+                env[key] = value
+        return env
 
     def _spawn_meshspace_process(self, meshspace_id: str) -> Dict[str, Any]:
         record = self.get_meshspace(meshspace_id)

--- a/canopy/network/connection.py
+++ b/canopy/network/connection.py
@@ -130,16 +130,21 @@ def create_server_ssl_context(cert_path: Path, key_path: Path) -> Optional[ssl.S
         return None
 
 
-def create_client_ssl_context() -> ssl.SSLContext:
-    """Create a permissive SSL context for connecting to peers.
+def create_client_ssl_context(*, verify_certificates: bool = False) -> ssl.SSLContext:
+    """Create an SSL context for connecting to peers.
 
-    Self-signed certs are expected in a mesh network, so we disable
-    hostname and certificate verification.  E2E encryption
-    (ChaCha20-Poly1305) protects the content independently.
+    The default remains permissive because many Canopy mesh peers use
+    self-signed transport certificates.  E2E encryption and peer-key
+    verification protect content independently from the transport TLS layer.
     """
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    if verify_certificates:
+        ctx.load_default_certs()
+        ctx.check_hostname = True
+        ctx.verify_mode = ssl.CERT_REQUIRED
+    else:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
     return ctx
 
 
@@ -226,6 +231,7 @@ class ConnectionManager:
                  meshspace_avatar_mime: str = "",
                  peer_label: str = "",
                  instance_label: str = "",
+                 require_verified_wss: bool = False,
                  reject_protocol_mismatch: bool = False):
         """
         Initialize connection manager.
@@ -259,22 +265,31 @@ class ConnectionManager:
         self.local_meshspace_avatar_mime = str(meshspace_avatar_mime or 'image/png').strip() or 'image/png'
         self.local_peer_label = self._sanitize_public_label(peer_label)
         self.local_instance_label = self._sanitize_public_label(instance_label)
+        self.require_verified_wss = bool(require_verified_wss)
+        self.client_verification_mode = 'verified' if self.require_verified_wss else 'permissive'
         self.reject_protocol_mismatch = bool(reject_protocol_mismatch)
         
         # TLS configuration
         self.enable_tls = enable_tls
         self._server_ssl: Optional[ssl.SSLContext] = None
-        self._client_ssl: Optional[ssl.SSLContext] = None
+        self._client_ssl: Optional[ssl.SSLContext] = create_client_ssl_context(
+            verify_certificates=self.require_verified_wss
+        )
+        self.tls_cert_path = str(tls_cert_path or 'data/tls/canopy.crt')
+        self.tls_key_path = str(tls_key_path or 'data/tls/canopy.key')
+        self.tls_cert_mode = 'disabled'
         if enable_tls:
-            cert_p = Path(tls_cert_path) if tls_cert_path else Path('data/tls/canopy.crt')
-            key_p = Path(tls_key_path) if tls_key_path else Path('data/tls/canopy.key')
+            cert_p = Path(self.tls_cert_path)
+            key_p = Path(self.tls_key_path)
+            had_operator_cert = bool(tls_cert_path and tls_key_path and cert_p.exists() and key_p.exists())
             self._server_ssl = create_server_ssl_context(cert_p, key_p)
-            self._client_ssl = create_client_ssl_context()
             if self._server_ssl:
+                self.tls_cert_mode = 'provided' if had_operator_cert else 'self_signed'
                 logger.info("TLS enabled for P2P connections (wss://)")
             else:
                 logger.warning("TLS requested but cert setup failed — falling back to ws://")
                 self.enable_tls = False
+                self.tls_cert_mode = 'disabled'
         
         # Connection tracking
         self.connections: Dict[str, PeerConnection] = {}
@@ -301,6 +316,57 @@ class ConnectionManager:
         tls_tag = ' (TLS)' if self.enable_tls else ''
         logger.info(f"Initialized ConnectionManager for {local_peer_id} "
                      f"on {host}:{port}{tls_tag}")
+
+    def get_transport_security_status(
+        self,
+        advertised_endpoints: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Return operator-facing TLS/WebSocket transport status."""
+        from .invite import classify_invite_endpoints
+
+        tls_active = bool(self.enable_tls and self._server_ssl)
+        scheme = 'wss' if tls_active else 'ws'
+        cert_path = Path(self.tls_cert_path)
+        key_path = Path(self.tls_key_path)
+        endpoints = [
+            str(endpoint or '').strip()
+            for endpoint in (advertised_endpoints or [])
+            if str(endpoint or '').strip()
+        ]
+        classification = classify_invite_endpoints(endpoints)
+        secure_count = sum(1 for endpoint in endpoints if endpoint.lower().startswith('wss://'))
+        plain_count = sum(1 for endpoint in endpoints if endpoint.lower().startswith('ws://'))
+        warnings: List[str] = []
+        if not tls_active:
+            warnings.append('Local mesh listener is plain ws:// unless a tunnel or reverse proxy terminates TLS.')
+        if classification.get('has_public_plain_fallback'):
+            warnings.append('This invite still advertises a plain public ws:// fallback. Remote peers may connect insecurely unless you remove plain fallback.')
+        if endpoints and plain_count and secure_count:
+            warnings.append('Invite advertises both secure and plain endpoints; remote peers may use either candidate.')
+        elif endpoints and plain_count and not secure_count:
+            warnings.append('Invite currently advertises only plain ws:// endpoints.')
+        if not tls_active and classification.get('public_secure_endpoints'):
+            warnings.append('Canopy cannot verify external TLS termination from this local plain ws:// listener alone.')
+        if tls_active and self.tls_cert_mode == 'self_signed':
+            warnings.append('Local TLS certificate is self-signed; public VPS deployments should prefer a trusted cert or TLS reverse proxy.')
+        if self.client_verification_mode == 'permissive':
+            warnings.append('Outbound wss:// certificate verification is permissive in this build; Canopy still verifies peer identity at the application layer.')
+        return {
+            'mesh_scheme': scheme,
+            'tls_enabled': tls_active,
+            'transport_label': 'Secure WebSocket (wss)' if tls_active else 'Plain WebSocket (ws)',
+            'listener_endpoint': f"{scheme}://{self._format_endpoint_host(self.host)}:{self.port}",
+            'tls_cert_mode': self.tls_cert_mode if tls_active else 'disabled',
+            'tls_cert_path_present': cert_path.exists(),
+            'tls_key_path_present': key_path.exists(),
+            'client_verification_mode': self.client_verification_mode,
+            'advertised_endpoints': endpoints,
+            'advertised_secure_count': secure_count,
+            'advertised_plain_count': plain_count,
+            'explicit_wss_downgrade_allowed': False,
+            'warnings': warnings,
+            **classification,
+        }
 
     @staticmethod
     def _format_endpoint_host(host: str) -> str:
@@ -655,7 +721,15 @@ class ConnectionManager:
         
         logger.info("ConnectionManager stopped")
     
-    async def connect_to_peer(self, peer_id: str, address: str, port: int, scheme: Optional[str] = None) -> bool:
+    async def connect_to_peer(
+        self,
+        peer_id: str,
+        address: str,
+        port: int,
+        scheme: Optional[str] = None,
+        *,
+        scheme_explicit: bool = False,
+    ) -> bool:
         """
         Establish outbound connection to a peer.
         
@@ -664,6 +738,7 @@ class ConnectionManager:
             address: Peer's IP address
             port: Peer's port
             scheme: Optional explicit transport scheme ('ws' or 'wss')
+            scheme_explicit: True when the operator/invite explicitly chose the scheme.
             
         Returns:
             True if connection successful
@@ -731,6 +806,25 @@ class ConnectionManager:
                 websocket = await websockets.connect(uri, **connect_kwargs)
             except Exception as tls_err:
                 if connect_scheme == 'wss':
+                    if scheme_explicit or self.require_verified_wss:
+                        downgrade_scope = 'Explicit' if scheme_explicit else 'Verified'
+                        detail = (
+                            f"{downgrade_scope} wss:// endpoint failed; refusing unsafe ws:// downgrade "
+                            f"for {address}:{port}: {type(tls_err).__name__}: {tls_err}"
+                        )
+                        logger.warning(detail)
+                        connection.state = ConnectionState.FAILED
+                        connection.failure_reason = 'wss_downgrade_blocked'
+                        connection.failure_detail = detail
+                        self._record_connect_failure(
+                            peer_id,
+                            address,
+                            port,
+                            'wss_downgrade_blocked',
+                            detail,
+                        )
+                        await self._disconnect_connection(connection, notify=False)
+                        return False
                     # Fall back to plain ws:// if wss failed
                     logger.debug(
                         f"wss:// failed to {address}:{port}, falling back to ws:// ({tls_err})"

--- a/canopy/network/invite.py
+++ b/canopy/network/invite.py
@@ -83,6 +83,39 @@ def canonicalize_invite_endpoint(endpoint: str) -> Optional[str]:
     return f'{scheme}://{_format_endpoint_host(host)}:{port}'
 
 
+def _endpoint_host_key(endpoint: str) -> str:
+    parsed = parse_invite_endpoint(endpoint)
+    if not parsed:
+        return ''
+    host, _, _ = parsed
+    return str(host or '').strip().lower()
+
+
+def _is_lan_endpoint(endpoint: str) -> bool:
+    parsed = parse_invite_endpoint(endpoint)
+    if not parsed:
+        return False
+    host, _, _ = parsed
+    text = str(host or '').strip().lower()
+    if not text:
+        return False
+    if text == 'localhost' or text.endswith('.local'):
+        return True
+    try:
+        import ipaddress
+
+        ip = ipaddress.ip_address(text)
+        return bool(ip.is_private or ip.is_link_local or ip.is_loopback)
+    except ValueError:
+        return False
+
+
+def _is_same_host(endpoint_a: str, endpoint_b: str) -> bool:
+    a = _endpoint_host_key(endpoint_a)
+    b = _endpoint_host_key(endpoint_b)
+    return bool(a and b and a == b)
+
+
 def _sanitize_invite_endpoints(endpoints: List[str]) -> List[str]:
     """Keep only canonical, dialable invite endpoints in stable order."""
     out: List[str] = []
@@ -94,6 +127,63 @@ def _sanitize_invite_endpoints(endpoints: List[str]) -> List[str]:
         seen.add(canon)
         out.append(canon)
     return out
+
+
+def classify_invite_endpoints(endpoints: List[str]) -> Dict[str, Any]:
+    """Classify invite endpoints for operator UX without changing invite format."""
+    sanitized = _sanitize_invite_endpoints(endpoints or [])
+    public_secure: List[str] = []
+    public_plain: List[str] = []
+    lan_endpoints: List[str] = []
+
+    for endpoint in sanitized:
+        parsed = parse_invite_endpoint(endpoint)
+        if not parsed:
+            continue
+        _, _, scheme = parsed
+        if _is_lan_endpoint(endpoint):
+            lan_endpoints.append(endpoint)
+        elif scheme == 'wss':
+            public_secure.append(endpoint)
+        else:
+            public_plain.append(endpoint)
+
+    recommended = next((ep for ep in sanitized if ep.lower().startswith('wss://')), sanitized[0] if sanitized else '')
+    recommended_transport = ''
+    parsed_recommended = parse_invite_endpoint(recommended) if recommended else None
+    if parsed_recommended:
+        recommended_transport = parsed_recommended[2]
+
+    if public_secure and public_plain:
+        policy = 'mixed_public_secure_plain'
+        policy_label = 'Mixed secure/plain public invite'
+    elif public_secure:
+        policy = 'secure_public'
+        policy_label = 'Secure public invite'
+    elif public_plain:
+        policy = 'plain_public'
+        policy_label = 'Plain public invite'
+    elif any(ep.lower().startswith('wss://') for ep in lan_endpoints):
+        policy = 'secure_lan'
+        policy_label = 'Secure LAN invite'
+    elif lan_endpoints:
+        policy = 'lan_only'
+        policy_label = 'LAN-only invite'
+    else:
+        policy = 'no_direct_endpoints'
+        policy_label = 'No direct endpoints'
+
+    return {
+        'recommended_endpoint': recommended,
+        'recommended_transport': recommended_transport,
+        'public_secure_endpoints': public_secure,
+        'public_plain_endpoints': public_plain,
+        'lan_endpoints': lan_endpoints,
+        'has_public_plain_fallback': bool(public_secure and public_plain),
+        'has_lan_fallback': bool(lan_endpoints),
+        'invite_policy': policy,
+        'invite_policy_label': policy_label,
+    }
 
 
 def meshspace_fingerprint(meshspace_id: Optional[str], mesh_name: Optional[str] = None) -> str:
@@ -247,6 +337,8 @@ def generate_invite(identity_manager: Any, mesh_port: int,
                     public_host: Optional[str] = None,
                     public_port: Optional[int] = None,
                     external_endpoint: Optional[str] = None,
+                    allow_plain_fallback: bool = False,
+                    endpoint_scheme: str = 'ws',
                     mesh_name: Optional[str] = None,
                     meshspace_id: Optional[str] = None,
                     meshspace_id_aliases: Optional[List[str]] = None,
@@ -266,6 +358,8 @@ def generate_invite(identity_manager: Any, mesh_port: int,
         public_host: Optional public/external IP or hostname
         public_port: Optional public port (if port-forwarded)
         external_endpoint: Optional full ws:// or wss:// endpoint
+        allow_plain_fallback: If true, explicit WSS invites may also advertise same-host plain WS candidates
+        endpoint_scheme: Scheme for Canopy-owned listener endpoints (ws or wss)
         mesh_name: Optional human-facing mesh label for preview UX
         meshspace_id: Optional stable meshspace identifier for preview UX
         meshspace_id_aliases: Optional legacy/current alias IDs for transition-aware preview UX
@@ -288,6 +382,10 @@ def generate_invite(identity_manager: Any, mesh_port: int,
     xpk = base58.b58encode(local.x25519_public_key).decode()
 
     endpoints: List[str] = []
+    explicit_wss_endpoint = ''
+    listener_scheme = str(endpoint_scheme or 'ws').strip().lower()
+    if listener_scheme not in {'ws', 'wss'}:
+        listener_scheme = 'ws'
 
     # Explicit external endpoint first (e.g. ngrok or another tunnel)
     if external_endpoint:
@@ -295,15 +393,22 @@ def generate_invite(identity_manager: Any, mesh_port: int,
         if not canon:
             raise ValueError("Invalid external mesh endpoint")
         endpoints.append(canon)
+        parsed_external = parse_invite_endpoint(canon)
+        if parsed_external and parsed_external[2] == 'wss':
+            explicit_wss_endpoint = canon
 
     # Public / port-forwarded endpoint next
     if public_host:
         port = public_port or mesh_port
-        endpoints.append(f"ws://{_format_endpoint_host(public_host)}:{port}")
+        public_endpoint = f"{listener_scheme}://{_format_endpoint_host(public_host)}:{port}"
+        if not (explicit_wss_endpoint and not allow_plain_fallback and _is_same_host(public_endpoint, explicit_wss_endpoint)):
+            endpoints.append(public_endpoint)
 
     # LAN endpoints
     for ip in get_local_ips():
-        ep = f"ws://{ip}:{mesh_port}"
+        ep = f"{listener_scheme}://{ip}:{mesh_port}"
+        if explicit_wss_endpoint and not allow_plain_fallback and _is_same_host(ep, explicit_wss_endpoint):
+            continue
         if ep not in endpoints:
             endpoints.append(ep)
 

--- a/canopy/network/manager.py
+++ b/canopy/network/manager.py
@@ -133,6 +133,10 @@ class P2PNetworkManager:
         self._activity_events: Deque[Dict[str, Any]] = deque(maxlen=200)
         self._endpoint_health_lock = threading.Lock()
         self._endpoint_health: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        self._operator_external_endpoint: Optional[str] = None
+        self._operator_public_host: Optional[str] = None
+        self._operator_public_port: Optional[int] = None
+        self._operator_allow_plain_fallback: bool = False
         
         # Callback that returns list of public channels for sync
         self.get_public_channels_for_sync: Optional[Callable] = None
@@ -297,6 +301,155 @@ class P2PNetworkManager:
             'meshspace_avatar_b64': str(getattr(mesh_cfg, 'avatar_preview_b64', '') or '').strip(),
             'meshspace_avatar_mime': str(getattr(mesh_cfg, 'avatar_preview_mime', 'image/png') or 'image/png').strip() or 'image/png',
         }
+
+    @classmethod
+    def _extract_peer_meshspace_hint(cls, peer_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Normalize meshspace metadata carried by invites, handshakes, or introductions."""
+        if not isinstance(peer_meta, dict):
+            return {}
+        merged: Dict[str, Any] = {}
+        for nested_key in ('meshspace_hint', 'meshspace'):
+            nested = peer_meta.get(nested_key)
+            if isinstance(nested, dict):
+                for key, value in nested.items():
+                    if value is not None and value != '':
+                        merged[key] = value
+        for key, value in peer_meta.items():
+            if key in {'meshspace_hint', 'meshspace'}:
+                continue
+            if value is not None and value != '':
+                merged[key] = value
+        key_map = {
+            'meshspace_id': ('meshspace_id', 'mid', 'mesh_id'),
+            'meshspace_id_aliases': ('meshspace_id_aliases', 'mesh_id_aliases', 'mids'),
+            'meshspace_name': ('meshspace_name', 'mesh_name', 'mn'),
+            'meshspace_fingerprint': ('meshspace_fingerprint', 'mesh_fingerprint', 'mf'),
+            'meshspace_avatar_b64': ('meshspace_avatar_b64',),
+            'meshspace_avatar_mime': ('meshspace_avatar_mime',),
+            'cross_mesh_allowed': ('cross_mesh_allowed',),
+            'mesh_relationship': ('mesh_relationship',),
+        }
+        hint: Dict[str, Any] = {}
+        for target, keys in key_map.items():
+            for key in keys:
+                if key not in merged:
+                    continue
+                value = merged.get(key)
+                if value is None or value == '':
+                    continue
+                hint[target] = value
+                break
+        meshspace_id = str(hint.get('meshspace_id') or '').strip()
+        aliases = cls._normalize_meshspace_id_aliases(
+            hint.get('meshspace_id_aliases'),
+            current_id=meshspace_id,
+        )
+        normalized: Dict[str, Any] = {}
+        if meshspace_id:
+            normalized['meshspace_id'] = meshspace_id
+        if aliases:
+            normalized['meshspace_id_aliases'] = aliases
+        for key in ('meshspace_name', 'meshspace_fingerprint', 'meshspace_avatar_mime', 'mesh_relationship'):
+            value = str(hint.get(key) or '').strip()
+            if value:
+                normalized[key] = value
+        avatar_b64 = str(hint.get('meshspace_avatar_b64') or '').strip()
+        if avatar_b64 and len(avatar_b64) <= 24000:
+            normalized['meshspace_avatar_b64'] = avatar_b64
+        if 'cross_mesh_allowed' in hint:
+            normalized['cross_mesh_allowed'] = bool(hint.get('cross_mesh_allowed'))
+        return normalized
+
+    def _peer_meshspace_hint_for_announcement(self, peer_id: str) -> Dict[str, Any]:
+        """Return compact meshspace metadata safe to include in peer introductions."""
+        identity_manager = getattr(self, 'identity_manager', None)
+        getter = getattr(identity_manager, 'get_peer_meshspace_hint', None)
+        hint: Dict[str, Any] = {}
+        if callable(getter):
+            try:
+                hint = dict(getter(peer_id) or {})
+            except Exception:
+                hint = {}
+        elif identity_manager is not None:
+            hint = dict(getattr(identity_manager, 'peer_meshspace_hints', {}).get(peer_id, {}) or {})
+        normalized = self._extract_peer_meshspace_hint(hint)
+        if not normalized:
+            return {}
+        # Keep introductions lightweight; text identity is enough to prevent accidental bridging.
+        return {
+            key: value
+            for key, value in normalized.items()
+            if key not in {'meshspace_avatar_b64', 'meshspace_avatar_mime'}
+        }
+
+    def _introduced_peer_meshspace_status(
+        self,
+        peer_id: str,
+        record: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Classify introduced peers so cross-mesh candidates cannot look routine."""
+        identity_manager = getattr(self, 'identity_manager', None)
+        persisted_hint: Dict[str, Any] = {}
+        getter = getattr(identity_manager, 'get_peer_meshspace_hint', None)
+        if callable(getter):
+            try:
+                persisted_hint = dict(getter(peer_id) or {})
+            except Exception:
+                persisted_hint = {}
+        elif identity_manager is not None:
+            persisted_hint = dict(getattr(identity_manager, 'peer_meshspace_hints', {}).get(peer_id, {}) or {})
+
+        hint = self._extract_peer_meshspace_hint(persisted_hint)
+        record_hint = self._extract_peer_meshspace_hint(record)
+        if record_hint:
+            hint.update(record_hint)
+
+        local = self._local_meshspace_identity()
+        local_ids = self._meshspace_hint_ids(local)
+        remote_ids = self._meshspace_hint_ids(hint)
+        local_fingerprint = str(local.get('meshspace_fingerprint') or '').strip()
+        remote_fingerprint = str(hint.get('meshspace_fingerprint') or '').strip()
+        mismatch = False
+        if self._meshspace_boundary_enabled():
+            if local_ids and remote_ids:
+                mismatch = not bool(local_ids.intersection(remote_ids))
+            elif local_fingerprint and remote_fingerprint:
+                mismatch = remote_fingerprint != local_fingerprint
+
+        if mismatch:
+            relationship = 'cross_mesh_candidate'
+        elif remote_ids or remote_fingerprint:
+            relationship = 'same_mesh_candidate'
+        else:
+            relationship = 'unknown'
+
+        remote_label = (
+            str(hint.get('meshspace_name') or '').strip()
+            or str(hint.get('meshspace_id') or '').strip()
+            or 'another meshspace'
+        )
+        return {
+            'meshspace_hint': hint,
+            'meshspace_relationship': relationship,
+            'meshspace_mismatch': bool(mismatch),
+            'requires_explicit_meshspace_connect': bool(mismatch),
+            'local_meshspace_id': str(local.get('meshspace_id') or '').strip(),
+            'local_meshspace_name': str(local.get('meshspace_name') or '').strip(),
+            'remote_meshspace_id': str(hint.get('meshspace_id') or '').strip(),
+            'remote_meshspace_name': str(hint.get('meshspace_name') or '').strip(),
+            'remote_meshspace_fingerprint': str(hint.get('meshspace_fingerprint') or '').strip(),
+            'remote_meshspace_label': remote_label,
+        }
+
+    def get_introduced_peer_meshspace_status(self, peer_id: str) -> Dict[str, Any]:
+        """Return meshspace review status for an introduced peer."""
+        clean_peer_id = str(peer_id or '').strip()
+        record = {}
+        if clean_peer_id and hasattr(self, '_introduced_peers'):
+            candidate = self._introduced_peers.get(clean_peer_id)
+            if isinstance(candidate, dict):
+                record = candidate
+        return self._introduced_peer_meshspace_status(clean_peer_id, record)
 
     def _record_peer_meshspace_hint(
         self,
@@ -1459,6 +1612,7 @@ class P2PNetworkManager:
                 meshspace_avatar_mime=local_meshspace.get('meshspace_avatar_mime', 'image/png'),
                 peer_label=local_peer_hint.get('peer_label', ''),
                 instance_label=local_peer_hint.get('instance_label', ''),
+                require_verified_wss=bool(getattr(network_config, 'require_verified_wss', False)),
                 reject_protocol_mismatch=bool(
                     os.getenv('CANOPY_REJECT_PROTOCOL_MISMATCH', '').strip().lower() in ('1', 'true', 'yes', 'on')
                 ),
@@ -1788,12 +1942,69 @@ class P2PNetworkManager:
             mesh_port = int(getattr(self.config.network, 'mesh_port', 0) or 0)
             if mesh_port <= 0:
                 return []
-            invite = generate_invite(self.identity_manager, mesh_port)
+            network_config = getattr(self.config, 'network', None)
+            external_endpoint = (
+                self._operator_external_endpoint
+                or str(getattr(network_config, 'external_tls_endpoint', '') or '').strip()
+                or None
+            )
+            # Advertise the transport the listener is using right now, not just
+            # the next persisted mode. Admin transport changes require restart,
+            # so invite/handshake truth must follow the live connection manager
+            # until that restart actually happens.
+            conn_mgr = getattr(self, 'connection_manager', None)
+            if conn_mgr is not None:
+                endpoint_scheme = 'wss' if bool(getattr(conn_mgr, 'enable_tls', False)) else 'ws'
+            else:
+                endpoint_scheme = 'wss' if bool(getattr(network_config, 'enable_tls', False)) else 'ws'
+            invite = generate_invite(
+                self.identity_manager,
+                mesh_port,
+                public_host=self._operator_public_host,
+                public_port=self._operator_public_port,
+                external_endpoint=external_endpoint,
+                allow_plain_fallback=self._operator_allow_plain_fallback,
+                endpoint_scheme=endpoint_scheme,
+            )
             local_peer_id = self.local_identity.peer_id if self.local_identity else ''
             return self._sanitize_endpoints(local_peer_id, list(invite.endpoints or []))
         except Exception as exc:
             logger.debug("Could not compute local advertised endpoints: %s", exc)
             return []
+
+    def remember_operator_advertised_endpoint(
+        self,
+        *,
+        external_endpoint: Optional[str] = None,
+        public_host: Optional[str] = None,
+        public_port: Optional[int] = None,
+        allow_plain_fallback: bool = False,
+    ) -> None:
+        """Remember the operator's current public invite endpoint for handshakes."""
+        from .invite import canonicalize_invite_endpoint
+
+        clean_external = str(external_endpoint or '').strip()
+        if clean_external:
+            canon = canonicalize_invite_endpoint(clean_external)
+            if canon:
+                self._operator_external_endpoint = canon
+                self._operator_public_host = None
+                self._operator_public_port = None
+                self._operator_allow_plain_fallback = bool(allow_plain_fallback)
+                return
+
+        clean_host = str(public_host or '').strip()
+        if clean_host:
+            self._operator_external_endpoint = None
+            self._operator_public_host = clean_host
+            self._operator_public_port = int(public_port) if public_port else None
+            self._operator_allow_plain_fallback = bool(allow_plain_fallback)
+            return
+
+        self._operator_external_endpoint = None
+        self._operator_public_host = None
+        self._operator_public_port = None
+        self._operator_allow_plain_fallback = False
 
     @staticmethod
     def _merge_endpoint_lists(*endpoint_groups: list[str]) -> list[str]:
@@ -2103,9 +2314,9 @@ class P2PNetworkManager:
                 logger.debug(f"Reconnect: skipping unusable endpoint {endpoint} for {peer_id}")
                 return False
         if scheme == 'wss' and not self.connection_manager.enable_tls:
-            logger.warning(
-                f"Reconnect: endpoint {endpoint} requires TLS, but TLS is disabled; "
-                f"connection may fail."
+            logger.debug(
+                "Reconnect: attempting outbound wss:// endpoint while the local listener is plain ws://; "
+                "this is expected for tunnels or reverse proxies."
             )
         endpoint_sources: list[str] = []
         stored = set(
@@ -2125,7 +2336,15 @@ class P2PNetworkManager:
             detail='Attempting connection',
             endpoint=canon or endpoint,
         )
-        ok = await self.connection_manager.connect_to_peer(peer_id, host, port, scheme=scheme)
+        endpoint_text = str(endpoint or '').strip().lower()
+        scheme_explicit = endpoint_text.startswith('wss://')
+        ok = await self.connection_manager.connect_to_peer(
+            peer_id,
+            host,
+            port,
+            scheme=scheme,
+            scheme_explicit=scheme_explicit,
+        )
         if ok and canon:
             get_connection = getattr(self.connection_manager, 'get_connection', None)
             conn = get_connection(peer_id) if callable(get_connection) else None
@@ -2989,7 +3208,7 @@ class P2PNetworkManager:
                     else self.identity_manager.peer_display_names.get(pid, pid[:8])
                 )
                 display_name = self._sanitize_public_peer_label(display_name)
-                introduced.append({
+                peer_payload = {
                     'peer_id': pid,
                     'display_name': display_name,
                     'peer_label': display_name,
@@ -3001,7 +3220,12 @@ class P2PNetworkManager:
                         list((getattr(self.connection_manager.get_connection(pid), 'capabilities', None) or {}).keys())
                     ),
                     'device_profile': device_profile,
-                })
+                }
+                meshspace_hint = self._peer_meshspace_hint_for_announcement(pid)
+                if meshspace_hint:
+                    peer_payload['meshspace_hint'] = meshspace_hint
+                    peer_payload.update(meshspace_hint)
+                introduced.append(peer_payload)
             if introduced:
                 logger.debug(f"Announcing {len(introduced)} peers to {peer_id}")
                 await self.message_router.send_peer_announcement(peer_id, introduced)
@@ -3039,7 +3263,7 @@ class P2PNetworkManager:
                 else self.identity_manager.peer_display_names.get(new_peer_id, new_peer_id[:8])
             )
             display_name = self._sanitize_public_peer_label(display_name)
-            new_peer_info = [{
+            peer_payload = {
                 'peer_id': new_peer_id,
                 'display_name': display_name,
                 'peer_label': display_name,
@@ -3051,7 +3275,12 @@ class P2PNetworkManager:
                     list((getattr(self.connection_manager.get_connection(new_peer_id), 'capabilities', None) or {}).keys())
                 ),
                 'device_profile': device_profile,
-            }]
+            }
+            meshspace_hint = self._peer_meshspace_hint_for_announcement(new_peer_id)
+            if meshspace_hint:
+                peer_payload['meshspace_hint'] = meshspace_hint
+                peer_payload.update(meshspace_hint)
+            new_peer_info = [peer_payload]
 
             connected = self.connection_manager.get_connected_peers()
             local_id = self.local_identity.peer_id if self.local_identity else ''
@@ -3109,6 +3338,10 @@ class P2PNetworkManager:
             )
             if public_hint.get('display_name') and not cleaned.get('display_name'):
                 cleaned['display_name'] = public_hint['display_name']
+            meshspace_hint = self._extract_peer_meshspace_hint(cleaned)
+            if meshspace_hint:
+                cleaned['meshspace_hint'] = meshspace_hint
+                self._record_peer_meshspace_hint(pid, meshspace_hint, source='announcement')
             cleaned['endpoints'] = endpoints
             cleaned['introduced_by'] = from_peer
             cleaned['capabilities'] = self._normalize_capability_items(cleaned.get('capabilities'))
@@ -3206,12 +3439,16 @@ class P2PNetworkManager:
                 connect_strategy = 'broker_only' if broker_candidates else 'unreachable'
 
             row = dict(record)
+            meshspace_status = self._introduced_peer_meshspace_status(peer_id, record)
+            if meshspace_status.get('requires_explicit_meshspace_connect'):
+                connect_strategy = 'explicit_meshspace_required'
             row['peer_id'] = peer_id
             row['endpoints'] = merged_endpoints
             row['endpoint_count'] = len(merged_endpoints)
             row['endpoint_sources'] = endpoint_sources or ['none']
             row['connect_strategy'] = connect_strategy
             row['broker_candidates'] = broker_candidates
+            row.update(meshspace_status)
             rows.append(row)
         return rows
 
@@ -3343,7 +3580,8 @@ class P2PNetworkManager:
     def _on_broker_request(self, target_peer: str,
                            requester_endpoints: list,
                            requester_keys: dict,
-                           from_peer: str) -> None:
+                           from_peer: str,
+                           allow_cross_mesh: bool = False) -> None:
         """Handle a BROKER_REQUEST: peer asks us to help it connect to target_peer.
 
         If we are connected to target_peer, forward a BROKER_INTRO with
@@ -3385,6 +3623,7 @@ class P2PNetworkManager:
                     requester_peer_id=from_peer,
                     requester_endpoints=requester_endpoints,
                     requester_keys=requester_keys,
+                    allow_cross_mesh=allow_cross_mesh,
                 ),
                 self._event_loop
             )
@@ -3398,7 +3637,8 @@ class P2PNetworkManager:
     def _on_broker_intro(self, requester_peer_id: str,
                          requester_endpoints: list,
                          requester_keys: dict,
-                         from_peer: str) -> None:
+                         from_peer: str,
+                         allow_cross_mesh: bool = False) -> None:
         """Handle a BROKER_INTRO: an intermediary tells us a peer wants to connect.
 
         Attempt to connect directly to the requester using the provided endpoints.
@@ -3425,13 +3665,18 @@ class P2PNetworkManager:
         if self._event_loop and not self._event_loop.is_closed():
             asyncio.run_coroutine_threadsafe(
                 self._attempt_brokered_connection(
-                    requester_peer_id, requester_endpoints, broker_peer=from_peer),
+                    requester_peer_id,
+                    requester_endpoints,
+                    broker_peer=from_peer,
+                    allow_cross_mesh=allow_cross_mesh,
+                ),
                 self._event_loop
             )
 
     async def _attempt_brokered_connection(self, peer_id: str,
                                             endpoints: list,
-                                            broker_peer: Optional[str] = None) -> None:
+                                            broker_peer: Optional[str] = None,
+                                            allow_cross_mesh: bool = False) -> None:
         """Try each endpoint to establish a direct connection.
         
         Args:
@@ -3449,7 +3694,11 @@ class P2PNetworkManager:
         for ep in endpoints:
             try:
                 logger.info(f"Brokered connect attempt to {peer_id} via {ep}")
-                await self._connect_to_endpoint(peer_id, ep)
+                await self._connect_to_endpoint(
+                    peer_id,
+                    ep,
+                    allow_cross_mesh=allow_cross_mesh,
+                )
                 if self.connection_manager.is_connected(peer_id):
                     logger.info(f"Brokered connection to {peer_id} succeeded!")
                     # Remove any relay route since we now have a direct connection
@@ -3569,7 +3818,8 @@ class P2PNetworkManager:
         asyncio.run_coroutine_threadsafe(_send_offers(), self._event_loop)
 
     def send_broker_request(self, target_peer_id: str,
-                            via_peer_id: str) -> bool:
+                            via_peer_id: str,
+                            allow_cross_mesh: bool = False) -> bool:
         """Public method: ask via_peer to broker a connection to target_peer.
 
         Called from the API layer when a direct connection attempt fails.
@@ -3607,6 +3857,7 @@ class P2PNetworkManager:
                 target_peer=target_peer_id,
                 requester_endpoints=requester_endpoints,
                 requester_keys=requester_keys,
+                allow_cross_mesh=allow_cross_mesh,
             ),
             self._event_loop
         )
@@ -5988,6 +6239,24 @@ class P2PNetworkManager:
             return []
         return self.connection_manager.get_connected_peers()
 
+    def get_peer_active_transport(self, peer_id: str) -> Dict[str, Any]:
+        """Return the active direct endpoint and transport scheme for a peer."""
+        active_endpoint = self._current_connection_endpoint(peer_id) or ''
+        parsed = self._parse_endpoint(active_endpoint) if active_endpoint else None
+        scheme = parsed[2] if parsed else ''
+        if scheme == 'wss':
+            label = 'Secure WebSocket (wss)'
+        elif scheme == 'ws':
+            label = 'Plain WebSocket (ws)'
+        else:
+            label = 'Unknown'
+        return {
+            'active_endpoint': active_endpoint,
+            'active_transport': scheme,
+            'active_transport_label': label,
+            'active_transport_secure': scheme == 'wss',
+        }
+
     def get_peer_versions(self) -> Dict[str, Dict[str, Any]]:
         """Return cached per-peer version/protocol metadata."""
         # Refresh cache opportunistically from current live connections.
@@ -6020,6 +6289,99 @@ class P2PNetworkManager:
         if self.connection_manager and getattr(self.connection_manager, 'enable_tls', False):
             return 'wss'
         return 'ws'
+
+    def get_transport_security_status(self) -> Dict[str, Any]:
+        """Return operator-facing WebSocket/TLS status for UI diagnostics."""
+        from .invite import classify_invite_endpoints
+
+        advertised = self._get_local_advertised_endpoints()
+        classification = classify_invite_endpoints(advertised)
+        conn_mgr = self.connection_manager
+        if conn_mgr and hasattr(conn_mgr, 'get_transport_security_status'):
+            try:
+                status = dict(conn_mgr.get_transport_security_status(advertised_endpoints=advertised) or {})
+                status.update(classification)
+                return self._decorate_transport_security_status(status)
+            except Exception:
+                logger.debug("Could not get transport security status from connection manager", exc_info=True)
+        scheme = self.ws_scheme
+        secure_count = sum(1 for endpoint in advertised if str(endpoint).lower().startswith('wss://'))
+        plain_count = sum(1 for endpoint in advertised if str(endpoint).lower().startswith('ws://'))
+        warnings = []
+        if plain_count and not secure_count:
+            warnings.append('Invite currently advertises only plain ws:// endpoints.')
+        if classification.get('has_public_plain_fallback'):
+            warnings.append('This invite still advertises a plain public ws:// fallback. Remote peers may connect insecurely unless you remove plain fallback.')
+        status = {
+            'mesh_scheme': scheme,
+            'tls_enabled': scheme == 'wss',
+            'transport_label': 'Secure WebSocket (wss)' if scheme == 'wss' else 'Plain WebSocket (ws)',
+            'listener_endpoint': f"{scheme}://0.0.0.0:{getattr(self.config.network, 'mesh_port', 7771)}",
+            'tls_cert_mode': 'unknown' if scheme == 'wss' else 'disabled',
+            'tls_cert_path_present': False,
+            'tls_key_path_present': False,
+            'client_verification_mode': (
+                'verified'
+                if bool(getattr(self.config.network, 'require_verified_wss', False))
+                else 'permissive'
+            ),
+            'advertised_endpoints': advertised,
+            'advertised_secure_count': secure_count,
+            'advertised_plain_count': plain_count,
+            'explicit_wss_downgrade_allowed': False,
+            'warnings': warnings,
+            **classification,
+        }
+        return self._decorate_transport_security_status(status)
+
+    def _decorate_transport_security_status(self, status: Dict[str, Any]) -> Dict[str, Any]:
+        """Add config-backed transport mode/readiness details for admin/operator UX."""
+        network_config = getattr(self.config, 'network', None)
+        configured_tls = bool(getattr(network_config, 'enable_tls', False))
+        external_endpoint = str(getattr(network_config, 'external_tls_endpoint', '') or '').strip()
+        mode = str(getattr(network_config, 'transport_security_mode', '') or '').strip().lower()
+        tls_cert_path = str(getattr(network_config, 'tls_cert_path', '') or '').strip()
+        tls_key_path = str(getattr(network_config, 'tls_key_path', '') or '').strip()
+        if mode not in {'disabled', 'self_signed', 'provided', 'external_terminator'}:
+            if external_endpoint:
+                mode = 'external_terminator'
+            elif configured_tls:
+                live_mode = str(status.get('tls_cert_mode') or '').strip().lower()
+                mode = live_mode if live_mode in {'self_signed', 'provided'} else ('provided' if tls_cert_path and tls_key_path else 'self_signed')
+            else:
+                mode = 'disabled'
+        labels = {
+            'disabled': 'Disabled',
+            'self_signed': 'Self-signed local TLS',
+            'provided': 'Provided certificate',
+            'external_terminator': 'External TLS terminator',
+        }
+        external_declared = bool(mode == 'external_terminator' and external_endpoint.lower().startswith('wss://'))
+        warnings = [
+            str(item)
+            for item in (status.get('warnings') or [])
+            if str(item or '').strip()
+        ]
+        if external_declared:
+            warnings = [
+                item for item in warnings
+                if not item.startswith('Canopy cannot verify external TLS termination')
+            ]
+            if not bool(status.get('tls_enabled')):
+                warnings.append(
+                    'External TLS terminator mode is declared; Canopy advertises the public wss:// endpoint while the local mesh listener remains ws:// behind the proxy.'
+                )
+        secure_invite_ready = bool(status.get('tls_enabled')) or external_declared
+        status.update({
+            'configured_tls_enabled': configured_tls,
+            'external_tls_endpoint': external_endpoint,
+            'external_tls_terminator_declared': external_declared,
+            'transport_security_mode': mode,
+            'transport_security_mode_label': labels.get(mode, 'Disabled'),
+            'secure_invite_ready': secure_invite_ready,
+            'warnings': warnings,
+        })
+        return status
 
     def get_peer_id(self) -> Optional[str]:
         """Get local peer ID."""

--- a/canopy/network/routing.py
+++ b/canopy/network/routing.py
@@ -1450,6 +1450,7 @@ class MessageRouter:
                     requester_endpoints=meta.get('requester_endpoints', []),
                     requester_keys=meta.get('requester_keys', {}),
                     from_peer=message.from_peer,
+                    allow_cross_mesh=bool(meta.get('allow_cross_mesh')),
                 )
             except Exception as e:
                 logger.error(f"Error handling broker request: {e}", exc_info=True)
@@ -1462,6 +1463,7 @@ class MessageRouter:
                     requester_endpoints=meta.get('requester_endpoints', []),
                     requester_keys=meta.get('requester_keys', {}),
                     from_peer=message.from_peer,
+                    allow_cross_mesh=bool(meta.get('allow_cross_mesh')),
                 )
             except Exception as e:
                 logger.error(f"Error handling broker intro: {e}", exc_info=True)
@@ -2251,7 +2253,8 @@ class MessageRouter:
 
     async def send_broker_request(self, to_peer: str, target_peer: str,
                                    requester_endpoints: List[str],
-                                   requester_keys: Dict[str, str]) -> bool:
+                                  requester_keys: Dict[str, str],
+                                  allow_cross_mesh: bool = False) -> bool:
         """Ask a connected peer to broker a connection to target_peer."""
         payload = {
             'content': '',
@@ -2260,6 +2263,7 @@ class MessageRouter:
                 'target_peer': target_peer,
                 'requester_endpoints': requester_endpoints,
                 'requester_keys': requester_keys,
+                'allow_cross_mesh': bool(allow_cross_mesh),
             }
         }
         message = self.create_message(MessageType.BROKER_REQUEST, to_peer, payload, ttl=2)
@@ -2269,7 +2273,8 @@ class MessageRouter:
     async def send_broker_intro(self, to_peer: str,
                                  requester_peer_id: str,
                                  requester_endpoints: List[str],
-                                 requester_keys: Dict[str, str]) -> bool:
+                                 requester_keys: Dict[str, str],
+                                 allow_cross_mesh: bool = False) -> bool:
         """Forward a broker introduction to the target peer."""
         payload = {
             'content': '',
@@ -2278,6 +2283,7 @@ class MessageRouter:
                 'requester_peer_id': requester_peer_id,
                 'requester_endpoints': requester_endpoints,
                 'requester_keys': requester_keys,
+                'allow_cross_mesh': bool(allow_cross_mesh),
             }
         }
         message = self.create_message(MessageType.BROKER_INTRO, to_peer, payload, ttl=2)

--- a/canopy/ui/routes.py
+++ b/canopy/ui/routes.py
@@ -21,6 +21,7 @@ import socket
 import signal
 import ipaddress
 import sqlite3
+import ssl
 import tempfile
 import html as html_lib
 import threading
@@ -267,6 +268,69 @@ def _current_invite_peer_label(
         except Exception:
             pass
     return str(fallback_device_label or '').strip()
+
+
+def _transport_security_status(
+    p2p_manager: Any,
+    advertised_endpoints: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Return UI-safe transport security diagnostics for the active mesh listener."""
+    from ..network.invite import classify_invite_endpoints
+
+    endpoints = [
+        str(endpoint or '').strip()
+        for endpoint in (advertised_endpoints or [])
+        if str(endpoint or '').strip()
+    ]
+    classification = classify_invite_endpoints(endpoints)
+    conn_mgr = getattr(p2p_manager, 'connection_manager', None) if p2p_manager else None
+    if conn_mgr and hasattr(conn_mgr, 'get_transport_security_status'):
+        try:
+            status = dict(conn_mgr.get_transport_security_status(advertised_endpoints=endpoints) or {})
+            status.update(classification)
+            decorator = getattr(p2p_manager, '_decorate_transport_security_status', None) if p2p_manager else None
+            if callable(decorator) and getattr(decorator, '__self__', None) is p2p_manager:
+                status = dict(decorator(status) or status)
+            return status
+        except Exception:
+            logger.debug("Could not load connection-manager transport security status", exc_info=True)
+    if p2p_manager and hasattr(p2p_manager, 'get_transport_security_status'):
+        try:
+            status = dict(p2p_manager.get_transport_security_status() or {})
+            if endpoints:
+                status['advertised_endpoints'] = endpoints
+                status['advertised_secure_count'] = sum(1 for ep in endpoints if ep.lower().startswith('wss://'))
+                status['advertised_plain_count'] = sum(1 for ep in endpoints if ep.lower().startswith('ws://'))
+            status.update(classification)
+            return status
+        except Exception:
+            logger.debug("Could not load P2P transport security status", exc_info=True)
+    secure_count = sum(1 for ep in endpoints if ep.lower().startswith('wss://'))
+    plain_count = sum(1 for ep in endpoints if ep.lower().startswith('ws://'))
+    return {
+        'mesh_scheme': 'ws',
+        'tls_enabled': False,
+        'transport_label': 'Plain WebSocket (ws)',
+        'listener_endpoint': '',
+        'tls_cert_mode': 'disabled',
+        'tls_cert_path_present': False,
+        'tls_key_path_present': False,
+        'client_verification_mode': 'permissive',
+        'advertised_endpoints': endpoints,
+        'advertised_secure_count': secure_count,
+        'advertised_plain_count': plain_count,
+        'explicit_wss_downgrade_allowed': False,
+        'warnings': ['P2P transport security status is unavailable.'],
+        **classification,
+    }
+
+
+def _live_invite_endpoint_scheme(config: Any, p2p_manager: Any) -> str:
+    """Return the current listener scheme for truthful invite generation."""
+    conn_mgr = getattr(p2p_manager, 'connection_manager', None) if p2p_manager else None
+    if conn_mgr is not None:
+        return 'wss' if bool(getattr(conn_mgr, 'enable_tls', False)) else 'ws'
+    return 'wss' if bool(getattr(getattr(config, 'network', None), 'enable_tls', False)) else 'ws'
 
 
 def _current_meshspace_default_agent_permissions() -> list[str]:
@@ -5995,7 +6059,11 @@ def create_ui_blueprint() -> Blueprint:
                             connect_coro = connect_to_endpoint(p2p_manager, peer_id, ep)
                         else:
                             connect_coro = connection_manager.connect_to_peer(
-                                peer_id, host, port, scheme=scheme
+                                peer_id,
+                                host,
+                                port,
+                                scheme=scheme,
+                                scheme_explicit=str(ep or '').strip().lower().startswith('wss://'),
                             )
                         future = asyncio.run_coroutine_threadsafe(
                             connect_coro,
@@ -8334,13 +8402,180 @@ def create_ui_blueprint() -> Blueprint:
         return redirect(url_for('ui.admin_page'))
 
     # Admin — user/agent management (instance owner only)
+    def _validate_tls_cert_chain(cert_path: str, key_path: str) -> None:
+        cert = Path(str(cert_path or '').strip()).expanduser()
+        key = Path(str(key_path or '').strip()).expanduser()
+        if not cert.exists() or not cert.is_file():
+            raise ValueError('Certificate file not found')
+        if not key.exists() or not key.is_file():
+            raise ValueError('Private key file not found')
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        try:
+            ctx.load_cert_chain(str(cert), str(key))
+        except Exception as exc:
+            raise ValueError(f'Certificate and key could not be loaded: {exc}') from exc
+
+    def _transport_security_admin_status(config: Any, p2p_manager: Any) -> dict[str, Any]:
+        from ..core.config import load_transport_security_settings, transport_security_config_path
+
+        settings = load_transport_security_settings(config) if config else {}
+        if p2p_manager and hasattr(p2p_manager, 'get_transport_security_status'):
+            try:
+                status = dict(p2p_manager.get_transport_security_status() or {})
+            except Exception:
+                status = _transport_security_status(p2p_manager, [])
+        else:
+            status = _transport_security_status(p2p_manager, [])
+
+        network = getattr(config, 'network', None)
+        mode = str(
+            status.get('transport_security_mode')
+            or getattr(network, 'transport_security_mode', '')
+            or settings.get('mode')
+            or ''
+        ).strip().lower()
+        if mode not in {'disabled', 'self_signed', 'provided', 'external_terminator'}:
+            if str(getattr(network, 'external_tls_endpoint', '') or '').strip():
+                mode = 'external_terminator'
+            elif bool(getattr(network, 'enable_tls', False)):
+                live_mode = str(status.get('tls_cert_mode') or '').strip().lower()
+                mode = live_mode if live_mode in {'self_signed', 'provided'} else 'provided'
+            else:
+                mode = 'disabled'
+        labels = {
+            'disabled': 'Disabled',
+            'self_signed': 'Self-signed local TLS',
+            'provided': 'Provided certificate',
+            'external_terminator': 'External TLS terminator',
+        }
+        conn_mgr = getattr(p2p_manager, 'connection_manager', None) if p2p_manager else None
+        configured_tls = bool(getattr(network, 'enable_tls', False))
+        live_tls = bool(status.get('tls_enabled'))
+        configured_verification_mode = (
+            'verified' if bool(getattr(network, 'require_verified_wss', False)) else 'permissive'
+        )
+        live_verification_mode = str(
+            status.get('client_verification_mode') or configured_verification_mode or 'permissive'
+        ).strip().lower() or 'permissive'
+        restart_required = configured_tls != live_tls
+        configured_cert = str(getattr(network, 'tls_cert_path', '') or '').strip()
+        configured_key = str(getattr(network, 'tls_key_path', '') or '').strip()
+        if configured_tls and conn_mgr:
+            live_cert = str(getattr(conn_mgr, 'tls_cert_path', '') or '').strip()
+            live_key = str(getattr(conn_mgr, 'tls_key_path', '') or '').strip()
+            if configured_cert and live_cert and Path(configured_cert).expanduser() != Path(live_cert).expanduser():
+                restart_required = True
+            if configured_key and live_key and Path(configured_key).expanduser() != Path(live_key).expanduser():
+                restart_required = True
+        if configured_verification_mode != live_verification_mode:
+            restart_required = True
+        external_endpoint = str(
+            getattr(network, 'external_tls_endpoint', '')
+            or settings.get('external_tls_endpoint')
+            or status.get('external_tls_endpoint')
+            or ''
+        ).strip()
+        external_declared = bool(mode == 'external_terminator' and external_endpoint.lower().startswith('wss://'))
+        secure_invite_ready = (not restart_required) and (bool(live_tls) or external_declared)
+        warnings = [
+            str(item).strip()
+            for item in (status.get('warnings') or [])
+            if str(item).strip()
+        ]
+        if configured_verification_mode != live_verification_mode:
+            warnings.append(
+                'Outbound certificate verification mode has changed and will apply after restart.'
+            )
+        verification_display = live_verification_mode
+        if configured_verification_mode != live_verification_mode:
+            verification_display = (
+                f"{live_verification_mode} (restart pending: {configured_verification_mode} configured)"
+            )
+        if restart_required:
+            readiness_label = 'Restart required'
+            readiness_detail = 'Transport settings are saved, but the running mesh listener has not restarted into the requested mode yet.'
+        elif secure_invite_ready and live_tls:
+            readiness_label = 'Ready: local listener is wss://'
+            readiness_detail = 'Generated invites can advertise secure Canopy-owned listener endpoints.'
+        elif secure_invite_ready and external_declared:
+            readiness_label = 'Ready: external TLS terminator declared'
+            readiness_detail = 'Generated invites can advertise the configured public wss:// proxy endpoint.'
+        else:
+            readiness_label = 'Not ready for secure public invites'
+            readiness_detail = 'Use local TLS or declare an external TLS terminator before advertising public wss://.'
+
+        restart_url = ''
+        current_meshspace_id = str(getattr(getattr(config, 'meshspace', None), 'meshspace_id', '') or '').strip()
+        if current_meshspace_id:
+            try:
+                restart_url = url_for('ui.meshspace_restart', meshspace_id=current_meshspace_id)
+            except Exception:
+                restart_url = ''
+
+        status.update({
+            'success': True,
+            'mode': mode,
+            'mode_label': labels.get(mode, 'Disabled'),
+            'settings': settings,
+            'config_path': str(transport_security_config_path(config)) if config else '',
+            'configured_tls_enabled': configured_tls,
+            'configured_tls_cert_path': configured_cert,
+            'configured_tls_key_path': configured_key,
+            'configured_client_verification_mode': configured_verification_mode,
+            'live_client_verification_mode': live_verification_mode,
+            'verification_display': verification_display,
+            'external_tls_endpoint': external_endpoint,
+            'external_tls_terminator_declared': external_declared,
+            'secure_invite_ready': secure_invite_ready,
+            'invite_readiness_label': readiness_label,
+            'invite_readiness_detail': readiness_detail,
+            'restart_required': restart_required,
+            'restart_url': restart_url,
+            'warnings': warnings,
+        })
+        return status
+
+    def _persist_transport_security_settings(settings: dict[str, Any]) -> dict[str, Any]:
+        from ..core.config import apply_transport_security_settings, save_transport_security_settings
+
+        config = current_app.config.get('CANOPY_CONFIG')
+        if not config:
+            raise RuntimeError('Canopy config is unavailable')
+        path = save_transport_security_settings(config, settings)
+        normalized = apply_transport_security_settings(config, settings, env_overrides={})
+        p2p_manager = current_app.config.get('P2P_MANAGER')
+        remember_operator = getattr(p2p_manager, 'remember_operator_advertised_endpoint', None) if p2p_manager else None
+        if callable(remember_operator):
+            try:
+                if normalized.get('mode') == 'external_terminator':
+                    remember_operator(external_endpoint=normalized.get('external_tls_endpoint'))
+                else:
+                    remember_operator()
+            except Exception:
+                logger.debug("Could not update live advertised transport endpoint", exc_info=True)
+        return {
+            'settings': normalized,
+            'config_path': str(path),
+            'status': _transport_security_admin_status(config, p2p_manager),
+        }
+
+    def _transport_payload_bool(value: Any, default: bool = False) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        text = str(value).strip().lower()
+        if not text:
+            return default
+        return text in {'1', 'true', 'yes', 'on'}
+
     @ui.route('/admin')
     @require_login
     @require_admin
     def admin_page():
         """Admin page: pending agent approvals, all users, approve/suspend/delete."""
         try:
-            db_manager, api_key_manager, _, _, _, _, _, _, _, config, _ = _get_app_components_any(current_app)
+            db_manager, api_key_manager, _, _, _, _, _, _, _, config, p2p_manager = _get_app_components_any(current_app)
             from .. import __version__ as canopy_version
             users = db_manager.get_all_users_for_admin()
             _annotate_user_presence(users, db_manager)
@@ -8427,6 +8662,7 @@ def create_ui_blueprint() -> Blueprint:
             all_permissions = [p.value for p in api_key_manager.get_all_permissions()]
             current_meshspace = _current_meshspace_record()
             default_permissions = _current_meshspace_default_agent_permissions()
+            transport_security_admin = _transport_security_admin_status(config, p2p_manager)
 
             return render_template('admin.html',
                                  users=users,
@@ -8447,6 +8683,7 @@ def create_ui_blueprint() -> Blueprint:
                                  workspace_users=workspace_users,
                                  remote_shadow_duplicate_groups=remote_shadow_duplicate_groups,
                                  cross_peer_same_name_groups=cross_peer_same_name_groups,
+                                 transport_security_admin=transport_security_admin,
                                  directive_presets=_agent_directive_presets_payload(),
                                  directive_max_length=MAX_AGENT_DIRECTIVES_LENGTH,
                                  user_id=get_current_user())
@@ -8495,9 +8732,13 @@ def create_ui_blueprint() -> Blueprint:
 
             if p2p_manager and p2p_manager.identity_manager.local_identity:
                 mesh_port = config.network.mesh_port if config else 7771
+                configured_external_endpoint = str(getattr(getattr(config, 'network', None), 'external_tls_endpoint', '') or '').strip()
+                endpoint_scheme = _live_invite_endpoint_scheme(config, p2p_manager)
                 invite = generate_invite(
                     p2p_manager.identity_manager,
                     mesh_port,
+                    external_endpoint=configured_external_endpoint or None,
+                    endpoint_scheme=endpoint_scheme,
                     mesh_name=current_mesh_name,
                     meshspace_id=current_meshspace_id or None,
                     meshspace_id_aliases=list(current_mesh_hint.get('meshspace_id_aliases') or []) or None,
@@ -8509,18 +8750,35 @@ def create_ui_blueprint() -> Blueprint:
                 invite_code = invite.encode()
                 peer_id = invite.peer_id
                 endpoints = invite.endpoints
+            transport_security = _transport_security_status(p2p_manager, list(endpoints or []))
 
             # Connected / discovered peers
             connected_peers = p2p_manager.get_connected_peers() if p2p_manager else []
             discovered_peers = p2p_manager.get_discovered_peers() if p2p_manager else []
+            peer_active_transports: dict[str, dict[str, Any]] = {}
+            get_active_transport = getattr(p2p_manager, 'get_peer_active_transport', None) if p2p_manager else None
+            if callable(get_active_transport):
+                for pid in connected_peers:
+                    try:
+                        peer_active_transports[pid] = dict(get_active_transport(pid) or {})
+                    except Exception:
+                        peer_active_transports[pid] = {}
 
             # Peers introduced by contacts
-            introduced_peers = p2p_manager.get_introduced_peers() if p2p_manager else []
+            introduced_peer_rows = p2p_manager.get_introduced_peers() if p2p_manager else []
             if p2p_manager and hasattr(p2p_manager, 'get_peer_public_identity'):
-                for entry in introduced_peers:
+                for entry in introduced_peer_rows:
                     pid = entry.get('peer_id') if isinstance(entry, dict) else None
                     if pid:
                         entry['public_identity'] = p2p_manager.get_peer_public_identity(pid)
+            introduced_meshspace_candidates = [
+                entry for entry in introduced_peer_rows
+                if isinstance(entry, dict) and entry.get('requires_explicit_meshspace_connect')
+            ]
+            introduced_peers = [
+                entry for entry in introduced_peer_rows
+                if not (isinstance(entry, dict) and entry.get('requires_explicit_meshspace_connect'))
+            ]
 
             # Relay status
             relay_status = p2p_manager.get_relay_status() if p2p_manager else {}
@@ -8566,6 +8824,7 @@ def create_ui_blueprint() -> Blueprint:
                         connection_type = 'direct'
                     elif pid in relayed_set:
                         connection_type = 'relayed'
+                    active_transport = peer_active_transports.get(pid, {}) if pid in connected_set else {}
                     public_identity = {}
                     if hasattr(p2p_manager, 'get_peer_public_identity'):
                         try:
@@ -8587,6 +8846,10 @@ def create_ui_blueprint() -> Blueprint:
                         'connected': connection_type in {'direct', 'relayed'},
                         'connection_type': connection_type,
                         'relay_via': active_relays.get(pid),
+                        'active_endpoint': str(active_transport.get('active_endpoint') or ''),
+                        'active_transport': str(active_transport.get('active_transport') or ''),
+                        'active_transport_label': str(active_transport.get('active_transport_label') or ''),
+                        'active_transport_secure': bool(active_transport.get('active_transport_secure')),
                     })
 
             # Device profiles for peer identification
@@ -8614,7 +8877,7 @@ def create_ui_blueprint() -> Blueprint:
             if trust_manager:
                 all_peer_ids = set(connected_peers)
                 all_peer_ids.update(p.get('peer_id', '') for p in known_peers)
-                all_peer_ids.update(p.get('peer_id', '') for p in introduced_peers)
+                all_peer_ids.update(p.get('peer_id', '') for p in introduced_peer_rows)
                 for pid in all_peer_ids:
                     if pid:
                         trust_scores[pid] = trust_manager.get_trust_score(pid)
@@ -8634,7 +8897,7 @@ def create_ui_blueprint() -> Blueprint:
                     continue
                 label = peer.get('display_name') or peer_labels.get(pid) or pid
                 peer_labels[pid] = label
-            for peer in introduced_peers:
+            for peer in introduced_peer_rows:
                 pid = peer.get('peer_id')
                 if not pid:
                     continue
@@ -8649,7 +8912,7 @@ def create_ui_blueprint() -> Blueprint:
                     peer_labels[dest] = dest
                 if relay and relay not in peer_labels:
                     peer_labels[relay] = relay
-            for peer in introduced_peers:
+            for peer in introduced_peer_rows:
                 introducer = peer.get('introduced_by') if isinstance(peer, dict) else None
                 if introducer and introducer not in peer_labels:
                     peer_labels[introducer] = introducer
@@ -8677,6 +8940,7 @@ def create_ui_blueprint() -> Blueprint:
                                  invite_code=invite_code,
                                  peer_id=peer_id,
                                  endpoints=endpoints,
+                                 transport_security=transport_security,
                                  local_ips=local_ips,
                                  current_mesh_name=current_mesh_name,
                                  current_meshspace_id=current_meshspace_id,
@@ -8688,8 +8952,10 @@ def create_ui_blueprint() -> Blueprint:
                                  current_instance_label=current_instance_label,
                                  mesh_port=config.network.mesh_port if config else 7771,
                                  connected_peers=connected_peers,
+                                 peer_active_transports=peer_active_transports,
                                  discovered_peers=discovered_peers,
                                  introduced_peers=introduced_peers,
+                                 introduced_meshspace_candidates=introduced_meshspace_candidates,
                                  known_peers=known_peers,
                                  relay_status=relay_status,
                                  peer_device_profiles=peer_device_profiles,
@@ -9602,6 +9868,185 @@ def create_ui_blueprint() -> Blueprint:
         except Exception as e:
             logger.error(f"Admin list users error: {e}")
             return jsonify({'error': 'Internal server error'}), 500
+
+    @ui.route('/ajax/admin/transport-security/status', methods=['GET'])
+    @require_login
+    @require_admin
+    def ajax_admin_transport_security_status():
+        """Return admin-facing transport-security setup and invite-readiness status."""
+        try:
+            _, _, _, _, _, _, _, _, _, config, p2p_manager = _get_app_components_any(current_app)
+            return jsonify(_transport_security_admin_status(config, p2p_manager))
+        except Exception as exc:
+            logger.error("Admin transport security status error: %s", exc, exc_info=True)
+            return jsonify({'success': False, 'error': 'Transport security status unavailable'}), 500
+
+    @ui.route('/ajax/admin/transport-security/self-signed', methods=['POST'])
+    @require_login
+    @require_admin
+    def ajax_admin_transport_security_self_signed():
+        """Generate and persist node-owned self-signed local TLS settings."""
+        try:
+            _, _, _, _, _, _, _, _, _, config, _ = _get_app_components_any(current_app)
+            data = request.get_json(silent=True) or {}
+            tls_dir = Path(str(getattr(getattr(config, 'storage', None), 'data_dir', '') or '')).expanduser() / 'tls'
+            cert_path = tls_dir / 'canopy-selfsigned.crt'
+            key_path = tls_dir / 'canopy-selfsigned.key'
+            from ..network.connection import create_server_ssl_context
+
+            if not create_server_ssl_context(cert_path, key_path):
+                return jsonify({'success': False, 'error': 'Could not generate or load self-signed TLS certificate'}), 500
+            result = _persist_transport_security_settings({
+                'mode': 'self_signed',
+                'enable_tls': True,
+                'tls_cert_path': str(cert_path),
+                'tls_key_path': str(key_path),
+                'require_verified_wss': _transport_payload_bool(data.get('require_verified_wss'), False),
+                'external_tls_endpoint': '',
+                'updated_at': datetime.now(timezone.utc).isoformat(),
+            })
+            return jsonify({
+                'success': True,
+                'message': 'Self-signed TLS settings saved. Restart this meshspace to activate wss://.',
+                **result,
+            })
+        except Exception as exc:
+            logger.error("Admin self-signed TLS setup error: %s", exc, exc_info=True)
+            return jsonify({'success': False, 'error': 'Self-signed TLS setup failed'}), 500
+
+    @ui.route('/ajax/admin/transport-security/certificate', methods=['POST'])
+    @require_login
+    @require_admin
+    def ajax_admin_transport_security_certificate():
+        """Persist provided certificate/key paths after validating they load."""
+        try:
+            data = request.get_json(silent=True) or {}
+            cert_path = str(data.get('cert_path') or '').strip()
+            key_path = str(data.get('key_path') or '').strip()
+            if not cert_path or not key_path:
+                return jsonify({'success': False, 'error': 'cert_path and key_path are required'}), 400
+            _validate_tls_cert_chain(cert_path, key_path)
+            result = _persist_transport_security_settings({
+                'mode': 'provided',
+                'enable_tls': True,
+                'tls_cert_path': str(Path(cert_path).expanduser()),
+                'tls_key_path': str(Path(key_path).expanduser()),
+                'require_verified_wss': _transport_payload_bool(data.get('require_verified_wss'), False),
+                'external_tls_endpoint': '',
+                'updated_at': datetime.now(timezone.utc).isoformat(),
+            })
+            return jsonify({
+                'success': True,
+                'message': 'Certificate settings saved. Restart this meshspace to activate wss://.',
+                **result,
+            })
+        except ValueError as exc:
+            return jsonify({'success': False, 'error': str(exc)}), 400
+        except Exception as exc:
+            logger.error("Admin provided TLS setup error: %s", exc, exc_info=True)
+            return jsonify({'success': False, 'error': 'Certificate setup failed'}), 500
+
+    @ui.route('/ajax/admin/transport-security/external', methods=['POST'])
+    @require_login
+    @require_admin
+    def ajax_admin_transport_security_external():
+        """Persist external TLS terminator mode for public wss:// advertising."""
+        try:
+            data = request.get_json(silent=True) or {}
+            raw_endpoint = str(data.get('external_tls_endpoint') or '').strip()
+            from ..network.invite import canonicalize_invite_endpoint, parse_invite_endpoint
+
+            endpoint = canonicalize_invite_endpoint(raw_endpoint)
+            parsed = parse_invite_endpoint(endpoint) if endpoint else None
+            if not parsed or parsed[2] != 'wss':
+                return jsonify({'success': False, 'error': 'External TLS endpoint must be a valid wss:// host:port endpoint'}), 400
+            result = _persist_transport_security_settings({
+                'mode': 'external_terminator',
+                'enable_tls': False,
+                'tls_cert_path': '',
+                'tls_key_path': '',
+                'require_verified_wss': _transport_payload_bool(data.get('require_verified_wss'), False),
+                'external_tls_endpoint': endpoint,
+                'updated_at': datetime.now(timezone.utc).isoformat(),
+            })
+            return jsonify({
+                'success': True,
+                'message': 'External TLS terminator saved. New invites will advertise the configured wss:// endpoint.',
+                **result,
+            })
+        except Exception as exc:
+            logger.error("Admin external TLS setup error: %s", exc, exc_info=True)
+            return jsonify({'success': False, 'error': 'External TLS terminator setup failed'}), 500
+
+    @ui.route('/ajax/admin/transport-security/disable', methods=['POST'])
+    @require_login
+    @require_admin
+    def ajax_admin_transport_security_disable():
+        """Disable local TLS/external terminator settings for this meshspace."""
+        try:
+            result = _persist_transport_security_settings({
+                'mode': 'disabled',
+                'enable_tls': False,
+                'tls_cert_path': '',
+                'tls_key_path': '',
+                'require_verified_wss': False,
+                'external_tls_endpoint': '',
+                'updated_at': datetime.now(timezone.utc).isoformat(),
+            })
+            return jsonify({
+                'success': True,
+                'message': 'Transport security disabled. Restart if the current listener is still wss://.',
+                **result,
+            })
+        except Exception as exc:
+            logger.error("Admin transport disable error: %s", exc, exc_info=True)
+            return jsonify({'success': False, 'error': 'Could not disable transport security'}), 500
+
+    @ui.route('/ajax/admin/transport-security/restart', methods=['POST'])
+    @require_login
+    @require_admin
+    def ajax_admin_transport_security_restart():
+        """Restart the current meshspace runtime after transport settings change."""
+        try:
+            config = current_app.config.get('CANOPY_CONFIG')
+            if not config:
+                return jsonify({'success': False, 'error': 'Canopy config unavailable'}), 503
+            env_map = build_runtime_environment_from_config(config)
+            schedule_self_restart(
+                env_map,
+                cwd=str(Path(__file__).resolve().parents[2]),
+                parent_pid=os.getpid(),
+                delay_seconds=0.9,
+            )
+            manager = _get_meshspace_registry_manager()
+            current_mid = str(getattr(getattr(config, 'meshspace', None), 'meshspace_id', '') or '').strip()
+            if manager and current_mid:
+                peer_id = ''
+                p2p_manager = current_app.config.get('P2P_MANAGER')
+                if p2p_manager:
+                    try:
+                        peer_id = str(p2p_manager.get_peer_id() or '').strip()
+                    except Exception:
+                        peer_id = ''
+                updated = manager.update_runtime_state(current_mid, 'starting', peer_id=peer_id)
+                if updated:
+                    current_app.config['MESHSPACE_RECORD'] = dict(updated)
+
+            def _terminate_current_runtime() -> None:
+                time.sleep(0.45)
+                try:
+                    os.kill(os.getpid(), signal.SIGTERM)
+                except Exception:
+                    logger.warning("Failed to terminate current meshspace process during transport restart", exc_info=True)
+
+            threading.Thread(target=_terminate_current_runtime, daemon=True).start()
+            return jsonify({
+                'success': True,
+                'message': 'Restart scheduled. This page will reconnect after the meshspace comes back up.',
+            })
+        except Exception as exc:
+            logger.error("Admin transport restart error: %s", exc, exc_info=True)
+            return jsonify({'success': False, 'error': 'Restart failed'}), 500
 
     @ui.route('/ajax/admin/users/<user_id>/repair-shadow-duplicates', methods=['POST'])
     @require_login
@@ -20387,6 +20832,30 @@ def create_ui_blueprint() -> Blueprint:
                     except Exception:
                         reconnect_scheduled = True
                 discovered_entry = discovered_by_peer.get(peer_id, {})
+                active_endpoint = next(
+                    (
+                        str(item.get('endpoint') or '').strip()
+                        for item in endpoint_details
+                        if item.get('currently_connected') and str(item.get('endpoint') or '').strip()
+                    ),
+                    '',
+                )
+                if not active_endpoint and conn is not None:
+                    active_endpoint = str(getattr(conn, 'endpoint_uri', '') or '').strip()
+                active_transport = ''
+                if active_endpoint:
+                    try:
+                        from ..network.invite import parse_invite_endpoint
+
+                        parsed_active = parse_invite_endpoint(active_endpoint)
+                        if parsed_active:
+                            active_transport = parsed_active[2]
+                    except Exception:
+                        active_transport = ''
+                active_transport_label = {
+                    'wss': 'Secure WebSocket (wss)',
+                    'ws': 'Plain WebSocket (ws)',
+                }.get(active_transport, 'Relayed' if is_relayed else 'Unknown')
                 peers.append({
                     'peer_id': peer_id,
                     'display_name': im.peer_display_names.get(peer_id, ''),
@@ -20396,6 +20865,10 @@ def create_ui_blueprint() -> Blueprint:
                     'latency_ms': latency_ms,
                     'connected_at': conn.connected_at if conn else None,
                     'last_activity': conn.last_activity if conn else None,
+                    'active_endpoint': active_endpoint,
+                    'active_transport': active_transport,
+                    'active_transport_label': active_transport_label,
+                    'active_transport_secure': active_transport == 'wss',
                     'endpoints': [item.get('endpoint') for item in endpoint_details if item.get('endpoint')],
                     'endpoint_details': endpoint_details,
                     'discovered': bool(discovered_entry),
@@ -20424,10 +20897,18 @@ def create_ui_blueprint() -> Blueprint:
             relay_status = p2p_manager.get_relay_status() if p2p_manager else {}
             local_endpoints: list[str] = []
             try:
-                invite = generate_invite(im, mesh_port)
+                configured_external_endpoint = str(getattr(getattr(config, 'network', None), 'external_tls_endpoint', '') or '').strip()
+                endpoint_scheme = _live_invite_endpoint_scheme(config, p2p_manager)
+                invite = generate_invite(
+                    im,
+                    mesh_port,
+                    external_endpoint=configured_external_endpoint or None,
+                    endpoint_scheme=endpoint_scheme,
+                )
                 local_endpoints = list(invite.endpoints)
             except Exception:
                 pass
+            transport_security = _transport_security_status(p2p_manager, local_endpoints)
 
             return jsonify({
                 'success': True,
@@ -20437,6 +20918,7 @@ def create_ui_blueprint() -> Blueprint:
                     'mesh_port': mesh_port,
                     'endpoints': local_endpoints,
                     'relay_policy': relay_status.get('relay_policy', 'broker_only'),
+                    'transport_security': transport_security,
                 },
             })
         except Exception as e:

--- a/canopy/ui/static/js/canopy-main.js
+++ b/canopy/ui/static/js/canopy-main.js
@@ -550,15 +550,26 @@
             return window.canopyPeerDisplayName ? window.canopyPeerDisplayName(peerId) : (peerId || '').slice(0, 12);
         }
 
+        function sidebarPeerTrustHref(peerId) {
+            const routes = (window.CANOPY_VARS && window.CANOPY_VARS.urls) || {};
+            const base = routes.trustNetwork || '/trust';
+            const cleanPeerId = String(peerId || '').trim();
+            if (!cleanPeerId) return base;
+            return `${base}#trust-peer-${encodeURIComponent(cleanPeerId)}`;
+        }
+
         function createSidebarPeerElement(peerRecord) {
             const peerId = (peerRecord && peerRecord.peerId) ? peerRecord.peerId : peerRecord;
             const displayName = (peerRecord && peerRecord.displayName)
                 ? peerRecord.displayName
                 : (sidebarPeerDisplayName(peerId) || (peerId || '').slice(0, 12));
             const trustMeta = canopyPeerTrustMeta(peerId);
-            const peerEl = document.createElement('div');
+            const peerEl = document.createElement('a');
             peerEl.className = 'sidebar-peer';
             peerEl.setAttribute('data-peer-id', peerId);
+            peerEl.href = sidebarPeerTrustHref(peerId);
+            peerEl.title = `Open ${displayName} in Trust Network`;
+            peerEl.setAttribute('aria-label', `Open ${displayName} in Trust Network`);
 
             const avatarWrap = document.createElement('div');
             avatarWrap.className = 'sidebar-peer-avatar';
@@ -5570,7 +5581,9 @@
                     btn.setAttribute('data-filter-key', def.key);
                     btn.setAttribute('aria-pressed', filters[def.key] !== false ? 'true' : 'false');
                     btn.innerHTML = `<i class="bi ${def.icon}"></i><span>${def.label}</span>`;
-                    btn.addEventListener('click', () => {
+                    btn.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
                         const next = normalizeCanopyAttentionFilters(canopySidebarAttentionState.filters);
                         next[def.key] = !(next[def.key] !== false);
                         saveCanopyAttentionFilters(next);
@@ -5725,7 +5738,9 @@
             }
 
             if (filterResetBtn) {
-                filterResetBtn.addEventListener('click', () => {
+                filterResetBtn.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
                     saveCanopyAttentionFilters(null);
                     renderFilterBar();
                     if (window.renderCanopyAttentionBell) {

--- a/canopy/ui/templates/admin.html
+++ b/canopy/ui/templates/admin.html
@@ -456,11 +456,12 @@
 .admin-section-agent-template { order: 3; }
 .admin-section-agent-ops { order: 4; }
 .admin-section-instance { order: 5; }
-.admin-section-users-secondary { order: 6; }
-.admin-section-relay { order: 7; }
-.admin-section-attachments { order: 8; }
-.admin-section-data { order: 9; }
-.admin-section-environment { order: 10; }
+.admin-section-transport { order: 6; }
+.admin-section-users-secondary { order: 7; }
+.admin-section-relay { order: 8; }
+.admin-section-attachments { order: 9; }
+.admin-section-data { order: 10; }
+.admin-section-environment { order: 11; }
 
 .admin-summary-row {
     --bs-gutter-y: 0.75rem;
@@ -494,6 +495,51 @@
 .meshspace-template-summary {
     font-size: 0.82rem;
     color: #9fb2cf;
+}
+
+.transport-admin-shell {
+    border: 1px solid rgba(75, 208, 166, 0.22);
+    background: linear-gradient(145deg, rgba(12, 42, 38, 0.82), rgba(10, 20, 36, 0.84));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.transport-kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.6rem;
+}
+
+.transport-kpi {
+    border: 1px solid rgba(139, 171, 222, 0.2);
+    border-radius: 12px;
+    background: rgba(7, 17, 32, 0.68);
+    padding: 0.65rem 0.75rem;
+}
+
+.transport-kpi-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #8fa6c9;
+}
+
+.transport-kpi-value {
+    margin-top: 0.15rem;
+    font-weight: 700;
+    color: var(--canopy-text-primary);
+    word-break: break-word;
+}
+
+.transport-mode-card {
+    height: 100%;
+    border: 1px solid rgba(139, 171, 222, 0.2);
+    border-radius: 14px;
+    background: rgba(8, 19, 35, 0.7);
+    padding: 0.85rem;
+}
+
+.transport-mode-card .form-control {
+    min-width: 0;
 }
 
 .keys-new-key-row {
@@ -996,6 +1042,101 @@
             <button type="button" class="btn btn-outline-info btn-sm" id="transfer-admin-btn">Transfer</button>
         </div>
         <div id="transfer-message" class="small mt-2 text-danger" style="display: none;"></div>
+    </div>
+</div>
+
+{% set ts = transport_security_admin or {} %}
+<div class="card mb-4 transport-admin-shell admin-section-transport" id="transportSecurityAdminCard" data-initial-status='{{ ts|tojson|safe }}'>
+    <div class="card-header bg-success bg-opacity-10">
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+            <div>
+                <h5 class="mb-0"><i class="bi bi-shield-check"></i> Transport Security</h5>
+                <div class="small text-muted">Configure how this meshspace advertises secure public WebSocket transport.</div>
+            </div>
+            <span class="badge {% if ts.get('secure_invite_ready') %}bg-success{% elif ts.get('restart_required') %}bg-warning text-dark{% else %}bg-secondary{% endif %}" id="transportInviteBadge">
+                {{ ts.get('invite_readiness_label') or 'Loading...' }}
+            </span>
+        </div>
+    </div>
+    <div class="card-body">
+        <div class="transport-kpi-grid mb-3">
+            <div class="transport-kpi">
+                <div class="transport-kpi-label">Listener</div>
+                <div class="transport-kpi-value font-monospace small" id="transportListenerValue">{{ ts.get('listener_endpoint') or '-' }}</div>
+            </div>
+            <div class="transport-kpi">
+                <div class="transport-kpi-label">TLS mode</div>
+                <div class="transport-kpi-value" id="transportModeValue">{{ ts.get('mode_label') or ts.get('transport_security_mode_label') or 'Disabled' }}</div>
+            </div>
+            <div class="transport-kpi">
+                <div class="transport-kpi-label">Verification</div>
+                <div class="transport-kpi-value" id="transportVerifyValue">{{ ts.get('verification_display') or ts.get('client_verification_mode') or 'permissive' }}</div>
+            </div>
+            <div class="transport-kpi">
+                <div class="transport-kpi-label">Recommended</div>
+                <div class="transport-kpi-value font-monospace small" id="transportRecommendedValue">{{ ts.get('recommended_endpoint') or '-' }}</div>
+            </div>
+        </div>
+
+        <div class="alert {% if ts.get('secure_invite_ready') %}alert-success{% elif ts.get('restart_required') %}alert-warning{% else %}alert-secondary{% endif %} py-2" id="transportReadinessAlert">
+            <div class="fw-semibold" id="transportReadinessTitle">{{ ts.get('invite_readiness_label') or 'Transport status loading' }}</div>
+            <div class="small" id="transportReadinessDetail">{{ ts.get('invite_readiness_detail') or '' }}</div>
+        </div>
+
+        <div class="row g-3">
+            <div class="col-lg-4">
+                <div class="transport-mode-card">
+                    <div class="d-flex justify-content-between align-items-start gap-2 mb-2">
+                        <div>
+                            <h6 class="mb-1">Self-signed TLS</h6>
+                            <div class="small text-muted">Fastest path for testing or controlled meshes.</div>
+                        </div>
+                        <i class="bi bi-lightning-charge text-success"></i>
+                    </div>
+                    <button type="button" class="btn btn-success btn-sm w-100" id="transportSelfSignedBtn">
+                        Enable self-signed TLS
+                    </button>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="transport-mode-card">
+                    <h6 class="mb-2">Certificate files</h6>
+                    <input type="text" class="form-control form-control-sm mb-2" id="transportCertPath" placeholder="/path/to/fullchain.pem" value="{{ ts.get('configured_tls_cert_path') or '' }}">
+                    <input type="text" class="form-control form-control-sm mb-2" id="transportKeyPath" placeholder="/path/to/privkey.pem" value="{{ ts.get('configured_tls_key_path') or '' }}">
+                    <button type="button" class="btn btn-outline-success btn-sm w-100" id="transportProvidedCertBtn">
+                        Use certificate files
+                    </button>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="transport-mode-card">
+                    <h6 class="mb-2">External TLS terminator</h6>
+                    <input type="text" class="form-control form-control-sm mb-2" id="transportExternalEndpoint" placeholder="wss://mesh.example.com:443" value="{{ ts.get('external_tls_endpoint') or '' }}">
+                    <button type="button" class="btn btn-outline-info btn-sm w-100" id="transportExternalBtn">
+                        Advertise external wss://
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-3">
+            <div class="small text-muted">
+                Settings file: <code id="transportConfigPath">{{ ts.get('config_path') or '-' }}</code>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                <div class="form-check form-switch d-flex align-items-center gap-1 me-2">
+                    <input class="form-check-input" type="checkbox" role="switch" id="transportRequireVerifiedWss" {% if (ts.get('configured_client_verification_mode') or ts.get('client_verification_mode')) == 'verified' %}checked{% endif %}>
+                    <label class="form-check-label small" for="transportRequireVerifiedWss">Verify outbound wss certs (applies on restart)</label>
+                </div>
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="transportRefreshBtn">Refresh</button>
+                <button type="button" class="btn btn-outline-danger btn-sm" id="transportDisableBtn">Disable</button>
+                <button type="button" class="btn btn-warning btn-sm" id="transportRestartBtn" {% if not ts.get('restart_required') %}disabled{% endif %}>
+                    Restart meshspace
+                </button>
+            </div>
+        </div>
+        <div id="transportWarnings" class="mt-2 small text-warning"></div>
+        <div id="transportAdminStatus" class="mt-2 small text-muted"></div>
     </div>
 </div>
 
@@ -3200,6 +3341,181 @@ export CANOPY_AUTO_APPROVE_AGENTS=1</code></pre>
             });
     }
 
+    function transportEscapeHtml(value) {
+        return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function setTransportText(id, value) {
+        const el = document.getElementById(id);
+        if (el) el.textContent = value || '-';
+    }
+
+    function renderTransportSecurityAdmin(status) {
+        const card = document.getElementById('transportSecurityAdminCard');
+        if (!card || !status) return;
+        setTransportText('transportListenerValue', status.listener_endpoint || '-');
+        setTransportText('transportModeValue', status.mode_label || status.transport_security_mode_label || 'Disabled');
+        setTransportText('transportVerifyValue', status.verification_display || status.client_verification_mode || 'permissive');
+        setTransportText('transportRecommendedValue', status.recommended_endpoint || '-');
+        setTransportText('transportConfigPath', status.config_path || '-');
+        setTransportText('transportReadinessTitle', status.invite_readiness_label || 'Transport status unavailable');
+        setTransportText('transportReadinessDetail', status.invite_readiness_detail || '');
+
+        const badge = document.getElementById('transportInviteBadge');
+        if (badge) {
+            badge.textContent = status.invite_readiness_label || 'Unknown';
+            badge.classList.remove('bg-success', 'bg-warning', 'bg-secondary', 'text-dark');
+            if (status.secure_invite_ready) {
+                badge.classList.add('bg-success');
+            } else if (status.restart_required) {
+                badge.classList.add('bg-warning', 'text-dark');
+            } else {
+                badge.classList.add('bg-secondary');
+            }
+        }
+
+        const alert = document.getElementById('transportReadinessAlert');
+        if (alert) {
+            alert.classList.remove('alert-success', 'alert-warning', 'alert-secondary');
+            if (status.secure_invite_ready) alert.classList.add('alert-success');
+            else if (status.restart_required) alert.classList.add('alert-warning');
+            else alert.classList.add('alert-secondary');
+        }
+
+        const certInput = document.getElementById('transportCertPath');
+        const keyInput = document.getElementById('transportKeyPath');
+        const externalInput = document.getElementById('transportExternalEndpoint');
+        if (certInput && document.activeElement !== certInput && status.configured_tls_cert_path) {
+            certInput.value = status.configured_tls_cert_path;
+        }
+        if (keyInput && document.activeElement !== keyInput && status.configured_tls_key_path) {
+            keyInput.value = status.configured_tls_key_path;
+        }
+        if (externalInput && document.activeElement !== externalInput) {
+            externalInput.value = status.external_tls_endpoint || '';
+        }
+        const verifyInput = document.getElementById('transportRequireVerifiedWss');
+        if (verifyInput) {
+            verifyInput.checked = ((status.configured_client_verification_mode || status.client_verification_mode || '').toLowerCase() === 'verified');
+        }
+
+        const restartBtn = document.getElementById('transportRestartBtn');
+        if (restartBtn) restartBtn.disabled = !status.restart_required;
+
+        const warnings = Array.isArray(status.warnings) ? status.warnings.filter(Boolean) : [];
+        const warningsEl = document.getElementById('transportWarnings');
+        if (warningsEl) {
+            warningsEl.innerHTML = warnings.length
+                ? warnings.map(item => `<div><i class="bi bi-exclamation-triangle me-1"></i>${transportEscapeHtml(item)}</div>`).join('')
+                : '';
+        }
+        const statusLine = document.getElementById('transportAdminStatus');
+        if (statusLine) {
+            const mode = status.mode_label || status.transport_security_mode_label || 'Disabled';
+            const restart = status.restart_required ? 'Restart required.' : 'No restart pending.';
+            statusLine.textContent = `${mode}. ${restart}`;
+        }
+    }
+
+    async function loadTransportSecurityStatus() {
+        const card = document.getElementById('transportSecurityAdminCard');
+        if (!card) return;
+        try {
+            const { ok, data } = await api('GET', '/ajax/admin/transport-security/status');
+            if (ok && data && data.success !== false) {
+                renderTransportSecurityAdmin(data);
+            }
+        } catch (_) {
+            const statusLine = document.getElementById('transportAdminStatus');
+            if (statusLine) statusLine.textContent = 'Transport status unavailable.';
+        }
+    }
+
+    async function postTransportSecurityAction(buttonId, url, body, busyLabel) {
+        setButtonBusy(buttonId, true, busyLabel || '<i class="bi bi-hourglass-split"></i> Saving...');
+        try {
+            const { ok, data } = await api('POST', url, body || {});
+            if (!ok || !data.success) {
+                throw new Error(data.error || data.message || 'Transport security update failed');
+            }
+            renderTransportSecurityAdmin(data.status || data);
+            showAlert(data.message || 'Transport security updated.', 'success');
+        } catch (err) {
+            showAlert('Transport security update failed: ' + extractErrorMessage(err, 'Unknown error'), 'danger');
+        } finally {
+            setButtonBusy(buttonId, false);
+        }
+    }
+
+    function bindTransportSecurityAdmin() {
+        const card = document.getElementById('transportSecurityAdminCard');
+        if (!card) return;
+        try {
+            const initial = JSON.parse(card.dataset.initialStatus || '{}');
+            if (initial && Object.keys(initial).length) renderTransportSecurityAdmin(initial);
+        } catch (_) {}
+
+        document.getElementById('transportRefreshBtn')?.addEventListener('click', loadTransportSecurityStatus);
+        document.getElementById('transportSelfSignedBtn')?.addEventListener('click', () => {
+            const requireVerified = !!document.getElementById('transportRequireVerifiedWss')?.checked;
+            postTransportSecurityAction(
+                'transportSelfSignedBtn',
+                '/ajax/admin/transport-security/self-signed',
+                { require_verified_wss: requireVerified },
+                '<i class="bi bi-hourglass-split"></i> Generating...'
+            );
+        });
+        document.getElementById('transportProvidedCertBtn')?.addEventListener('click', () => {
+            const certPath = document.getElementById('transportCertPath')?.value || '';
+            const keyPath = document.getElementById('transportKeyPath')?.value || '';
+            const requireVerified = !!document.getElementById('transportRequireVerifiedWss')?.checked;
+            postTransportSecurityAction(
+                'transportProvidedCertBtn',
+                '/ajax/admin/transport-security/certificate',
+                { cert_path: certPath, key_path: keyPath, require_verified_wss: requireVerified },
+                '<i class="bi bi-hourglass-split"></i> Validating...'
+            );
+        });
+        document.getElementById('transportExternalBtn')?.addEventListener('click', () => {
+            const endpoint = document.getElementById('transportExternalEndpoint')?.value || '';
+            const requireVerified = !!document.getElementById('transportRequireVerifiedWss')?.checked;
+            postTransportSecurityAction(
+                'transportExternalBtn',
+                '/ajax/admin/transport-security/external',
+                { external_tls_endpoint: endpoint, require_verified_wss: requireVerified },
+                '<i class="bi bi-hourglass-split"></i> Saving...'
+            );
+        });
+        document.getElementById('transportDisableBtn')?.addEventListener('click', () => {
+            if (!confirm('Disable local TLS and external TLS terminator settings for this meshspace?')) return;
+            postTransportSecurityAction(
+                'transportDisableBtn',
+                '/ajax/admin/transport-security/disable',
+                {},
+                '<i class="bi bi-hourglass-split"></i> Disabling...'
+            );
+        });
+        document.getElementById('transportRestartBtn')?.addEventListener('click', async () => {
+            if (!confirm('Restart this meshspace now to apply transport changes?')) return;
+            setButtonBusy('transportRestartBtn', true, '<i class="bi bi-hourglass-split"></i> Restarting...');
+            try {
+                const { ok, data } = await api('POST', '/ajax/admin/transport-security/restart', {});
+                if (!ok || !data.success) throw new Error(data.error || 'Restart failed');
+                showAlert(data.message || 'Restart scheduled.', 'success');
+                setTimeout(() => window.location.reload(), 4500);
+            } catch (err) {
+                showAlert('Restart failed: ' + extractErrorMessage(err, 'Unknown error'), 'danger');
+                setButtonBusy('transportRestartBtn', false);
+            }
+        });
+        loadTransportSecurityStatus();
+    }
+
     window.cleanupDatabase = cleanupDatabase;
     window.exportData = exportData;
     window.openImportDataPicker = openImportDataPicker;
@@ -3215,6 +3531,7 @@ export CANOPY_AUTO_APPROVE_AGENTS=1</code></pre>
         });
     }
     loadRelayStatus();
+    bindTransportSecurityAdmin();
 
     const reconcileChannelIds = document.getElementById('admin-reconcile-channel-ids');
     const reconcileTargetPeer = document.getElementById('admin-reconcile-target-peer');

--- a/canopy/ui/templates/base.html
+++ b/canopy/ui/templates/base.html
@@ -2901,11 +2901,29 @@
             border-radius: 11px;
             background: rgba(255, 255, 255, 0.03);
             border: 1px solid rgba(255, 255, 255, 0.04);
+            color: inherit;
             min-width: 0;
             width: 100%;
             overflow: hidden;
             box-sizing: border-box;
             min-height: 42px;
+            text-decoration: none;
+            cursor: pointer;
+            transition: border-color 0.16s ease, background 0.16s ease, transform 0.16s ease;
+        }
+
+        .sidebar-peer:hover,
+        .sidebar-peer:focus-visible {
+            color: inherit;
+            text-decoration: none;
+            border-color: rgba(34, 197, 94, 0.3);
+            background: rgba(34, 197, 94, 0.08);
+            transform: translateY(-1px);
+        }
+
+        .sidebar-peer:focus-visible {
+            outline: 2px solid rgba(34, 197, 94, 0.5);
+            outline-offset: 2px;
         }
 
         .sidebar-peer-avatar {
@@ -7845,7 +7863,7 @@
                     <i class="bi bi-list"></i>
                 </button>
                 {% if sidebar_connected_peers is defined %}
-                <a href="{{ url_for('ui.connect_page') }}" class="nav-link header-peer-link d-inline-flex align-items-center gap-1 me-2 text-nowrap" title="P2P peer connections">
+                <a href="{{ url_for('ui.connect_page') }}#connected-peers" class="nav-link header-peer-link d-inline-flex align-items-center gap-1 me-2 text-nowrap" title="P2P peer connections">
                     <i class="bi bi-link-45deg"></i>
                     <span class="badge rounded-pill {% if sidebar_connected_peers|length > 0 %}bg-success{% else %}bg-secondary{% endif %}" id="header-peer-count">{{ sidebar_connected_peers|length }}</span>
                 </a>
@@ -8325,7 +8343,11 @@
                                     {% else %}
                                         {% set trust_class = 'quarantine' %}
                                     {% endif %}
-                                    <div class="sidebar-peer" data-peer-id="{{ peer_id }}">
+                                    <a class="sidebar-peer"
+                                       data-peer-id="{{ peer_id }}"
+                                       href="{{ url_for('ui.trust_management') }}#trust-peer-{{ peer_id|urlencode }}"
+                                       title="Open {{ display_name }} in Trust Network"
+                                       aria-label="Open {{ display_name }} in Trust Network">
                                         <div class="sidebar-peer-avatar">
                                             {% if profile and profile.avatar_b64 %}
                                                 <img src="data:{{ profile.avatar_mime or 'image/png' }};base64,{{ profile.avatar_b64 }}" alt="{{ display_name }}">
@@ -8349,7 +8371,7 @@
                                             {% endif %}
                                             <span class="trust-pill {{ trust_class }}">{{ trust_label }}</span>
                                         {% endif %}
-                                    </div>
+                                    </a>
                                 {% endfor %}
                             {% else %}
                                 <div class="sidebar-peer-empty">No active peers</div>
@@ -8625,6 +8647,8 @@
                 feed: {{ url_for('ui.feed')|tojson }},
                 channels: {{ url_for('ui.channels')|tojson }},
                 messages: {{ url_for('ui.messages')|tojson }},
+                trustNetwork: {{ url_for('ui.trust_management')|tojson }},
+                connect: {{ url_for('ui.connect_page')|tojson }},
                 sidebarAttentionSummary: {{ url_for('ui.ajax_sidebar_attention_summary')|tojson }},
                 sidebarAttentionSnapshot: {{ url_for('ui.ajax_sidebar_attention_snapshot')|tojson }},
                 sidebarAttentionClear: {{ url_for('ui.ajax_sidebar_attention_clear')|tojson }},

--- a/canopy/ui/templates/connect.html
+++ b/canopy/ui/templates/connect.html
@@ -27,6 +27,11 @@
         border-color: var(--canopy-border);
         background: var(--canopy-bg-tertiary);
     }
+    .peer-row:target {
+        scroll-margin-top: 92px;
+        border-color: rgba(34, 197, 94, 0.62) !important;
+        box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.16);
+    }
     .peer-meta {
         min-width: 0;
     }
@@ -151,6 +156,86 @@
     .mesh-muted {
         color: var(--canopy-text-secondary);
         font-size: 0.8rem;
+    }
+    .remote-meshspace-review {
+        border: 1px solid rgba(245, 158, 11, 0.34);
+        background:
+            radial-gradient(circle at top left, rgba(245, 158, 11, 0.12), transparent 34%),
+            color-mix(in srgb, var(--canopy-bg-secondary) 88%, transparent);
+    }
+    .remote-meshspace-pill {
+        border: 1px solid rgba(245, 158, 11, 0.38);
+        color: #fbbf24;
+        background: rgba(245, 158, 11, 0.1);
+        border-radius: 999px;
+        font-size: 0.68rem;
+        padding: 0.18rem 0.5rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+    .transport-security-card {
+        border: 1px solid color-mix(in srgb, var(--canopy-border) 82%, transparent);
+        border-radius: 14px;
+        padding: 0.75rem;
+        background:
+            radial-gradient(circle at top left, rgba(14, 165, 233, 0.12), transparent 34%),
+            color-mix(in srgb, var(--canopy-bg-tertiary) 78%, transparent);
+    }
+    .transport-security-top {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+    .transport-security-title {
+        font-weight: 700;
+        color: var(--canopy-text-primary);
+    }
+    .transport-security-copy {
+        color: var(--canopy-text-secondary);
+        font-size: 0.8rem;
+        line-height: 1.45;
+    }
+    .transport-security-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 0.5rem;
+        margin-top: 0.65rem;
+    }
+    .transport-security-fact {
+        border: 1px solid color-mix(in srgb, var(--canopy-border) 70%, transparent);
+        border-radius: 12px;
+        padding: 0.55rem 0.6rem;
+        min-width: 0;
+    }
+    .transport-security-label {
+        color: var(--canopy-text-secondary);
+        font-size: 0.66rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        margin-bottom: 0.15rem;
+    }
+    .transport-security-value {
+        color: var(--canopy-text-primary);
+        font-weight: 650;
+        overflow-wrap: anywhere;
+    }
+    .endpoint-badge-secure {
+        background: rgba(16, 185, 129, 0.16) !important;
+        color: #047857 !important;
+        border: 1px solid rgba(16, 185, 129, 0.34);
+    }
+    .endpoint-badge-plain {
+        background: rgba(245, 158, 11, 0.16) !important;
+        color: #92400e !important;
+        border: 1px solid rgba(245, 158, 11, 0.34);
+    }
+    [data-bs-theme="dark"] .endpoint-badge-secure {
+        color: #6ee7b7 !important;
+    }
+    [data-bs-theme="dark"] .endpoint-badge-plain {
+        color: #fbbf24 !important;
     }
     .connect-page .card {
         margin-bottom: 0.85rem;
@@ -477,11 +562,72 @@
                     </div>
                 </div>
 
+                {% set ts = transport_security or {} %}
+                <div class="mb-3">
+                    <label class="form-label small text-muted">Transport security</label>
+                    <div class="transport-security-card">
+                        <div class="transport-security-top">
+                            <div>
+                                <div class="transport-security-title" id="transport-security-title">
+                                    {{ ts.transport_label or 'Plain WebSocket (ws)' }}
+                                </div>
+                                <div class="transport-security-copy">
+                                    <code>wss://</code> wraps the mesh WebSocket in TLS. Canopy still verifies peer identity at the application layer using peer keys from the invite.
+                                </div>
+                            </div>
+                            <span id="transport-security-badge" class="badge {% if ts.tls_enabled %}endpoint-badge-secure{% else %}endpoint-badge-plain{% endif %}">
+                                {% if ts.tls_enabled %}<i class="bi bi-shield-lock"></i> wss listener{% else %}<i class="bi bi-unlock"></i> ws listener{% endif %}
+                            </span>
+                        </div>
+                        <div class="transport-security-grid">
+                            <div class="transport-security-fact">
+                                <div class="transport-security-label">Mesh listener</div>
+                                <div class="transport-security-value" id="transport-listener-endpoint">{{ ts.listener_endpoint or 'Not running' }}</div>
+                            </div>
+                            <div class="transport-security-fact">
+                                <div class="transport-security-label">Certificate</div>
+                                <div class="transport-security-value" id="transport-cert-mode">{{ (ts.tls_cert_mode or 'disabled')|replace('_', ' ')|title }}</div>
+                            </div>
+                            <div class="transport-security-fact">
+                                <div class="transport-security-label">Outbound wss verification</div>
+                                <div class="transport-security-value" id="transport-client-verification">{{ (ts.client_verification_mode or 'permissive')|title }}</div>
+                            </div>
+                            <div class="transport-security-fact">
+                                <div class="transport-security-label">Invite advertises</div>
+                                <div class="transport-security-value" id="transport-advertised-summary">
+                                    {{ ts.advertised_secure_count or 0 }} secure / {{ ts.advertised_plain_count or 0 }} plain
+                                </div>
+                            </div>
+                            <div class="transport-security-fact">
+                                <div class="transport-security-label">Invite mode</div>
+                                <div class="transport-security-value" id="transport-invite-policy">{{ ts.invite_policy_label or 'Plain invite' }}</div>
+                            </div>
+                            <div class="transport-security-fact">
+                                <div class="transport-security-label">Recommended path</div>
+                                <div class="transport-security-value" id="transport-recommended-endpoint">{{ ts.recommended_endpoint or 'None' }}</div>
+                            </div>
+                        </div>
+                        <div class="transport-security-copy mt-2" id="transport-security-warnings">
+                            {% if ts.warnings %}
+                                {% for warning in ts.warnings[:3] %}
+                                    <div><i class="bi bi-info-circle"></i> {{ warning }}</div>
+                                {% endfor %}
+                            {% else %}
+                                <div><i class="bi bi-check-circle"></i> Explicit <code>wss://</code> endpoints will not silently downgrade to <code>ws://</code>.</div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
                 <div class="mb-3">
                     <label class="form-label small text-muted">Reachable at</label>
-                    <div>
+                    <div id="invite-endpoints-list">
                         {% for ep in endpoints %}
-                        <span class="badge bg-secondary me-1 mb-1">{{ ep }}</span>
+                        {% set ep_lower = ep|lower %}
+                        <span class="badge me-1 mb-1 {% if ep_lower.startswith('wss://') %}endpoint-badge-secure{% else %}endpoint-badge-plain{% endif %}">
+                            {% if ep_lower.startswith('wss://') %}<i class="bi bi-shield-lock"></i>{% else %}<i class="bi bi-unlock"></i>{% endif %}
+                            {{ ep }}
+                        </span>
                         {% endfor %}
                     </div>
                 </div>
@@ -504,13 +650,19 @@
                 <hr>
                 <p class="text-muted small mb-2">
                     <i class="bi bi-globe"></i> <strong>Connecting from outside your LAN?</strong><br>
-                    If you use ngrok or another tunnel, generate the invite from your full external mesh endpoint. Port-forwarded host/port still works as a fallback.
+                    If you use ngrok or another tunnel, generate the invite from your full external mesh endpoint. Use <code>wss://</code> when the tunnel or VPS endpoint actually terminates TLS; explicit <code>wss://</code> imports now fail instead of downgrading to plain <code>ws://</code>.
                 </p>
                 <div class="input-group mb-2 public-host-group">
                     <input type="text" class="form-control" id="externalEndpoint" placeholder="wss://example.ngrok-free.app or ws://0.tcp.ngrok.io:12345">
                     <button class="btn btn-outline-primary" onclick="regenerateInvite()">
                         <i class="bi bi-arrow-repeat"></i> Regenerate
                     </button>
+                </div>
+                <div class="form-check form-switch mb-2">
+                    <input class="form-check-input" type="checkbox" id="allowPlainFallback">
+                    <label class="form-check-label small text-muted" for="allowPlainFallback">
+                        Also advertise plain <code>ws://</code> fallback for compatibility. Leave off for WSS-only public intent.
+                    </label>
                 </div>
                 <p class="text-muted small mb-2">
                     Port forwarding instead? Enter the public host and mesh port below.
@@ -567,7 +719,7 @@
 <!-- Connected / Discovered Peers -->
 <div class="row">
     <div class="col-lg-6 mb-4">
-        <div class="card">
+        <div class="card" id="connected-peers">
             <div class="card-header">
                 <div class="d-flex justify-content-between align-items-center">
                     <h5 class="mb-0"><i class="bi bi-people"></i> Connected Peers</h5>
@@ -584,7 +736,8 @@
                     {% for pid in connected_peers %}
                     {% set dev = peer_device_profiles.get(pid) if peer_device_profiles else None %}
                     {% set pub = peer_public_identities.get(pid) if peer_public_identities else {} %}
-                    <li class="list-group-item d-flex align-items-start peer-row" data-peer-id="{{ pid }}" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
+                    {% set active = peer_active_transports.get(pid) if peer_active_transports else {} %}
+                    <li class="list-group-item d-flex align-items-start peer-row" id="connected-peer-{{ pid }}" data-peer-id="{{ pid }}" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
                         <span class="peer-status-dot"></span>
                         {% if dev and dev.avatar_b64 and dev.avatar_mime %}
                         <img src="data:{{ dev.avatar_mime }};base64,{{ dev.avatar_b64 }}"
@@ -615,6 +768,15 @@
                             {% endif %}
                             <small class="peer-activity d-block" data-peer-connected>Connected: —</small>
                             <small class="peer-activity d-block" data-peer-last>Last activity: —</small>
+                            <small class="peer-activity d-block" data-peer-active-transport>
+                                Active transport:
+                                {% if active and active.active_transport %}
+                                    {{ active.active_transport_label or active.active_transport }}
+                                    {% if active.active_endpoint %} · {{ active.active_endpoint }}{% endif %}
+                                {% else %}
+                                    Detecting...
+                                {% endif %}
+                            </small>
                         </div>
                         <div class="ms-auto peer-actions">
                             {% set tscore = trust_scores.get(pid, 100) if trust_scores is defined else 100 %}
@@ -626,6 +788,17 @@
                             <span class="badge bg-secondary" title="Trust score: {{ tscore }}/100" style="opacity:0.6;"><i class="bi bi-shield-check"></i> {{ tscore }}</span>
                             {% endif %}
                             <span class="badge bg-success" title="Direct connection" data-peer-conn-type><i class="bi bi-lightning-charge"></i> Direct</span>
+                            <span class="badge {% if active and active.active_transport == 'wss' %}endpoint-badge-secure{% elif active and active.active_transport == 'ws' %}endpoint-badge-plain{% else %}bg-secondary{% endif %} peer-pill"
+                                  data-peer-active-transport-badge
+                                  title="{{ active.active_endpoint if active else '' }}">
+                                {% if active and active.active_transport == 'wss' %}
+                                <i class="bi bi-shield-lock"></i> wss active
+                                {% elif active and active.active_transport == 'ws' %}
+                                <i class="bi bi-unlock"></i> ws active
+                                {% else %}
+                                <i class="bi bi-question-circle"></i> transport pending
+                                {% endif %}
+                            </span>
                             <span class="badge bg-secondary peer-pill" data-peer-latency style="display:none;" title="Round-trip latency"></span>
                             <div class="dropdown peer-controls">
                                 <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
@@ -646,7 +819,7 @@
                     {% set viadev = peer_device_profiles.get(relay) if peer_device_profiles else None %}
                     {% set rpub = peer_public_identities.get(dest) if peer_public_identities else {} %}
                     {% set viapub = peer_public_identities.get(relay) if peer_public_identities else {} %}
-                    <li class="list-group-item d-flex align-items-start peer-row" data-peer-id="{{ dest }}" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
+                    <li class="list-group-item d-flex align-items-start peer-row" id="relayed-peer-{{ dest }}" data-peer-id="{{ dest }}" style="background:transparent; color:var(--canopy-text-primary); border-color:var(--canopy-border);">
                         <span class="peer-status-dot relay"></span>
                         {% if rdev and rdev.avatar_b64 and rdev.avatar_mime %}
                         <img src="data:{{ rdev.avatar_mime }};base64,{{ rdev.avatar_b64 }}"
@@ -755,6 +928,103 @@
         </div>
     </div>
 </div>
+
+<!-- Remote meshspace candidates introduced by connected peers -->
+{% if introduced_meshspace_candidates %}
+<div class="row">
+    <div class="col-12 mb-4">
+        <div class="card remote-meshspace-review">
+            <div class="card-header">
+                <div class="d-flex justify-content-between align-items-start gap-2 flex-wrap">
+                    <div>
+                        <h5 class="mb-1"><i class="bi bi-signpost-split"></i> Remote Meshspace Candidates</h5>
+                        <div class="text-muted small">These peers were introduced through contacts but advertise a different meshspace. They are separated from routine peer introductions to prevent accidental mesh bridging.</div>
+                    </div>
+                    <span class="remote-meshspace-pill">Explicit review</span>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive connect-scroll-table">
+                    <table class="table table-sm" style="color:var(--canopy-text-primary);">
+                        <thead>
+                            <tr>
+                                <th>Peer</th>
+                                <th>Remote meshspace</th>
+                                <th>Introduced by</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for peer in introduced_meshspace_candidates %}
+                            {% set idev = peer_device_profiles.get(peer.peer_id) if peer_device_profiles else None %}
+                            {% set ibydev = peer_device_profiles.get(peer.introduced_by) if peer_device_profiles else None %}
+                            {% set pub = peer.public_identity if peer.public_identity else None %}
+                            {% set bypub = peer_public_identities.get(peer.introduced_by) if peer_public_identities else {} %}
+                            <tr>
+                                <td>
+                                    <div class="d-flex align-items-center">
+                                        {% if idev and idev.avatar_b64 and idev.avatar_mime %}
+                                        <img src="data:{{ idev.avatar_mime }};base64,{{ idev.avatar_b64 }}"
+                                             alt="" style="width:24px; height:24px; border-radius:50%; margin-right:6px; object-fit:cover;">
+                                        {% elif pub and pub.avatar_initials %}
+                                        <div class="peer-preview-avatar" style="background:{{ pub.avatar_color or '#334155' }};">{{ pub.avatar_initials }}</div>
+                                        {% endif %}
+                                        <div>
+                                            {% if idev and idev.display_name %}
+                                            <strong>{{ idev.display_name }}</strong>
+                                            {% elif peer.display_name %}
+                                            <strong>{{ peer.display_name }}</strong>
+                                            {% elif pub and pub.node_name %}
+                                            <strong>{{ pub.node_name }}</strong>
+                                            {% else %}
+                                            <code>{{ peer.peer_id[:12] }}...</code>
+                                            {% endif %}
+                                            <small class="text-muted d-block" style="font-size:0.75rem;">{{ peer.peer_id[:12] }}...</small>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div><strong>{{ peer.remote_meshspace_label or 'Another meshspace' }}</strong></div>
+                                    {% if peer.remote_meshspace_id %}
+                                    <code class="small">{{ peer.remote_meshspace_id }}</code>
+                                    {% endif %}
+                                    {% if peer.remote_meshspace_fingerprint %}
+                                    <div class="text-muted small">Fingerprint {{ peer.remote_meshspace_fingerprint }}</div>
+                                    {% endif %}
+                                    <div class="text-warning small mt-1">Connect only if this bridge is intentional.</div>
+                                </td>
+                                <td>
+                                    {% if ibydev and ibydev.display_name %}
+                                    <strong>{{ ibydev.display_name }}</strong>
+                                    {% elif bypub and bypub.node_name %}
+                                    <strong>{{ bypub.node_name }}</strong>
+                                    {% else %}
+                                    <code>{{ peer.introduced_by[:12] }}...</code>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if is_admin %}
+                                    <button class="btn btn-sm btn-outline-warning"
+                                            data-remote-mesh="{{ peer.remote_meshspace_label or 'another meshspace' }}"
+                                            onclick="connectToIntroduced('{{ peer.peer_id }}', this, {allowCrossMesh: true})">
+                                        <i class="bi bi-shield-exclamation"></i> Explicit Connect
+                                    </button>
+                                    {% else %}
+                                    <button class="btn btn-sm btn-outline-secondary" disabled title="Instance admin approval is required for remote meshspace candidates.">
+                                        <i class="bi bi-lock"></i> Admin required
+                                    </button>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
 
 <!-- Peers via Contacts (introduced by connected peers) -->
 {% if introduced_peers %}
@@ -938,12 +1208,29 @@
                                 {% for ep in peer.endpoints %}
                                 <span class="badge bg-secondary me-1" style="font-size:0.65rem;">{{ ep }}</span>
                                 {% endfor %}
+                                {% if peer.active_transport %}
+                                <small class="peer-activity d-block" data-peer-active-transport>
+                                    Active transport: {{ peer.active_transport_label or peer.active_transport }}
+                                    {% if peer.active_endpoint %} · {{ peer.active_endpoint }}{% endif %}
+                                </small>
+                                {% endif %}
                                 <small class="peer-activity d-block" data-peer-last>Last activity: —</small>
                             </div>
                         </div>
                         <div class="ms-auto peer-actions">
                             {% if peer.connection_type == 'direct' %}
                             <span class="badge bg-success">Connected</span>
+                            <span class="badge {% if peer.active_transport == 'wss' %}endpoint-badge-secure{% elif peer.active_transport == 'ws' %}endpoint-badge-plain{% else %}bg-secondary{% endif %} peer-pill"
+                                  data-peer-active-transport-badge
+                                  title="{{ peer.active_endpoint or '' }}">
+                                {% if peer.active_transport == 'wss' %}
+                                <i class="bi bi-shield-lock"></i> wss active
+                                {% elif peer.active_transport == 'ws' %}
+                                <i class="bi bi-unlock"></i> ws active
+                                {% else %}
+                                <i class="bi bi-question-circle"></i> transport pending
+                                {% endif %}
+                            </span>
                             {% if peer.can_treat_same_mesh %}
                             <button class="btn btn-sm btn-outline-success" onclick="reviewPeerMesh('{{ peer.peer_id }}', 'same_mesh_alias', this)">
                                 <i class="bi bi-check2-circle"></i> Treat as Same Mesh
@@ -1182,7 +1469,11 @@
                         <div class="mesh-muted mb-2">Advertised endpoints</div>
                         <div id="ts-endpoints-list">
                             {% for ep in endpoints %}
-                            <span class="badge bg-secondary me-1 mb-1">{{ ep }}</span>
+                            {% set ep_lower = ep|lower %}
+                            <span class="badge me-1 mb-1 {% if ep_lower.startswith('wss://') %}endpoint-badge-secure{% else %}endpoint-badge-plain{% endif %}">
+                                {% if ep_lower.startswith('wss://') %}<i class="bi bi-shield-lock"></i>{% else %}<i class="bi bi-unlock"></i>{% endif %}
+                                {{ ep }}
+                            </span>
                             {% else %}
                             <span class="text-muted small">None detected</span>
                             {% endfor %}
@@ -1207,6 +1498,10 @@
                             <li class="mb-2">
                                 <i class="bi bi-globe text-success me-2"></i>
                                 <strong>Public endpoint</strong> — Use the "Regenerate" button above with a public IP or full tunnel endpoint so the invite contains a dialable address.
+                            </li>
+                            <li class="mb-2">
+                                <i class="bi bi-shield-lock text-success me-2"></i>
+                                <strong>wss:// endpoints</strong> — <code>wss://</code> means TLS-wrapped WebSocket transport. Canopy still verifies peer keys separately, and explicit <code>wss://</code> endpoints are not downgraded to <code>ws://</code> if TLS fails.
                             </li>
                         </ul>
                     </div>
@@ -1238,7 +1533,7 @@
                 </div>
                 <div class="col-md-4 mb-3">
                     <h6><span class="badge bg-primary me-1">2</span> Different location</h6>
-                    <p class="small text-muted mb-0">One person shares a reachable endpoint: public IP plus port-forwarding, a VPS public IP, or a full tunnel endpoint such as <code>wss://...</code>.</p>
+                    <p class="small text-muted mb-0">One person shares a reachable endpoint: public IP plus port-forwarding, a VPS public IP, or a full tunnel endpoint such as <code>wss://...</code>. Prefer <code>wss://</code> for public internet use when TLS is really terminated at that endpoint.</p>
                 </div>
                 <div class="col-md-4 mb-3">
                     <h6><span class="badge bg-primary me-1">3</span> Friend imports the code</h6>
@@ -1258,6 +1553,7 @@ const CURRENT_MESH_NAME = {{ (current_mesh_name or 'Default Mesh') | tojson }};
 const CURRENT_MESHSPACE_ID = {{ (current_meshspace_id or '') | tojson }};
 const CURRENT_MESHSPACE_ID_ALIASES = {{ (current_meshspace_id_aliases or []) | tojson }};
 const CURRENT_MESH_FINGERPRINT = {{ (current_mesh_fingerprint or '') | tojson }};
+let currentTransportSecurity = {{ (transport_security or {}) | tojson }};
 const CURRENT_PEER_ID = {{ (peer_id or '') | tojson }};
 const USER_IS_ADMIN = {{ 'true' if is_admin else 'false' }};
 const DEVICE_ICON_CHOICES = new Set([
@@ -1352,6 +1648,12 @@ function buildConnectErrorMessage(err) {
     if (code === 'cross_mesh_reconnect_confirmation_required') {
         return 'This peer is from a different meshspace. Reload the page to review the current mesh warning and confirm explicitly.';
     }
+    if (code === 'introduced_cross_mesh_confirmation_required') {
+        return 'This introduced peer advertises a different meshspace. Use the remote-meshspace section and confirm only if the bridge is intentional.';
+    }
+    if (code === 'secure_transport_failed') {
+        return 'The explicit wss:// endpoint failed TLS connection and Canopy refused to downgrade it to plain ws://. Verify the VPS, tunnel, or reverse proxy is serving secure WebSocket traffic.';
+    }
     const text = String(err?.message ?? (err ?? 'Unknown error'));
     if (/session may have expired|authentication required|api key required/i.test(text)) {
         return 'Authentication required for this action. Please reload the page and sign in again. ' +
@@ -1371,6 +1673,7 @@ function copyInvite() {
 
 function regenerateInvite() {
     const externalEndpoint = document.getElementById('externalEndpoint').value.trim();
+    const allowPlainFallback = !!document.getElementById('allowPlainFallback')?.checked;
     const host = document.getElementById('publicHost').value.trim();
     const port = document.getElementById('publicPort').value.trim();
     if (!externalEndpoint && !host) {
@@ -1380,6 +1683,7 @@ function regenerateInvite() {
     let url = '/api/v1/p2p/invite';
     if (externalEndpoint) {
         url += '?external_endpoint=' + encodeURIComponent(externalEndpoint);
+        if (allowPlainFallback) url += '&allow_plain_fallback=true';
     } else {
         url += '?public_host=' + encodeURIComponent(host);
         if (port) url += '&public_port=' + encodeURIComponent(port);
@@ -1387,6 +1691,18 @@ function regenerateInvite() {
     apiJsonFetch(url).then(data => {
         if (data.invite_code) {
             document.getElementById('inviteCode').value = data.invite_code;
+            if (Array.isArray(data.endpoints)) {
+                renderEndpointBadges('invite-endpoints-list', data.endpoints);
+            }
+            if (data.transport_security || Array.isArray(data.endpoints)) {
+                currentTransportSecurity = data.transport_security || currentTransportSecurity || {};
+                if (Array.isArray(data.endpoints)) {
+                    currentTransportSecurity.advertised_endpoints = data.endpoints;
+                    currentTransportSecurity.advertised_secure_count = data.endpoints.filter(ep => String(ep || '').toLowerCase().startsWith('wss://')).length;
+                    currentTransportSecurity.advertised_plain_count = data.endpoints.filter(ep => String(ep || '').toLowerCase().startsWith('ws://')).length;
+                }
+                updateTransportSecurityPanel(currentTransportSecurity);
+            }
             const s = document.getElementById('copySuccess');
             s.textContent = externalEndpoint ? 'Regenerated with external endpoint!' : 'Regenerated with public endpoint!';
             s.style.display = 'block';
@@ -1528,6 +1844,10 @@ function invitePreviewWarnings(preview) {
     }
     if (!preview.endpoints.length) {
         warnings.push('No direct endpoints are advertised. Canopy can register the peer, but direct connection may require broker/relay help.');
+    } else if (!preview.endpoints.some((ep) => String(ep || '').toLowerCase().startsWith('wss://'))) {
+        warnings.push('This invite advertises only plain ws:// endpoints. Use a wss:// tunnel, reverse proxy, or TLS mesh listener for public internet connections when possible.');
+    } else if (preview.endpoints.some((ep) => String(ep || '').toLowerCase().startsWith('ws://'))) {
+        warnings.push('This invite mixes wss:// and ws:// endpoints. The active session is only secure if Canopy actually connects over the wss:// endpoint.');
     }
     const knownLabel = PEER_LABELS[preview.peerId] || '';
     if (knownLabel && preview.peerLabel && knownLabel !== preview.peerLabel) {
@@ -1581,8 +1901,8 @@ function renderInvitePreview(preview, error) {
         ? `${preview.endpoints.length} direct ${preview.endpoints.length === 1 ? 'endpoint' : 'endpoints'}`
         : 'No direct endpoints';
     const endpointPreview = preview.endpoints.slice(0, 3)
-        .map((ep) => `<code>${_escapeHtml(ep)}</code>`)
-        .join('<br>');
+        .map((ep) => endpointBadgeHtml(ep))
+        .join(' ');
     const ageLabel = invitePreviewAgeLabel(preview.generatedAt);
     const knownBadge = knownLabel
         ? '<span class="badge bg-info-subtle text-info-emphasis border">Known peer</span>'
@@ -1761,6 +2081,9 @@ function connectPreviewedInvite() {
             res.className = 'mt-3 alert alert-warning';
             if (data.diagnostic_code === 'invite_has_no_usable_endpoints') {
                 res.innerHTML = '<i class="bi bi-exclamation-triangle"></i> Peer <code>' + safePeerId + '</code> registered, but the invite did not include any usable direct endpoints. Ask the remote peer to regenerate the invite with a public or tunnel endpoint.';
+            } else if (data.diagnostic_code === 'secure_transport_failed') {
+                res.className = 'mt-3 alert alert-danger';
+                res.innerHTML = '<i class="bi bi-shield-exclamation"></i> Peer <code>' + safePeerId + '</code> registered, but its explicit <code>wss://</code> endpoint failed and Canopy refused to downgrade to plain <code>ws://</code>. Confirm the VPS, tunnel, or reverse proxy is accepting secure WebSocket traffic at the advertised endpoint.';
             } else {
                 res.innerHTML = '<i class="bi bi-exclamation-triangle"></i> Peer <code>' + safePeerId + '</code> registered but could not connect to any advertised endpoint. The peer may be offline, the endpoint may be stale, or the connection may require broker/relay help.';
             }
@@ -1798,14 +2121,28 @@ function importInvite() {
     return connectPreviewedInvite();
 }
 
-function connectToIntroduced(peerId, buttonEl) {
+function connectToIntroduced(peerId, buttonEl, options = {}) {
     const btn = buttonEl || (typeof event !== 'undefined' ? event.target.closest('button') : null);
     if (!btn) return;
+    const allowCrossMesh = Boolean(options && options.allowCrossMesh);
+    if (allowCrossMesh) {
+        const remoteMesh = btn.dataset.remoteMesh || 'another meshspace';
+        const ok = confirm(
+            'Connect to a peer that advertises "' + remoteMesh + '" from this meshspace? ' +
+            'This can intentionally bridge meshes. Continue only if you mean to create that connection.'
+        );
+        if (!ok) return;
+    }
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Connecting...';
+    const payload = {peer_id: peerId};
+    if (allowCrossMesh) {
+        payload.allow_cross_mesh = true;
+        payload.explicit_meshspace_connect = true;
+    }
     apiJsonFetch('/api/v1/p2p/connect_introduced', {
         method: 'POST',
-        body: JSON.stringify({peer_id: peerId})
+        body: JSON.stringify(payload)
     })
     .then((data) => {
         if (data.status === 'connected') {
@@ -1816,7 +2153,7 @@ function connectToIntroduced(peerId, buttonEl) {
             btn.innerHTML = '<i class="bi bi-hourglass-split"></i> Brokering...';
             btn.title = data.message || 'Waiting for broker to arrange connection';
             // Poll for connection after a delay
-            setTimeout(() => checkBrokeredConnection(peerId, btn), 8000);
+            setTimeout(() => checkBrokeredConnection(peerId, btn, 1, {allowCrossMesh}), 8000);
         } else {
             alert(data.error || data.message || 'Could not connect');
             btn.disabled = false;
@@ -1830,7 +2167,7 @@ function connectToIntroduced(peerId, buttonEl) {
     });
 }
 
-function checkBrokeredConnection(peerId, btn, attempt) {
+function checkBrokeredConnection(peerId, btn, attempt, options = {}) {
     attempt = attempt || 1;
     const maxAttempts = 12;
     const pollInterval = 5000; // 5s between polls
@@ -1857,7 +2194,7 @@ function checkBrokeredConnection(peerId, btn, attempt) {
                     btn.disabled = false;
                 } else if (attempt < maxAttempts) {
                     // Keep polling
-                    setTimeout(() => checkBrokeredConnection(peerId, btn, attempt + 1), pollInterval);
+                    setTimeout(() => checkBrokeredConnection(peerId, btn, attempt + 1, options), pollInterval);
                 } else {
                     // Exhausted retries
                     const relayPolicy = relay && relay.relay_policy ? relay.relay_policy : '';
@@ -1869,12 +2206,12 @@ function checkBrokeredConnection(peerId, btn, attempt) {
                     btn.disabled = false;
                     btn.title = 'Broker could not arrange a direct or relay connection.' +
                         (relayPolicy ? (' Relay policy: ' + relayPolicy + '.') : '') + policyHint;
-                    btn.onclick = function() { connectToIntroduced(peerId, btn); };
+                    btn.onclick = function() { connectToIntroduced(peerId, btn, options); };
                 }
             })
             .catch((err) => {
                 if (attempt < maxAttempts) {
-                    setTimeout(() => checkBrokeredConnection(peerId, btn, attempt + 1), pollInterval);
+                    setTimeout(() => checkBrokeredConnection(peerId, btn, attempt + 1, options), pollInterval);
                 } else {
                     const msg = buildConnectErrorMessage(err);
                     btn.className = 'btn btn-sm btn-outline-secondary';
@@ -1886,7 +2223,7 @@ function checkBrokeredConnection(peerId, btn, attempt) {
     })
     .catch((err) => {
         if (attempt < maxAttempts) {
-            setTimeout(() => checkBrokeredConnection(peerId, btn, attempt + 1), pollInterval);
+            setTimeout(() => checkBrokeredConnection(peerId, btn, attempt + 1, options), pollInterval);
         } else {
             const msg = buildConnectErrorMessage(err);
             btn.disabled = false;
@@ -2163,6 +2500,60 @@ function _escapeHtml(text) {
     return div.innerHTML;
 }
 
+function endpointBadgeHtml(endpoint) {
+    const ep = String(endpoint || '').trim();
+    if (!ep) return '';
+    const secure = ep.toLowerCase().startsWith('wss://');
+    const cls = secure ? 'endpoint-badge-secure' : 'endpoint-badge-plain';
+    const icon = secure ? 'bi-shield-lock' : 'bi-unlock';
+    const label = secure ? 'Secure TLS endpoint' : 'Plain WebSocket endpoint';
+    return `<span class="badge ${cls} me-1 mb-1" title="${label}"><i class="bi ${icon}"></i> ${_escapeHtml(ep)}</span>`;
+}
+
+function renderEndpointBadges(containerId, endpoints) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    const list = Array.isArray(endpoints) ? endpoints.filter(Boolean) : [];
+    container.innerHTML = list.length
+        ? list.map(endpointBadgeHtml).join('')
+        : '<span class="text-muted small">None detected</span>';
+}
+
+function updateTransportSecurityPanel(status) {
+    const ts = status || {};
+    const tlsEnabled = !!ts.tls_enabled;
+    const titleEl = document.getElementById('transport-security-title');
+    const badgeEl = document.getElementById('transport-security-badge');
+    const listenerEl = document.getElementById('transport-listener-endpoint');
+    const certEl = document.getElementById('transport-cert-mode');
+    const verificationEl = document.getElementById('transport-client-verification');
+    const advertisedEl = document.getElementById('transport-advertised-summary');
+    const policyEl = document.getElementById('transport-invite-policy');
+    const recommendedEl = document.getElementById('transport-recommended-endpoint');
+    const warningsEl = document.getElementById('transport-security-warnings');
+    if (titleEl) titleEl.textContent = ts.transport_label || (tlsEnabled ? 'Secure WebSocket (wss)' : 'Plain WebSocket (ws)');
+    if (badgeEl) {
+        badgeEl.className = `badge ${tlsEnabled ? 'endpoint-badge-secure' : 'endpoint-badge-plain'}`;
+        badgeEl.innerHTML = tlsEnabled
+            ? '<i class="bi bi-shield-lock"></i> wss listener'
+            : '<i class="bi bi-unlock"></i> ws listener';
+    }
+    if (listenerEl) listenerEl.textContent = ts.listener_endpoint || 'Not running';
+    if (certEl) certEl.textContent = String(ts.tls_cert_mode || 'disabled').replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+    if (verificationEl) verificationEl.textContent = String(ts.client_verification_mode || 'permissive').replace(/\b\w/g, c => c.toUpperCase());
+    const secureCount = Number(ts.advertised_secure_count || 0);
+    const plainCount = Number(ts.advertised_plain_count || 0);
+    if (advertisedEl) advertisedEl.textContent = `${secureCount} secure / ${plainCount} plain`;
+    if (policyEl) policyEl.textContent = ts.invite_policy_label || 'Plain invite';
+    if (recommendedEl) recommendedEl.textContent = ts.recommended_endpoint || 'None';
+    if (warningsEl) {
+        const warnings = Array.isArray(ts.warnings) ? ts.warnings.slice(0, 3) : [];
+        warningsEl.innerHTML = warnings.length
+            ? warnings.map(warning => `<div><i class="bi bi-info-circle"></i> ${_escapeHtml(warning)}</div>`).join('')
+            : '<div><i class="bi bi-check-circle"></i> Explicit <code>wss://</code> endpoints will not silently downgrade to <code>ws://</code>.</div>';
+    }
+}
+
 function renderConnectionHistory() {
     const list = document.getElementById('connection-history-list');
     if (!list) return;
@@ -2378,6 +2769,36 @@ function updatePeerConnDiag(peers) {
                     connTypeBadge.innerHTML = '<i class="bi bi-lightning-charge"></i> Direct';
                 }
             }
+            const activeTransport = String(info.active_transport || '').toLowerCase();
+            const activeEndpoint = String(info.active_endpoint || '');
+            const activeLabel = info.active_transport_label || (
+                activeTransport === 'wss' ? 'Secure WebSocket (wss)' :
+                activeTransport === 'ws' ? 'Plain WebSocket (ws)' :
+                info.connection_type === 'relayed' ? 'Relayed' : 'Unknown'
+            );
+            const activeText = row.querySelector('[data-peer-active-transport]');
+            if (activeText) {
+                activeText.textContent = activeEndpoint
+                    ? `Active transport: ${activeLabel} · ${activeEndpoint}`
+                    : `Active transport: ${activeLabel}`;
+            }
+            const activeBadge = row.querySelector('[data-peer-active-transport-badge]');
+            if (activeBadge) {
+                if (activeTransport === 'wss') {
+                    activeBadge.className = 'badge endpoint-badge-secure peer-pill';
+                    activeBadge.innerHTML = '<i class="bi bi-shield-lock"></i> wss active';
+                } else if (activeTransport === 'ws') {
+                    activeBadge.className = 'badge endpoint-badge-plain peer-pill';
+                    activeBadge.innerHTML = '<i class="bi bi-unlock"></i> ws active';
+                } else if (info.connection_type === 'relayed') {
+                    activeBadge.className = 'badge bg-info peer-pill';
+                    activeBadge.innerHTML = '<i class="bi bi-arrow-left-right"></i> relayed';
+                } else {
+                    activeBadge.className = 'badge bg-secondary peer-pill';
+                    activeBadge.innerHTML = '<i class="bi bi-question-circle"></i> transport pending';
+                }
+                activeBadge.title = activeEndpoint || activeLabel;
+            }
             // Update latency badge
             const latBadge = row.querySelector('[data-peer-latency]');
             if (latBadge) {
@@ -2403,14 +2824,12 @@ function updateTroubleshootingPanel(local) {
     const endpointsList = document.getElementById('ts-endpoints-list');
     const endpointCount = document.getElementById('ts-endpoint-count');
     if (endpointsList && Array.isArray(local.endpoints)) {
-        if (local.endpoints.length) {
-            endpointsList.innerHTML = local.endpoints.map(ep =>
-                `<span class="badge bg-secondary me-1 mb-1">${_escapeHtml(ep)}</span>`
-            ).join('');
-        } else {
-            endpointsList.innerHTML = '<span class="text-muted small">None detected</span>';
-        }
+        renderEndpointBadges('ts-endpoints-list', local.endpoints);
         if (endpointCount) endpointCount.textContent = local.endpoints.length;
+    }
+    if (local.transport_security) {
+        currentTransportSecurity = local.transport_security;
+        updateTransportSecurityPanel(currentTransportSecurity);
     }
 }
 

--- a/canopy/ui/templates/trust.html
+++ b/canopy/ui/templates/trust.html
@@ -270,6 +270,14 @@
         cursor: grab;
     }
 
+    .trust-peer-card:target {
+        scroll-margin-top: 92px;
+        border-color: rgba(34, 197, 94, 0.72);
+        box-shadow:
+            0 0 0 2px rgba(34, 197, 94, 0.2),
+            0 20px 46px rgba(2, 6, 23, 0.34);
+    }
+
     .trust-peer-card.dragging {
         opacity: 0.78;
         transform: scale(0.99);

--- a/docs/CONNECT_FAQ.md
+++ b/docs/CONNECT_FAQ.md
@@ -26,7 +26,7 @@ It is intentionally action-first. The important value is whether you can connect
 What it shows:
 
 - **Peer ID**: your local cryptographic identity.
-- **Reachable at**: one or more `ws://host:port` endpoint candidates included in your invite.
+- **Reachable at**: one or more `ws://host:port` or `wss://host:port` endpoint candidates included in your invite.
 - **Invite code**: compact `canopy:...` payload containing identity + endpoint list.
 - **Peer-facing identity hints**: the remote side will see the peer name/avatar/node hint built from **Settings -> Device Profile** plus the active mesh hint.
 
@@ -34,6 +34,7 @@ Buttons/actions:
 
 - **Copy**: copies the full invite code.
 - **Regenerate** (with public IP/hostname and optional port): regenerates invite with a public endpoint prepended.
+- If Admin -> Transport Security declares local TLS or an external TLS terminator, generated invites can advertise the matching `wss://` path instead of plain `ws://`.
 
 Why this makes sense:
 
@@ -209,6 +210,36 @@ These are usually local/private addresses, not automatically your public interne
 - `Reachable at` addresses shown by default are local candidates.
 - If peers are outside your LAN, use **Regenerate** with your public IP/hostname (and forwarded port).
 - Regenerated invite includes the public endpoint plus local fallbacks.
+
+### How do I know whether my invite is using `wss://`?
+
+Open **Connect -> Your Invite Code -> Transport security**.
+
+That panel shows:
+
+- whether the local mesh listener is `Secure WebSocket (wss)` or `Plain WebSocket (ws)`,
+- which listener endpoint is active,
+- whether the TLS certificate is disabled, self-signed, or operator-provided,
+- whether outbound `wss://` verification is permissive or verified,
+- how many invite endpoints are secure vs plain.
+
+The `Reachable at` list also labels each advertised endpoint. If the endpoint shown to your peer starts with `wss://`, the invite is telling their node to connect with TLS-wrapped WebSocket transport. The panel now also shows the recommended endpoint and invite mode: secure public, mixed secure/plain, plain public, or LAN-only.
+
+### Why do I still see both `wss://` and `ws://` endpoints?
+
+For an explicitly generated public `wss://...` invite, Canopy suppresses same-host public `ws://...` fallback by default. LAN/private `ws://...` fallbacks may still appear for same-network convenience, and a plain public fallback can be intentionally enabled with the compatibility option. If a mixed invite is shown, check the connected peer card or diagnostics for **Active transport**; the live session is only WSS if the active endpoint is `wss://...`.
+
+### Does `wss://` replace Canopy's peer verification?
+
+No. `wss://` protects the WebSocket transport with TLS. Canopy still verifies the remote peer identity using the public keys in the invite and its application-layer handshake. Treat `wss://` as the transport-security layer, not the peer-trust decision.
+
+### Can an explicit `wss://` invite fall back to `ws://`?
+
+No. When an invite or direct action explicitly chooses `wss://`, Canopy does not silently retry the same endpoint as plain `ws://` if TLS fails. This is intentional so operators can rely on the meaning of a secure endpoint. Fix the VPS, reverse proxy, tunnel, certificate, or endpoint instead.
+
+### Why does the UI say certificate verification is permissive?
+
+Many current Canopy meshes use self-signed transport certificates, so the default outbound `wss://` client mode accepts those certificates while Canopy verifies peer identity separately at the application layer. For stricter public-internet deployments, set `CANOPY_REQUIRE_VERIFIED_WSS=true` and use an externally trusted certificate or TLS-terminating proxy. In verified mode, failed `wss://` certificate/hostname checks are not downgraded to plain `ws://`.
 
 ### Why do I get an "API key required" error in web UI?
 

--- a/docs/PEER_CONNECT_GUIDE.md
+++ b/docs/PEER_CONNECT_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide is for an AI agent (or human) setting up a **second Canopy instance** on a different machine and connecting it to an existing instance via invite codes.
 
-Version scope: this guide is aligned to Canopy `0.6.27`.
+Version scope: this guide is aligned to Canopy `0.6.32`.
 
 ---
 
@@ -265,7 +265,41 @@ curl -s "http://localhost:7770/api/v1/p2p/invite?external_endpoint=wss://example
   -H "X-API-Key: YOUR_API_KEY"
 ```
 
-Canopy preserves the explicit `ws://` or `wss://` scheme from the invite during import, reconnect, and direct connect attempts.
+Canopy preserves the explicit `ws://` or `wss://` scheme from the invite during import, reconnect, and direct connect attempts. If you explicitly generate a public `wss://...` invite, Canopy no longer pairs that same public host with an automatic plain `ws://...` fallback unless you explicitly enable the plain fallback option.
+
+### What `wss://` means in Canopy
+
+`wss://` means the P2P WebSocket transport is wrapped in TLS. It is useful for VPS, public internet, and tunnel endpoints because it prevents the mesh transport itself from being plain WebSocket. Canopy still performs its own application-layer peer identity verification using the public keys in the invite, and message contents remain protected by Canopy's cryptographic transport.
+
+Important operator details:
+
+- An invite only uses `wss://` when the advertised endpoint starts with `wss://`.
+- The Connect page now shows **Transport security**, including whether the local mesh listener is `ws://` or `wss://`, what certificate mode is active, and whether the invite advertises secure or plain endpoints.
+- If you enter `wss://example.ngrok-free.app`, the invite advertises that exact secure endpoint as the recommended path. Same-host public `ws://` fallback is off by default.
+- The Connect page also labels the live active transport for connected peers, so a mixed invite can be distinguished from the actual session path.
+- If an explicit `wss://` endpoint fails, Canopy does **not** silently retry the same endpoint as `ws://`. Fix the TLS endpoint, tunnel, proxy, or certificate instead.
+- Current default outbound `wss://` certificate handling is permissive for self-signed mesh deployments unless `CANOPY_REQUIRE_VERIFIED_WSS=true` is set. When verified mode is enabled, a failed `wss://` certificate/hostname check is not downgraded to plain `ws://`.
+
+Recommended public-internet setup:
+
+- In the web UI, open **Admin -> Transport Security**. From there an instance admin can:
+  - generate node-owned self-signed TLS settings for testing,
+  - save provided certificate/key paths,
+  - declare an external `wss://` TLS terminator such as a VPS reverse proxy or tunnel,
+  - see whether a restart is required before secure invites are ready.
+- Use a TLS-terminating tunnel/reverse proxy with an externally trusted certificate, or run the mesh listener with TLS enabled and a real cert.
+- For a TLS mesh listener, set:
+  ```bash
+  export CANOPY_ENABLE_TLS=true
+  export CANOPY_TLS_CERT_PATH=/path/to/fullchain.pem
+  export CANOPY_TLS_KEY_PATH=/path/to/privkey.pem
+  ```
+- For stricter VPS/client behavior, additionally set:
+  ```bash
+  export CANOPY_REQUIRE_VERIFIED_WSS=true
+  ```
+
+If you use a reverse proxy or tunnel, prefer declaring it in **Admin -> Transport Security** as an external TLS terminator. The local Canopy mesh listener may still show as `ws://` while the external invite advertises `wss://...`; that is valid only if the proxy/tunnel actually terminates TLS and forwards WebSocket traffic to the mesh port.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,7 +1,7 @@
 # Canopy Quick Start
 
 This guide is the primary technical first-run path for Canopy. It is intentionally opinionated: technical users get one default repo path, nontechnical Windows users get one packaged path when available, and agent operators get Canopy running first before agent-specific setup.
-Version scope: this quick start is aligned to Canopy `0.6.27`.
+Version scope: this quick start is aligned to Canopy `0.6.32`.
 
 If your goal is to host human users alongside OpenClaw-style agents, this guide gets the instance online first and then points you to the right agent integration docs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canopy"
-version = "0.6.27"
+version = "0.6.32"
 description = "Local-first peer-to-peer collaboration for humans and AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_connect_introduced_broker_fallback.py
+++ b/tests/test_connect_introduced_broker_fallback.py
@@ -55,9 +55,12 @@ class TestConnectIntroducedBrokerFallback(unittest.TestCase):
         self.p2p_manager.connection_manager = MagicMock()
         self.p2p_manager.connection_manager.connect_to_peer = MagicMock()
 
+        self.db_manager = MagicMock()
+        self.db_manager.get_instance_owner_user_id.return_value = 'admin-user'
+
         # Order must match get_app_components in canopy.core.utils
         components = (
-            MagicMock(),           # db_manager
+            self.db_manager,       # db_manager
             self.api_key_manager,  # api_key_manager
             MagicMock(),           # trust_manager
             MagicMock(),           # message_manager
@@ -193,6 +196,48 @@ class TestConnectIntroducedBrokerFallback(unittest.TestCase):
         self.assertEqual(payload.get('direct_attempt_count'), 0)
         self.assertIn('No direct endpoints were announced', payload.get('message', ''))
 
+    def test_connect_introduced_cross_mesh_candidate_requires_explicit_confirmation(self) -> None:
+        peer_id = 'peer-target'
+        self.p2p_manager._introduced_peers[peer_id] = {
+            'peer_id': peer_id,
+            'endpoints': ['ws://203.0.113.10:7771'],
+            'introduced_by': 'broker-a',
+        }
+        self.p2p_manager.get_introduced_peer_meshspace_status.return_value = {
+            'requires_explicit_meshspace_connect': True,
+            'remote_meshspace_label': 'Private Mesh',
+        }
+
+        response = self._post_connect_introduced(peer_id)
+
+        self.assertEqual(response.status_code, 409)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('diagnostic_code'), 'introduced_cross_mesh_confirmation_required')
+        self.assertEqual(payload.get('status'), 'confirmation_required')
+        self.p2p_manager.connection_manager.connect_to_peer.assert_not_called()
+
+    def test_connect_introduced_cross_mesh_explicit_action_requires_admin(self) -> None:
+        peer_id = 'peer-target'
+        self.p2p_manager._introduced_peers[peer_id] = {
+            'peer_id': peer_id,
+            'endpoints': ['ws://203.0.113.10:7771'],
+            'introduced_by': 'broker-a',
+        }
+        self.p2p_manager.get_introduced_peer_meshspace_status.return_value = {
+            'requires_explicit_meshspace_connect': True,
+            'remote_meshspace_label': 'Private Mesh',
+        }
+
+        response = self._post_connect_introduced(
+            peer_id,
+            extra_payload={'allow_cross_mesh': True},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('diagnostic_code'), 'cross_mesh_admin_required')
+        self.p2p_manager.connection_manager.connect_to_peer.assert_not_called()
+
     def test_connect_introduced_force_broker_skips_direct_attempts(self) -> None:
         peer_id = 'peer-target'
         self.p2p_manager._introduced_peers[peer_id] = {
@@ -216,6 +261,35 @@ class TestConnectIntroducedBrokerFallback(unittest.TestCase):
         self.assertFalse(payload.get('direct_attempted'))
         self.assertEqual(payload.get('direct_attempt_count'), 0)
         self.assertEqual(payload.get('attempted_brokers'), ['broker-a'])
+        run_coro.assert_not_called()
+
+    def test_connect_introduced_force_broker_preserves_explicit_cross_mesh_intent(self) -> None:
+        peer_id = 'peer-target'
+        self.db_manager.get_instance_owner_user_id.return_value = 'test-user'
+        self.p2p_manager._introduced_peers[peer_id] = {
+            'peer_id': peer_id,
+            'endpoints': ['ws://203.0.113.10:7771'],
+            'introduced_via': ['broker-a'],
+        }
+        self.p2p_manager.get_introduced_peer_meshspace_status.return_value = {
+            'requires_explicit_meshspace_connect': True,
+            'remote_meshspace_label': 'Private Mesh',
+        }
+        self.p2p_manager.get_connected_peers.return_value = ['broker-a']
+        self.p2p_manager.send_broker_request.return_value = True
+
+        with patch('asyncio.run_coroutine_threadsafe') as run_coro:
+            response = self._post_connect_introduced(
+                peer_id,
+                extra_payload={'force_broker': True, 'allow_cross_mesh': True},
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.get_json() or {}
+        self.assertEqual(payload.get('status'), 'brokering')
+        self.assertTrue(payload.get('forced_failover'))
+        self.assertEqual(payload.get('attempted_brokers'), ['broker-a'])
+        self.assertTrue(self.p2p_manager.send_broker_request.call_args.kwargs.get('allow_cross_mesh'))
         run_coro.assert_not_called()
 
     def test_connect_introduced_prefers_public_endpoint_over_stale_lan_history(self) -> None:

--- a/tests/test_connection_diagnostics_endpoint.py
+++ b/tests/test_connection_diagnostics_endpoint.py
@@ -49,6 +49,19 @@ def _make_mock_p2p_manager(
 
     conn_mgr = MagicMock()
     conn_mgr.get_connection.return_value = None
+    conn_mgr.get_transport_security_status.return_value = {
+        'mesh_scheme': 'ws',
+        'tls_enabled': False,
+        'transport_label': 'Plain WebSocket (ws)',
+        'listener_endpoint': 'ws://0.0.0.0:7771',
+        'tls_cert_mode': 'disabled',
+        'client_verification_mode': 'permissive',
+        'advertised_endpoints': [],
+        'advertised_secure_count': 0,
+        'advertised_plain_count': 0,
+        'explicit_wss_downgrade_allowed': False,
+        'warnings': ['Invite currently advertises only plain ws:// endpoints.'],
+    }
 
     p2p = MagicMock()
     p2p.identity_manager = im
@@ -136,6 +149,18 @@ class TestConnectionDiagnosticsEndpoint(unittest.TestCase):
         self.assertEqual(local.get('mesh_port'), 7771)
         self.assertEqual(local.get('relay_policy'), 'broker_only')
 
+    def test_local_section_contains_transport_security_status(self):
+        """local section exposes operator-visible ws/wss transport status."""
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        security = (data.get('local', {}) or {}).get('transport_security') or {}
+        self.assertEqual(security.get('mesh_scheme'), 'ws')
+        self.assertEqual(security.get('tls_cert_mode'), 'disabled')
+        self.assertEqual(security.get('client_verification_mode'), 'permissive')
+        self.assertFalse(security.get('explicit_wss_downgrade_allowed'))
+
     def test_direct_peer_is_reported_as_direct(self):
         """A peer not in active_relays is labelled as a direct connection."""
         self.p2p_manager.get_connected_peers.return_value = ['peer-abc']
@@ -149,6 +174,35 @@ class TestConnectionDiagnosticsEndpoint(unittest.TestCase):
         self.assertEqual(peers[0]['peer_id'], 'peer-abc')
         self.assertEqual(peers[0]['connection_type'], 'direct')
         self.assertIsNone(peers[0]['relay_via'])
+
+    def test_direct_peer_reports_active_transport_separately_from_known_endpoints(self):
+        """Diagnostics should expose the live ws/wss path separately from advertised candidates."""
+        self.p2p_manager.get_connected_peers.return_value = ['peer-abc']
+        self.p2p_manager.get_peer_endpoint_diagnostics.return_value = [
+            {
+                'endpoint': 'wss://vps.example.com:443',
+                'sources': ['active'],
+                'currently_connected': True,
+                'attempt_count': 1,
+                'success_count': 1,
+            },
+            {
+                'endpoint': 'ws://vps.example.com:443',
+                'sources': ['stored'],
+                'currently_connected': False,
+                'attempt_count': 0,
+                'success_count': 0,
+            },
+        ]
+        self._authenticate()
+        with patch('canopy.network.invite.generate_invite', side_effect=Exception('no-op')):
+            response = self.client.get('/ajax/connection_diagnostics')
+        data = response.get_json()
+        peer = data.get('peers', [])[0]
+        self.assertEqual(peer.get('active_endpoint'), 'wss://vps.example.com:443')
+        self.assertEqual(peer.get('active_transport'), 'wss')
+        self.assertTrue(peer.get('active_transport_secure'))
+        self.assertIn('ws://vps.example.com:443', peer.get('endpoints', []))
 
     def test_relayed_peer_is_reported_as_relayed(self):
         """A peer in active_relays is labelled as a relayed connection."""

--- a/tests/test_cross_mesh_safety_remaining_paths.py
+++ b/tests/test_cross_mesh_safety_remaining_paths.py
@@ -272,6 +272,32 @@ class TestConnectToEndpointPostHandshakeCrossMeshGuard(unittest.IsolatedAsyncioT
         self.assertTrue(result)
         manager.connection_manager.disconnect_peer.assert_not_called()
 
+    async def test_brokered_connection_preserves_explicit_cross_mesh_flag(self):
+        manager = self._make_manager_no_prior_hint()
+        manager.connection_manager.is_connected = MagicMock(side_effect=[False, False, True])
+        manager._connect_to_endpoint = AsyncMock(return_value=True)
+        manager.message_router.remove_route = MagicMock()
+        manager._active_relays = {FOREIGN_PEER_ID: RELAY_PEER_ID}
+        manager._run_post_connect_sync = AsyncMock()
+
+        await manager._attempt_brokered_connection(
+            FOREIGN_PEER_ID,
+            ['ws://10.0.0.7:7771', 'ws://10.0.0.8:7771'],
+            broker_peer=RELAY_PEER_ID,
+            allow_cross_mesh=True,
+        )
+
+        self.assertGreaterEqual(manager._connect_to_endpoint.await_count, 1)
+        first_call = manager._connect_to_endpoint.await_args_list[0]
+        self.assertEqual(
+            first_call.args,
+            (FOREIGN_PEER_ID, 'ws://10.0.0.7:7771'),
+        )
+        self.assertTrue(first_call.kwargs.get('allow_cross_mesh'))
+        manager.message_router.remove_route.assert_called_once_with(FOREIGN_PEER_ID)
+        self.assertNotIn(FOREIGN_PEER_ID, manager._active_relays)
+        manager._run_post_connect_sync.assert_awaited_once_with(FOREIGN_PEER_ID)
+
 
 class TestRelayOfferCrossMeshGuard(unittest.TestCase):
     def _make_manager_with_cross_mesh_hint(self) -> P2PNetworkManager:

--- a/tests/test_frontend_regressions.py
+++ b/tests/test_frontend_regressions.py
@@ -209,7 +209,38 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn('id="externalEndpoint"', connect_template)
         self.assertIn('wss://example.ngrok-free.app or ws://0.tcp.ngrok.io:12345', connect_template)
         self.assertIn('external_endpoint=', connect_template)
+        self.assertIn('id="allowPlainFallback"', connect_template)
+        self.assertIn('allow_plain_fallback=true', connect_template)
         self.assertIn('Regenerated with external endpoint!', connect_template)
+        self.assertIn('data.transport_security', connect_template)
+        self.assertIn("renderEndpointBadges('invite-endpoints-list', data.endpoints)", connect_template)
+
+    def test_connect_page_surfaces_transport_security_status(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn('Transport security', connect_template)
+        self.assertIn('transport-security-card', connect_template)
+        self.assertIn('transport-security-title', connect_template)
+        self.assertIn('Outbound wss verification', connect_template)
+        self.assertIn('Invite mode', connect_template)
+        self.assertIn('Recommended path', connect_template)
+        self.assertIn('Explicit <code>wss://</code> endpoints will not silently downgrade', connect_template)
+        self.assertIn('function updateTransportSecurityPanel(status)', connect_template)
+        self.assertIn('function endpointBadgeHtml(endpoint)', connect_template)
+        self.assertIn('secure_transport_failed', connect_template)
+        self.assertIn('data-peer-active-transport-badge', connect_template)
+        self.assertIn('Active transport:', connect_template)
+        self.assertIn('This invite mixes wss:// and ws:// endpoints', connect_template)
+
+    def test_admin_page_exposes_transport_security_controls(self) -> None:
+        admin_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'admin.html').read_text(encoding='utf-8')
+        self.assertIn('Transport Security', admin_template)
+        self.assertIn('transportSecurityAdminCard', admin_template)
+        self.assertIn('Enable self-signed TLS', admin_template)
+        self.assertIn('Use certificate files', admin_template)
+        self.assertIn('Advertise external wss://', admin_template)
+        self.assertIn('/ajax/admin/transport-security/self-signed', admin_template)
+        self.assertIn('/ajax/admin/transport-security/external', admin_template)
+        self.assertIn('function renderTransportSecurityAdmin', admin_template)
 
     def test_connect_page_previews_invites_before_importing(self) -> None:
         connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
@@ -257,6 +288,8 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn("code === 'mesh_identity_admin_required'", connect_template)
         self.assertIn("code === 'cross_mesh_confirmation_required'", connect_template)
         self.assertIn("code === 'cross_mesh_reconnect_confirmation_required'", connect_template)
+        self.assertIn("code === 'introduced_cross_mesh_confirmation_required'", connect_template)
+        self.assertIn("code === 'secure_transport_failed'", connect_template)
         self.assertIn('Instance admin permission is required to connect to a peer from a different meshspace.', connect_template)
 
     def test_connect_page_mesh_badge_distinguishes_no_hint_from_mismatch(self) -> None:
@@ -271,6 +304,15 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn('isCrossMeshBlocked', connect_template)
         self.assertIn('Admin required', connect_template)
         self.assertIn('const blocked = Boolean(', connect_template)
+
+    def test_connect_page_separates_remote_meshspace_introductions(self) -> None:
+        connect_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'connect.html').read_text(encoding='utf-8')
+        self.assertIn('Remote Meshspace Candidates', connect_template)
+        self.assertIn('introduced_meshspace_candidates', connect_template)
+        self.assertIn('Explicit Connect', connect_template)
+        self.assertIn('introduced_cross_mesh_confirmation_required', connect_template)
+        self.assertIn('payload.allow_cross_mesh = true', connect_template)
+        self.assertIn('explicit_meshspace_connect', connect_template)
 
     def test_feed_video_surfaces_preserve_actual_video_mime_type(self) -> None:
         feed_template = (ROOT / 'canopy' / 'ui' / 'templates' / 'feed.html').read_text(encoding='utf-8')
@@ -324,6 +366,9 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn('canopy.attention.seenThrough.', main_js)
         self.assertIn('Reset to inbox-only default', main_js)
         self.assertIn('New accounts show inbox items only. Click a filter chip to customise.', main_js)
+        self.assertIn("btn.addEventListener('click', (event) => {", main_js)
+        self.assertIn("filterResetBtn.addEventListener('click', (event) => {", main_js)
+        self.assertGreaterEqual(main_js.count('event.stopPropagation();'), 2)
         self.assertIn('id="notificationFilterReset">Reset</button>', base_template)
         self.assertIn('New accounts start with inbox items only in the bell until you customize the filters.', base_template)
 
@@ -724,10 +769,14 @@ class TestFrontendRegressions(unittest.TestCase):
         self.assertIn('id="sidebar-peers-toggle"', base_template)
         self.assertIn('id="sidebar-peers-expand-btn"', base_template)
         self.assertIn('id="sidebar-peers-open-modal"', base_template)
+        self.assertIn('href="{{ url_for(\'ui.trust_management\') }}#trust-peer-{{ peer_id|urlencode }}"', base_template)
+        self.assertIn('href="{{ url_for(\'ui.connect_page\') }}#connected-peers"', base_template)
         self.assertIn('id="sidebar-media-mini-slot-top"', base_template)
         self.assertIn('id="sidebar-media-mini-slot-bottom"', base_template)
         self.assertIn('id="sidebar-media-mini-pin"', base_template)
         self.assertIn("const SIDEBAR_CARD_PEEK_LIMIT = 5;", main_js)
+        self.assertIn("function sidebarPeerTrustHref(peerId)", main_js)
+        self.assertIn("peerEl.href = sidebarPeerTrustHref(peerId);", main_js)
         self.assertIn("function toggleSidebarCardCollapsed(kind)", main_js)
         self.assertIn("function toggleSidebarCardExpansion(kind, totalCount)", main_js)
         self.assertIn("function updateSidebarCardChrome(kind, totalCount)", main_js)

--- a/tests/test_meshspaces_foundation.py
+++ b/tests/test_meshspaces_foundation.py
@@ -1573,6 +1573,27 @@ class LegacyMeshspaceAdoptionTest(unittest.TestCase):
         self.assertIsNone(generate_invite_mock.call_args.kwargs.get('meshspace_avatar_mime'))
         self.assertIsNone(generate_invite_mock.call_args.kwargs.get('meshspace_id_aliases'))
 
+    def test_invite_generation_keeps_live_ws_scheme_until_tls_listener_restarts(self) -> None:
+        self._authenticate()
+        config = self.app.config['CANOPY_CONFIG']
+        config.network.enable_tls = True
+        config.network.transport_security_mode = 'self_signed'
+
+        fake_invite = SimpleNamespace(
+            encode=lambda: 'canopy:test',
+            peer_id='peer-mesh-test',
+            endpoints=['ws://192.168.1.12:7771'],
+            meshspace_id=config.meshspace.meshspace_id,
+            mesh_name=config.meshspace.name,
+            meshspace_fingerprint='ABCD-1234',
+            to_dict=lambda: {'mn': config.meshspace.name},
+        )
+        with patch('canopy.network.invite.generate_invite', return_value=fake_invite) as generate_invite_mock:
+            response = self.client.get('/api/v1/p2p/invite')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(generate_invite_mock.call_args.kwargs.get('endpoint_scheme'), 'ws')
+
     def test_connect_page_uses_device_profile_as_primary_peer_hint(self) -> None:
         self._authenticate()
         fake_invite = SimpleNamespace(

--- a/tests/test_network_connectivity_regressions.py
+++ b/tests/test_network_connectivity_regressions.py
@@ -28,9 +28,16 @@ if 'zeroconf' not in sys.modules:
     sys.modules['zeroconf'] = zeroconf_stub
 
 from canopy.network.discovery import DiscoveredPeer, PeerDiscovery
-from canopy.network.invite import InviteCode, import_invite, generate_invite
+from canopy.network.connection import ConnectionManager
+from canopy.network.invite import InviteCode, classify_invite_endpoints, import_invite, generate_invite
 from canopy.network.manager import P2PNetworkManager
 from canopy.network.identity import IdentityManager
+from canopy.core.config import (
+    Config,
+    apply_transport_security_settings,
+    load_transport_security_settings,
+    save_transport_security_settings,
+)
 
 
 class _DummyConfig:
@@ -43,6 +50,9 @@ class _DummyConfig:
             enable_tls=False,
             tls_cert_path=None,
             tls_key_path=None,
+            require_verified_wss=False,
+            external_tls_endpoint='',
+            transport_security_mode='',
         )
         self.security = types.SimpleNamespace(
             allow_unverified_relay_messages=False,
@@ -161,14 +171,92 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
         identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
         identity_manager.initialize()
 
-        invite = generate_invite(
-            identity_manager,
-            7771,
-            external_endpoint='wss://demo.ngrok-free.app:443',
-        )
+        with patch('canopy.network.invite.get_local_ips', return_value=['192.168.1.10']):
+            invite = generate_invite(
+                identity_manager,
+                7771,
+                external_endpoint='wss://demo.ngrok-free.app:443',
+            )
 
         self.assertEqual(invite.endpoints[0], 'wss://demo.ngrok-free.app:443')
-        self.assertTrue(any(endpoint.startswith('ws://') for endpoint in invite.endpoints[1:]))
+        self.assertIn('ws://192.168.1.10:7771', invite.endpoints[1:])
+
+    def test_generate_invite_uses_wss_for_local_tls_listener_endpoints(self) -> None:
+        identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
+        identity_manager.initialize()
+
+        with patch('canopy.network.invite.get_local_ips', return_value=['192.168.1.10']):
+            invite = generate_invite(
+                identity_manager,
+                7771,
+                public_host='mesh.example.com',
+                endpoint_scheme='wss',
+            )
+
+        self.assertIn('wss://mesh.example.com:7771', invite.endpoints)
+        self.assertIn('wss://192.168.1.10:7771', invite.endpoints)
+        self.assertNotIn('ws://mesh.example.com:7771', invite.endpoints)
+
+    def test_transport_security_settings_persist_per_data_dir(self) -> None:
+        config = Config()
+        config.storage.data_dir = self.tempdir
+
+        path = save_transport_security_settings(config, {
+            'mode': 'external_terminator',
+            'external_tls_endpoint': 'wss://mesh.example.com:443',
+            'require_verified_wss': True,
+        })
+        loaded = load_transport_security_settings(config)
+        applied = apply_transport_security_settings(config, loaded)
+
+        self.assertTrue(path.exists())
+        self.assertEqual(applied.get('mode'), 'external_terminator')
+        self.assertFalse(config.network.enable_tls)
+        self.assertEqual(config.network.external_tls_endpoint, 'wss://mesh.example.com:443')
+        self.assertTrue(config.network.require_verified_wss)
+
+    def test_generate_invite_suppresses_same_host_plain_public_wss_fallback_by_default(self) -> None:
+        identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
+        identity_manager.initialize()
+
+        with patch('canopy.network.invite.get_local_ips', return_value=['50.6.243.52', '192.168.1.10']):
+            invite = generate_invite(
+                identity_manager,
+                7771,
+                external_endpoint='wss://50.6.243.52:7771',
+                public_host='50.6.243.52',
+            )
+
+        self.assertIn('wss://50.6.243.52:7771', invite.endpoints)
+        self.assertNotIn('ws://50.6.243.52:7771', invite.endpoints)
+        self.assertIn('ws://192.168.1.10:7771', invite.endpoints)
+
+    def test_generate_invite_allows_same_host_plain_fallback_when_explicitly_requested(self) -> None:
+        identity_manager = IdentityManager(Path(self.tempdir) / 'peer_identity.json')
+        identity_manager.initialize()
+
+        with patch('canopy.network.invite.get_local_ips', return_value=['50.6.243.52']):
+            invite = generate_invite(
+                identity_manager,
+                7771,
+                external_endpoint='wss://50.6.243.52:7771',
+                allow_plain_fallback=True,
+            )
+
+        self.assertEqual(invite.endpoints[0], 'wss://50.6.243.52:7771')
+        self.assertIn('ws://50.6.243.52:7771', invite.endpoints)
+
+    def test_classify_invite_endpoints_marks_secure_public_and_lan_fallbacks(self) -> None:
+        classification = classify_invite_endpoints([
+            'wss://50.6.243.52:7771',
+            'ws://192.168.1.10:7771',
+        ])
+
+        self.assertEqual(classification.get('recommended_endpoint'), 'wss://50.6.243.52:7771')
+        self.assertEqual(classification.get('recommended_transport'), 'wss')
+        self.assertEqual(classification.get('invite_policy'), 'secure_public')
+        self.assertFalse(classification.get('has_public_plain_fallback'))
+        self.assertTrue(classification.get('has_lan_fallback'))
 
     def test_invite_encode_decode_preserves_preview_metadata(self) -> None:
         invite = InviteCode(
@@ -329,10 +417,10 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
 
     async def test_connect_to_endpoint_preserves_explicit_wss_scheme(self) -> None:
         manager = self._build_manager()
-        captured: list[tuple[str, str, int, str | None]] = []
+        captured: list[tuple[str, str, int, str | None, bool]] = []
 
-        async def _connect(peer_id: str, host: str, port: int, scheme=None) -> bool:
-            captured.append((peer_id, host, port, scheme))
+        async def _connect(peer_id: str, host: str, port: int, scheme=None, scheme_explicit=False) -> bool:
+            captured.append((peer_id, host, port, scheme, scheme_explicit))
             return True
 
         manager.connection_manager = types.SimpleNamespace(
@@ -347,15 +435,15 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(ok)
         self.assertEqual(
             captured,
-            [('peer-remote', 'demo.ngrok-free.app', 443, 'wss')],
+            [('peer-remote', 'demo.ngrok-free.app', 443, 'wss', True)],
         )
 
     async def test_connect_to_endpoint_defaults_missing_wss_port_to_443(self) -> None:
         manager = self._build_manager()
-        captured: list[tuple[str, str, int, str | None]] = []
+        captured: list[tuple[str, str, int, str | None, bool]] = []
 
-        async def _connect(peer_id: str, host: str, port: int, scheme=None) -> bool:
-            captured.append((peer_id, host, port, scheme))
+        async def _connect(peer_id: str, host: str, port: int, scheme=None, scheme_explicit=False) -> bool:
+            captured.append((peer_id, host, port, scheme, scheme_explicit))
             return True
 
         manager.connection_manager = types.SimpleNamespace(
@@ -370,8 +458,143 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(ok)
         self.assertEqual(
             captured,
-            [('peer-remote', 'demo.ngrok-free.app', 443, 'wss')],
+            [('peer-remote', 'demo.ngrok-free.app', 443, 'wss', True)],
         )
+
+    async def test_explicit_wss_connect_does_not_retry_plain_ws_after_tls_failure(self) -> None:
+        manager = ConnectionManager(
+            local_peer_id='local-peer',
+            identity_manager=types.SimpleNamespace(),
+            enable_tls=False,
+        )
+        attempts: list[str] = []
+
+        async def _fail_connect(uri: str, **_kwargs):
+            attempts.append(uri)
+            raise OSError('tls failed')
+
+        with patch('canopy.network.connection.websockets.connect', new=_fail_connect):
+            ok = await manager.connect_to_peer(
+                'peer-remote',
+                'demo.ngrok-free.app',
+                443,
+                scheme='wss',
+                scheme_explicit=True,
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(attempts, ['wss://demo.ngrok-free.app:443/p2p'])
+        failure = manager.get_last_connect_failure('peer-remote', 'demo.ngrok-free.app', 443)
+        self.assertEqual(failure.get('reason'), 'wss_downgrade_blocked')
+
+    async def test_inferred_tls_connect_can_still_retry_plain_ws_for_legacy_peers(self) -> None:
+        manager = ConnectionManager(
+            local_peer_id='local-peer',
+            identity_manager=types.SimpleNamespace(),
+            enable_tls=False,
+        )
+        manager.enable_tls = True
+        manager._client_ssl = None
+        attempts: list[str] = []
+
+        class _FakeWebSocket:
+            async def close(self):
+                return None
+
+        async def _connect(uri: str, **_kwargs):
+            attempts.append(uri)
+            if uri.startswith('wss://'):
+                raise OSError('tls failed')
+            return _FakeWebSocket()
+
+        async def _handshake(_connection):
+            return False
+
+        manager._perform_handshake = _handshake  # type: ignore[assignment]
+
+        with patch('canopy.network.connection.websockets.connect', new=_connect):
+            ok = await manager.connect_to_peer(
+                'peer-remote',
+                'demo.ngrok-free.app',
+                7771,
+                scheme=None,
+                scheme_explicit=False,
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(
+            attempts,
+            ['wss://demo.ngrok-free.app:7771/p2p', 'ws://demo.ngrok-free.app:7771/p2p'],
+        )
+
+    async def test_verified_wss_mode_blocks_inferred_plain_ws_downgrade(self) -> None:
+        manager = ConnectionManager(
+            local_peer_id='local-peer',
+            identity_manager=types.SimpleNamespace(),
+            enable_tls=False,
+            require_verified_wss=True,
+        )
+        manager.enable_tls = True
+        attempts: list[str] = []
+
+        async def _fail_connect(uri: str, **_kwargs):
+            attempts.append(uri)
+            raise OSError('certificate verify failed')
+
+        with patch('canopy.network.connection.websockets.connect', new=_fail_connect):
+            ok = await manager.connect_to_peer(
+                'peer-remote',
+                'secure.example.com',
+                443,
+                scheme=None,
+                scheme_explicit=False,
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(attempts, ['wss://secure.example.com:443/p2p'])
+        failure = manager.get_last_connect_failure('peer-remote', 'secure.example.com', 443)
+        self.assertEqual(failure.get('reason'), 'wss_downgrade_blocked')
+
+    def test_transport_security_status_reports_plain_invite_endpoints(self) -> None:
+        manager = ConnectionManager(
+            local_peer_id='local-peer',
+            identity_manager=types.SimpleNamespace(),
+            enable_tls=False,
+        )
+
+        status = manager.get_transport_security_status(
+            advertised_endpoints=['ws://192.168.1.10:7771']
+        )
+
+        self.assertEqual(status.get('mesh_scheme'), 'ws')
+        self.assertFalse(status.get('tls_enabled'))
+        self.assertEqual(status.get('tls_cert_mode'), 'disabled')
+        self.assertEqual(status.get('client_verification_mode'), 'permissive')
+        self.assertEqual(status.get('advertised_secure_count'), 0)
+        self.assertEqual(status.get('advertised_plain_count'), 1)
+        self.assertFalse(status.get('explicit_wss_downgrade_allowed'))
+
+    def test_transport_security_status_reports_self_signed_tls_listener(self) -> None:
+        cert_path = Path(self.tempdir) / 'tls' / 'canopy.crt'
+        key_path = Path(self.tempdir) / 'tls' / 'canopy.key'
+        manager = ConnectionManager(
+            local_peer_id='local-peer',
+            identity_manager=types.SimpleNamespace(),
+            enable_tls=True,
+            tls_cert_path=str(cert_path),
+            tls_key_path=str(key_path),
+        )
+
+        status = manager.get_transport_security_status(
+            advertised_endpoints=['wss://mesh.example.com:443']
+        )
+
+        self.assertEqual(status.get('mesh_scheme'), 'wss')
+        self.assertTrue(status.get('tls_enabled'))
+        self.assertEqual(status.get('tls_cert_mode'), 'self_signed')
+        self.assertTrue(status.get('tls_cert_path_present'))
+        self.assertTrue(status.get('tls_key_path_present'))
+        self.assertEqual(status.get('advertised_secure_count'), 1)
 
     def test_parse_endpoint_rejects_non_websocket_schemes(self) -> None:
         manager = self._build_manager()
@@ -601,6 +824,55 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(introduced[0]['connect_strategy'], 'unreachable')
         self.assertEqual(introduced[0]['broker_candidates'], [])
 
+    def test_get_introduced_peers_requires_explicit_review_for_cross_mesh_candidate(self) -> None:
+        manager = self._build_manager()
+        manager._introduced_peers = {
+            'peer-remote': {
+                'peer_id': 'peer-remote',
+                'introduced_by': 'broker-a',
+                'endpoints': ['ws://198.51.100.12:7771'],
+                'meshspace_hint': {
+                    'meshspace_id': 'business-mesh',
+                    'meshspace_name': 'Business Mesh',
+                },
+            }
+        }
+        manager.get_connected_peers = lambda: ['broker-a']
+        manager.get_peer_id = lambda: 'local-peer'
+
+        introduced = manager.get_introduced_peers()
+
+        self.assertEqual(len(introduced), 1)
+        self.assertEqual(introduced[0]['connect_strategy'], 'explicit_meshspace_required')
+        self.assertTrue(introduced[0]['requires_explicit_meshspace_connect'])
+        self.assertEqual(introduced[0]['meshspace_relationship'], 'cross_mesh_candidate')
+        self.assertEqual(introduced[0]['remote_meshspace_label'], 'Business Mesh')
+
+    def test_store_introduced_peers_persists_announced_meshspace_hint(self) -> None:
+        manager = self._build_manager()
+        manager.store_introduced_peers(
+            [
+                {
+                    'peer_id': 'peer-remote',
+                    'display_name': 'Remote Business Node',
+                    'endpoints': ['ws://198.51.100.12:7771'],
+                    'ed25519_public_key': '',
+                    'x25519_public_key': '',
+                    'meshspace_id': 'business-mesh',
+                    'meshspace_name': 'Business Mesh',
+                }
+            ],
+            'broker-a',
+        )
+
+        introduced = manager.get_introduced_peers()
+
+        self.assertEqual(introduced[0]['remote_meshspace_id'], 'business-mesh')
+        self.assertEqual(
+            manager.identity_manager.get_peer_meshspace_hint('peer-remote').get('meshspace_id'),
+            'business-mesh',
+        )
+
     def test_send_broker_request_prefers_advertised_endpoints(self) -> None:
         manager = self._build_manager()
         manager._running = True
@@ -611,20 +883,97 @@ class TestNetworkConnectivityRegressions(unittest.IsolatedAsyncioTestCase):
             ed25519_public_key=b'\x01' * 32,
             x25519_public_key=b'\x02' * 32,
         )
-        manager._record_connection_event = lambda *args, **kwargs: None  # type: ignore[assignment]
+        manager._record_connection_event = MagicMock()
         manager._get_local_advertised_endpoints = lambda: ['wss://demo.example.com:443']  # type: ignore[assignment]
 
         future = MagicMock()
         future.result.return_value = True
 
         with patch('asyncio.run_coroutine_threadsafe', return_value=future):
-            sent = manager.send_broker_request('peer-target', 'broker-a')
+            sent = manager.send_broker_request('peer-target', 'broker-a', allow_cross_mesh=True)
 
         self.assertTrue(sent)
         self.assertEqual(
             manager.message_router.send_broker_request.call_args.kwargs['requester_endpoints'],
             ['wss://demo.example.com:443'],
         )
+        self.assertTrue(
+            manager.message_router.send_broker_request.call_args.kwargs['allow_cross_mesh']
+        )
+
+    def test_operator_wss_endpoint_is_reused_for_handshake_advertisements(self) -> None:
+        manager = self._build_manager()
+        manager.identity_manager.initialize()
+        manager.local_identity = manager.identity_manager.local_identity
+        manager.remember_operator_advertised_endpoint(
+            external_endpoint='wss://50.6.243.52:7771',
+            allow_plain_fallback=False,
+        )
+
+        with patch('canopy.network.invite.get_local_ips', return_value=['50.6.243.52', '192.168.1.10']):
+            endpoints = manager._get_local_advertised_endpoints()
+
+        self.assertEqual(endpoints[0], 'wss://50.6.243.52:7771')
+        self.assertNotIn('ws://50.6.243.52:7771', endpoints)
+        self.assertIn('ws://192.168.1.10:7771', endpoints)
+
+    def test_local_tls_config_advertises_wss_handshake_endpoints(self) -> None:
+        manager = self._build_manager()
+        manager.config.network.enable_tls = True
+        manager.config.network.transport_security_mode = 'self_signed'
+        manager.identity_manager.initialize()
+        manager.local_identity = manager.identity_manager.local_identity
+
+        with patch('canopy.network.invite.get_local_ips', return_value=['192.168.1.10']):
+            endpoints = manager._get_local_advertised_endpoints()
+
+        self.assertEqual(endpoints, ['wss://192.168.1.10:7771'])
+
+    def test_pending_tls_config_does_not_advertise_wss_until_listener_restarts(self) -> None:
+        manager = self._build_manager()
+        manager.config.network.enable_tls = True
+        manager.config.network.transport_security_mode = 'self_signed'
+        manager.identity_manager.initialize()
+        manager.local_identity = manager.identity_manager.local_identity
+        manager.connection_manager = types.SimpleNamespace(enable_tls=False)
+
+        with patch('canopy.network.invite.get_local_ips', return_value=['192.168.1.10']):
+            endpoints = manager._get_local_advertised_endpoints()
+
+        self.assertEqual(endpoints, ['ws://192.168.1.10:7771'])
+
+    def test_clearing_operator_endpoint_restores_default_handshake_advertisements(self) -> None:
+        manager = self._build_manager()
+        manager.identity_manager.initialize()
+        manager.local_identity = manager.identity_manager.local_identity
+        manager.remember_operator_advertised_endpoint(
+            external_endpoint='wss://50.6.243.52:7771',
+            allow_plain_fallback=False,
+        )
+        manager.remember_operator_advertised_endpoint()
+
+        with patch('canopy.network.invite.get_local_ips', return_value=['50.6.243.52', '192.168.1.10']):
+            endpoints = manager._get_local_advertised_endpoints()
+
+        self.assertNotIn('wss://50.6.243.52:7771', endpoints)
+        self.assertIn('ws://50.6.243.52:7771', endpoints)
+        self.assertIn('ws://192.168.1.10:7771', endpoints)
+
+    def test_peer_active_transport_reports_current_endpoint_scheme(self) -> None:
+        manager = self._build_manager()
+        manager.connection_manager = types.SimpleNamespace(
+            get_connection=lambda peer_id: types.SimpleNamespace(
+                endpoint_uri='wss://demo.ngrok-free.app:443',
+                address='10.0.0.10',
+                port=7771,
+            )
+        )
+
+        status = manager.get_peer_active_transport('peer-remote')
+
+        self.assertEqual(status.get('active_endpoint'), 'wss://demo.ngrok-free.app:443')
+        self.assertEqual(status.get('active_transport'), 'wss')
+        self.assertTrue(status.get('active_transport_secure'))
 
     def test_connectable_endpoints_prefer_public_over_stale_private_storage(self) -> None:
         manager = self._build_manager()

--- a/tests/test_transport_security_admin_status.py
+++ b/tests/test_transport_security_admin_status.py
@@ -1,0 +1,117 @@
+"""Regression tests for admin transport-security status truthfulness."""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+if 'zeroconf' not in sys.modules:
+    zeroconf_stub = types.ModuleType('zeroconf')
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    zeroconf_stub.ServiceBrowser = _Dummy
+    zeroconf_stub.ServiceInfo = _Dummy
+    zeroconf_stub.Zeroconf = _Dummy
+    zeroconf_stub.ServiceStateChange = _Dummy
+    sys.modules['zeroconf'] = zeroconf_stub
+
+from canopy.ui.routes import create_ui_blueprint
+
+
+def _build_components(tmpdir: str):
+    db_manager = MagicMock()
+    db_manager.get_instance_owner_user_id.return_value = 'owner-user'
+
+    network = types.SimpleNamespace(
+        mesh_port=7771,
+        enable_tls=False,
+        tls_cert_path='',
+        tls_key_path='',
+        external_tls_endpoint='',
+        transport_security_mode='disabled',
+        require_verified_wss=True,
+    )
+    config = types.SimpleNamespace(
+        network=network,
+        storage=types.SimpleNamespace(data_dir=tmpdir),
+        meshspace=types.SimpleNamespace(meshspace_id='mesh-a'),
+    )
+    p2p_manager = types.SimpleNamespace(
+        connection_manager=types.SimpleNamespace(tls_cert_path='', tls_key_path=''),
+        get_transport_security_status=lambda: {
+            'tls_enabled': False,
+            'client_verification_mode': 'permissive',
+            'transport_security_mode': 'disabled',
+            'transport_security_mode_label': 'Disabled',
+            'listener_endpoint': 'ws://0.0.0.0:7771',
+            'warnings': [],
+        },
+    )
+
+    return (
+        db_manager,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        config,
+        p2p_manager,
+    )
+
+
+class TestTransportSecurityAdminStatus(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        components = _build_components(self._tmp.name)
+        self.patcher = patch('canopy.ui.routes.get_app_components', return_value=components)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+        self.app = Flask(__name__)
+        self.app.config['TESTING'] = True
+        self.app.secret_key = 'test-secret'
+        self.app.register_blueprint(create_ui_blueprint())
+        self.client = self.app.test_client()
+
+    def _authenticate_admin(self):
+        with self.client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess['user_id'] = 'owner-user'
+
+    def test_status_marks_verification_mode_drift_as_restart_required(self):
+        self._authenticate_admin()
+
+        with patch('canopy.ui.routes.validate_csrf_request', return_value=None):
+            response = self.client.get('/ajax/admin/transport-security/status')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json() or {}
+        self.assertTrue(payload.get('restart_required'))
+        self.assertEqual(payload.get('configured_client_verification_mode'), 'verified')
+        self.assertEqual(payload.get('live_client_verification_mode'), 'permissive')
+        self.assertEqual(payload.get('client_verification_mode'), 'permissive')
+        self.assertIn('restart pending', str(payload.get('verification_display') or '').lower())
+        self.assertTrue(
+            any(
+                'verification mode has changed' in str(item).lower()
+                for item in (payload.get('warnings') or [])
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the 0.6.28-0.6.32 transport update set, including explicit WSS handling, truthful live-vs-configured transport status, admin transport setup, and clearer invite/active transport reporting
- ship the introduced remote-meshspace review flow so cross-mesh peers are separated on Connect and require explicit admin-approved bridging intent
- align release-facing docs, changelog, and version metadata with the shipped transport and review model

## Test plan
- python3 -m pytest tests/test_transport_security_admin_status.py tests/test_connect_introduced_broker_fallback.py tests/test_cross_mesh_safety_remaining_paths.py tests/test_network_connectivity_regressions.py tests/test_connection_diagnostics_endpoint.py tests/test_frontend_regressions.py tests/test_meshspaces_foundation.py